### PR TITLE
fix(ci): align Buildchain signing controller contract

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,14 +158,14 @@ jobs:
   build:
     needs: [preflight, windows-fast-sentinel, auditable-demo-fast-sentinel]
     if: ${{ needs.preflight.result == 'success' && needs.windows-fast-sentinel.result == 'success' && needs.auditable-demo-fast-sentinel.result == 'success' && !inputs.fast-sentinels-only && fromJSON(inputs.macos-overflow-request-json || '{}').mode != 'control' }}
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@5246afd4ff5608f6e8d09fb71003992119364880 # pre-upload transport smoke
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@5f4d81bf79da5b8fbd62f3c7dc75361ec92cab46 # detached signing controller
     secrets:
       BUILDCHAIN_PROMOTION_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}
       BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN }}
       BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN }}
       BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN }}
     with:
-      buildchain-ref: ${{ inputs.buildchain-ref || '5246afd4ff5608f6e8d09fb71003992119364880' }}
+      buildchain-ref: ${{ inputs.buildchain-ref || '5f4d81bf79da5b8fbd62f3c7dc75361ec92cab46' }}
       runner-preset: custom
       platforms-json: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'self-hosted' && '[{"id":"macos-arm64","name":"macOS ARM64 self-hosted primary","platform":"macos","runner":"[\"self-hosted\",\"macOS\",\"ARM64\",\"kungfu-build-v4-macos-arm64\"]","capabilities":["native-toolchain","node","product-artifacts","rust"]}]' || (fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'github-hosted' && '[{"id":"macos-arm64","name":"macOS ARM64 GitHub-hosted overflow","platform":"macos","runner":"[\"macos-15\"]","capabilities":["native-toolchain","node","product-artifacts","rust"]}]' || (inputs.platforms-json || '[{"id":"linux-x64","name":"Linux x64","platform":"linux","runner":"[\"self-hosted\",\"Linux\",\"X64\",\"kungfu-build-v4-linux-x64\"]","capabilities":["node","native-toolchain","product-artifacts","rust"]},{"id":"linux-arm64","name":"Linux ARM64","platform":"linux","runner":"[\"ubuntu-24.04-arm\"]","capabilities":["node","native-toolchain","product-artifacts","rust"]},{"id":"macos-arm64","name":"macOS ARM64","platform":"macos","runner":"[\"self-hosted\",\"macOS\",\"ARM64\",\"kungfu-build-v4-macos-arm64\"]","capabilities":["node","native-toolchain","product-artifacts","rust"]},{"id":"windows-x64","name":"Windows x64","platform":"windows","runner":"[\"self-hosted\",\"Windows\",\"X64\",\"kungfu-build-v4-windows-x64\"]","capabilities":["node","native-toolchain","product-artifacts","rust"]}]')) }}
       # Normal native builds route each exact-label self-hosted lane to its

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -301,9 +301,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:5e3d1fcb5cc78a67e65577371296819a6b80b33ef767d499d4315d9977e66b37",
+          "definitionDigest": "sha256:172491e1f5d1cf5122df8346541bd7dd1a1d74e94d3802dd2f833c6ce13ced18",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN","KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@5246afd4ff5608f6e8d09fb71003992119364880"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@5f4d81bf79da5b8fbd62f3c7dc75361ec92cab46"],
           "steps": []
         },
         {

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -468,7 +468,7 @@
       "adapter": {
         "type": "buildchain-heavy-build",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@5246afd4ff5608f6e8d09fb71003992119364880",
+      "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@5f4d81bf79da5b8fbd62f3c7dc75361ec92cab46",
         "job": {
       "needs": [
         "preflight",
@@ -483,7 +483,7 @@
           }
         },
         "with": {
-          "buildchain-ref": "${{ inputs.buildchain-ref || '5246afd4ff5608f6e8d09fb71003992119364880' }}",
+      "buildchain-ref": "${{ inputs.buildchain-ref || '5f4d81bf79da5b8fbd62f3c7dc75361ec92cab46' }}",
           "runner-preset": "custom",
           "platforms-json": "${{ fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'self-hosted' && '[{\"id\":\"macos-arm64\",\"name\":\"macOS ARM64 self-hosted primary\",\"platform\":\"macos\",\"runner\":\"[\\\"self-hosted\\\",\\\"macOS\\\",\\\"ARM64\\\",\\\"kungfu-build-v4-macos-arm64\\\"]\",\"capabilities\":[\"native-toolchain\",\"node\",\"product-artifacts\",\"rust\"]}]' || (fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'github-hosted' && '[{\"id\":\"macos-arm64\",\"name\":\"macOS ARM64 GitHub-hosted overflow\",\"platform\":\"macos\",\"runner\":\"[\\\"macos-15\\\"]\",\"capabilities\":[\"native-toolchain\",\"node\",\"product-artifacts\",\"rust\"]}]' || (inputs.platforms-json || '[{\"id\":\"linux-x64\",\"name\":\"Linux x64\",\"platform\":\"linux\",\"runner\":\"[\\\"self-hosted\\\",\\\"Linux\\\",\\\"X64\\\",\\\"kungfu-build-v4-linux-x64\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]},{\"id\":\"linux-arm64\",\"name\":\"Linux ARM64\",\"platform\":\"linux\",\"runner\":\"[\\\"ubuntu-24.04-arm\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]},{\"id\":\"macos-arm64\",\"name\":\"macOS ARM64\",\"platform\":\"macos\",\"runner\":\"[\\\"self-hosted\\\",\\\"macOS\\\",\\\"ARM64\\\",\\\"kungfu-build-v4-macos-arm64\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]},{\"id\":\"windows-x64\",\"name\":\"Windows x64\",\"platform\":\"windows\",\"runner\":\"[\\\"self-hosted\\\",\\\"Windows\\\",\\\"X64\\\",\\\"kungfu-build-v4-windows-x64\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]}]')) }}",
           "install-command": "${{ fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'self-hosted' && format('node .github/actions/require-alpha-preflight/alpha-macos-overflow.mjs health --route self-hosted --health-mode {0} && node .github/actions/require-alpha-preflight/windows-alpha-sccache.mjs && node scripts/buildchain-install.mjs', fromJSON(inputs.macos-overflow-request-json).healthMode || 'auto') || fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'github-hosted' && 'node .github/actions/require-alpha-preflight/alpha-macos-overflow.mjs health --route github-hosted --health-mode auto && node .github/actions/require-alpha-preflight/windows-alpha-sccache.mjs && node scripts/buildchain-install.mjs' || 'node .github/actions/require-alpha-preflight/windows-alpha-sccache.mjs && node scripts/buildchain-install.mjs' }}",

--- a/docs/release-promotion-rehearsal.contract.json
+++ b/docs/release-promotion-rehearsal.contract.json
@@ -7,6 +7,7 @@
   },
   "buildchain": {
     "workflow_shell_sha": "5246afd4ff5608f6e8d09fb71003992119364880",
+    "build_workflow_shell_sha": "5f4d81bf79da5b8fbd62f3c7dc75361ec92cab46",
     "alpha": {
       "workflow_ref": "v3-alpha",
       "contract_lock": ".buildchain/alpha-contract-lock.json",

--- a/framework/maintainability/semantic-amplification-report.json
+++ b/framework/maintainability/semantic-amplification-report.json
@@ -5,7 +5,7 @@
   "manifestPath": "framework/maintainability/semantic-amplification.manifest.json",
   "manifestRoot": "sha256:b64ab1daecaec8560dd649af61b7e175adaf562df3aa8b94e3733ef499a308aa",
   "baselineRef": "dbfed9ca1785d147b26f4f06e7e6895ac7368fee",
-  "sourceRoot": "sha256:07799fcf90c044223159108f96726bc43f0ca89feeec1425c139dd359c077949",
+  "sourceRoot": "sha256:2b3b3de3d493656736fa35361857e2dbadfb44a4f6bdaff84ec958e627814fa7",
   "roles": {
     "authority": "exactly one authority route per family; the route may name multiple co-owned source files",
     "allowedProjectionRoles": [
@@ -1144,9 +1144,9 @@
         },
         {
           "path": "scripts/release-promotion-rehearsal.mjs",
-          "currentLines": 773,
+          "currentLines": 776,
           "baselineLines": 713,
-          "currentRoot": "sha256:97d635a70a6ce52370814ed1c418c40bfcc856f6ebe9cec06e983df7126fa532",
+          "currentRoot": "sha256:a4b4f05edc446316fcf5ad540a216a232d8c7ab2dd92cb7fbc4ce6e93ca33e17",
           "baselineRoot": "sha256:12df72a7b881c2c3c83d5a19f1ab8d4189156a4d09ef759fe1e36328f5b4ed1d",
           "changedSinceBaseline": true
         },
@@ -1162,7 +1162,7 @@
           "path": "docs/qualification/gates/workflow-bindings.json",
           "currentLines": 662,
           "baselineLines": 580,
-          "currentRoot": "sha256:17dedc50fbe4042b736a51f82aa630c4c0d56a3d82feb9e375a21dddf8bc4b42",
+          "currentRoot": "sha256:775453323b6b40d43c656bdf253a97c82794ee233074cada1d058148fc29c91e",
           "baselineRoot": "sha256:233cd22ebce4c9930e0e4889808b88661d77c202d5e5f73121823dcdc461576d",
           "changedSinceBaseline": true
         },

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -122,7 +122,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:2a048484f383035e23ce4e5c390cb35e2b64b7bef24fcb9a0b011f965ae8efad"
+          "sourceRoot": "sha256:9238db964f007263ae5f1f41c1584d46994bd0df04c1854b64cb3c8ad589c3b5"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",
@@ -846,5 +846,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:e066706c06d6dc9f079176b7dc9336da678515ff2b62a6eb84cab3da9ac57553"
+  "registryRoot": "sha256:43ed0497edb2ec180fd195579775b7d59a3eb5f852e51cb98100a426163bc7c2"
 }

--- a/scripts/alpha-macos-overflow.test.mjs
+++ b/scripts/alpha-macos-overflow.test.mjs
@@ -464,7 +464,7 @@ test('workflow contract keeps candidates exact-source, independent, and publish-
   );
   assert.match(
     workflow,
-    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@5246afd4ff5608f6e8d09fb71003992119364880/u,
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@5f4d81bf79da5b8fbd62f3c7dc75361ec92cab46/u,
   );
   assert.match(workflow, /checkout-history-mode: full/u);
   assert.match(

--- a/scripts/auditable-demo-workflow.test.mjs
+++ b/scripts/auditable-demo-workflow.test.mjs
@@ -50,7 +50,7 @@ test('one exact Buildchain workflow owns every declared demo', () => {
 test('the build fails the real transported binary before either upload path', () => {
   assert.equal(
     build.uses,
-    'kungfu-systems/buildchain/.github/workflows/.build.yml@5246afd4ff5608f6e8d09fb71003992119364880',
+    'kungfu-systems/buildchain/.github/workflows/.build.yml@5f4d81bf79da5b8fbd62f3c7dc75361ec92cab46',
   );
   assert.equal(
     demo.uses,

--- a/scripts/release-promotion-rehearsal.mjs
+++ b/scripts/release-promotion-rehearsal.mjs
@@ -80,11 +80,14 @@ export function validateWorkflowSources(root, contract, overrides = {}) {
   const promote = extractWorkflowJob(promotion, 'promote');
   const rehearsal = extractWorkflowJob(validation, 'promotion-rehearsal');
   const attestation = contract.buildchain.artifact_attestation;
+  const buildWorkflowShellSha =
+    contract.buildchain.build_workflow_shell_sha ||
+    contract.buildchain.workflow_shell_sha;
 
   requirePattern(
     build,
     new RegExp(
-      `uses: kungfu-systems/buildchain/\\.github/workflows/\\.build\\.yml@${contract.buildchain.workflow_shell_sha}`,
+      `uses: kungfu-systems/buildchain/\\.github/workflows/\\.build\\.yml@${buildWorkflowShellSha}`,
     ),
     findings,
     'release-candidate build must consume the exact stable Buildchain workflow shell',
@@ -92,7 +95,7 @@ export function validateWorkflowSources(root, contract, overrides = {}) {
   requirePattern(
     build,
     new RegExp(
-      `buildchain-ref: \\$\\{\\{ inputs\\.buildchain-ref \\|\\| '${contract.buildchain.workflow_shell_sha}' \\}\\}`,
+      `buildchain-ref: \\$\\{\\{ inputs\\.buildchain-ref \\|\\| '${buildWorkflowShellSha}' \\}\\}`,
     ),
     findings,
     'manual validation must retain the Buildchain ref pass-through and default to the reviewed workflow shell',

--- a/scripts/release-promotion-rehearsal.test.mjs
+++ b/scripts/release-promotion-rehearsal.test.mjs
@@ -171,7 +171,7 @@ test('promotion rejects a static Buildchain ref that differs from its workflow s
 test('PR-stage builds reject a premature publish-source lock', () => {
   const buildPath = CONTRACT.workflows.build;
   const original = fs.readFileSync(path.join(ROOT, buildPath), 'utf8');
-  const buildchainRef = `      buildchain-ref: \${{ inputs.buildchain-ref || '${CONTRACT.buildchain.workflow_shell_sha}' }}`;
+  const buildchainRef = `      buildchain-ref: \${{ inputs.buildchain-ref || '${CONTRACT.buildchain.build_workflow_shell_sha}' }}`;
   const drifted = original.replace(
     buildchainRef,
     [


### PR DESCRIPTION
<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Restore the exact Product Build contract after Buildchain signing authority added immutable run-attempt and request-root inputs"
}
-->

## Summary

Pin the Product Build reusable workflow shell and runtime to the same protected Buildchain cut that owns the detached signing controller. This closes the 422 dispatch mismatch where the old caller omitted the authority required source-run-attempt input.

## Changes

- align the Product Build workflow shell and default runtime at exact Buildchain commit 5f4d81bf79da5b8fbd62f3c7dc75361ec92cab46
- refresh closed-world workflow authority and structured binding facts
- separate the Product Build shell pin from the unchanged stable release-promotion shell
- update overflow, auditable-demo, and promotion rehearsal regression expectations

## Verification

- actionlint .github/workflows/build.yml
- node scripts/check-kungfu-gate-catalog.mjs
- node --test scripts/check-kungfu-gate-catalog.test.mjs scripts/kungfu-workflow-authority.test.mjs (25/25)
- node --test scripts/release-promotion-rehearsal.test.mjs scripts/alpha-macos-overflow.test.mjs scripts/auditable-demo-workflow.test.mjs (36/36)
- complete staged pre-commit gate passed

## Evolution Map impact

Evolution impact: extends

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The patch changes only exact Buildchain contract binding. It does not grant publication authority, weaken signing verification, or make new authority inputs optional.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Machine-generated workflow authority refreshed
