### PR TITLE
fix(shifu): adopt legacy installed Product

### DIFF
--- a/crates/shifu/src/main.rs
+++ b/crates/shifu/src/main.rs
@@ -161,6 +161,7 @@ fn print_usage() {
         style::dim("release; --list provenance; --rollback one step back)")
     );
     println!("  shifu promote [--launch]   install the unique descendant dev build");
+    println!("  shifu promote --adopt-installed --build <id>  bind a pre-receipt local Product");
     println!("  shifu promote --rollback   restore the exact retained prior Product");
     println!("  shifu builds               list provenance and Git relation for dev builds");
     println!("  shifu artifacts <verb>     print the local artifact contract or schema");

--- a/crates/shifu/src/promote.rs
+++ b/crates/shifu/src/promote.rs
@@ -686,6 +686,7 @@ pub fn run_promote(args: &[String]) -> ! {
     let mut check = false;
     let mut rollback = false;
     let mut preview = false;
+    let mut adopt_installed = false;
     let mut allow_nonlinear = false;
     let mut build_arg: Option<String> = None;
     let mut iter = args.iter();
@@ -696,6 +697,7 @@ pub fn run_promote(args: &[String]) -> ! {
             "--check" => check = true,
             "--rollback" => rollback = true,
             "--preview" => preview = true,
+            "--adopt-installed" => adopt_installed = true,
             "--allow-nonlinear" => allow_nonlinear = true,
             "--build" => match iter.next() {
                 Some(value) => build_arg = Some(value.clone()),
@@ -705,7 +707,14 @@ pub fn run_promote(args: &[String]) -> ! {
         }
     }
 
-    let _lock = if check {
+    if adopt_installed
+        && (build_arg.is_none() || rollback || preview || allow_nonlinear || launch || force)
+    {
+        util::die(
+            "--adopt-installed requires --build <id>; --check is its only optional companion",
+        );
+    }
+    let mut promotion_lock = if check {
         None
     } else {
         Some(
@@ -726,6 +735,21 @@ pub fn run_promote(args: &[String]) -> ! {
     }
     if entries.is_empty() {
         no_builds_hint();
+    }
+    if adopt_installed {
+        let build_id = build_arg.as_deref().expect("validated build id");
+        let entry = entries
+            .iter()
+            .find(|candidate| candidate.name == build_id)
+            .unwrap_or_else(|| util::die("--adopt-installed build id is not registered"));
+        let result = adopt_installed_product(entry, !check).unwrap_or_else(|error| {
+            util::die(&format!("installed Product adoption failed: {error}"))
+        });
+        if let Some(lock) = promotion_lock.take() {
+            lock.release().unwrap_or_else(|error| util::die(&error));
+        }
+        println!("{result}");
+        std::process::exit(0);
     }
     let installed = installed_sha();
     let previous_build_id = installed_value("KUNGFU_INSTALLED_BUILD_ID");
@@ -814,7 +838,7 @@ pub fn run_promote(args: &[String]) -> ! {
 }
 
 const PROMOTE_USAGE: &str =
-    "usage: shifu promote [--build <id> [--preview] [--allow-nonlinear] | --rollback] [--check] [--launch] [--force]";
+    "usage: shifu promote [--build <id> [--preview] [--allow-nonlinear] | --rollback | --adopt-installed --build <id>] [--check] [--launch] [--force]";
 
 /// Install target: KUNGFU_PRODUCT_INSTALL_DIR > platform default (falling
 /// back to a per-user location when the default is not writable).

--- a/crates/shifu/src/promote_desktop.rs
+++ b/crates/shifu/src/promote_desktop.rs
@@ -160,6 +160,269 @@ pub(crate) fn product_app_manifests_valid(app: &Path, expected_sha: &str) -> Res
         && profile_count > 0)
 }
 
+struct InstalledAdoption {
+    app: PathBuf,
+    artifact: String,
+    build_id: String,
+    source_commit: String,
+    artifact_digest: String,
+    product_version: String,
+    release_cut_root: String,
+    platform_slice_root: String,
+    native_receipt_root: String,
+    native_updater: PathBuf,
+    native_updater_digest: String,
+}
+
+fn inspect_installed_adoption_at(
+    entry: &BuildEntry,
+    registry: &Path,
+    target_dir: &Path,
+) -> Result<InstalledAdoption, String> {
+    if entry.kind != "app" {
+        return Err("installed adoption currently requires a macOS app candidate".to_string());
+    }
+    if registry.join("installed.meta.env").exists() {
+        return Err("installed Product already has a Shifu receipt".to_string());
+    }
+    let app = target_dir.join(&entry.artifact);
+    let resources = app.join("Contents/Resources");
+    let build = read_document(&resources.join("kungfu/kungfubuildinfo.json"))?
+        .ok_or_else(|| "installed Product has no build identity".to_string())?;
+    let release = read_document(&resources.join("upgrade/kungfu-release-manifest.json"))?
+        .ok_or_else(|| "installed Product has no release manifest".to_string())?;
+    let source_commit = build
+        .get("git")
+        .map(|git| git.str_of("revision").to_string())
+        .unwrap_or_default();
+    if source_commit.len() != 40
+        || !source_commit.bytes().all(|byte| byte.is_ascii_hexdigit())
+        || release.str_of("sourceCommit") != source_commit
+        || !product_app_manifests_valid(&app, &source_commit)?
+    {
+        return Err("installed Product manifests do not bind one exact source commit".to_string());
+    }
+    let product_version = release.str_of("productVersion").to_string();
+    let desktop_release_cut_root = release.str_of("releaseCutRoot").to_string();
+    let desktop_platform_slice_root = release.str_of("platformSliceRoot").to_string();
+    if product_version.is_empty()
+        || !valid_root(&desktop_release_cut_root)
+        || !valid_root(&desktop_platform_slice_root)
+        || release
+            .get("releaseCut")
+            .and_then(|cut| cut.get("publicationPolicy"))
+            .map(|policy| policy.str_of("trustDomain"))
+            != Some("shifu-local")
+    {
+        return Err("installed Product release manifest has no exact local Cut".to_string());
+    }
+    let native_updater = resources.join("kungfu/kungfu");
+    if !native_updater.is_file() {
+        return Err("installed Product has no native updater".to_string());
+    }
+    let output = Command::new(&native_updater)
+        .args(["update", "status", "--json"])
+        .output()
+        .map_err(|error| format!("cannot inspect installed native inventory: {error}"))?;
+    if !output.status.success() {
+        return Err("installed native inventory status failed".to_string());
+    }
+    let status = json::parse(&String::from_utf8_lossy(&output.stdout))
+        .map_err(|error| format!("installed native inventory returned invalid JSON: {error}"))?;
+    let selected = status
+        .get("frontendInventory")
+        .and_then(|inventory| inventory.get("selected"))
+        .ok_or_else(|| "installed native inventory has no selected image".to_string())?;
+    let release_cut_root = selected.str_of("releaseCutRoot").to_string();
+    let platform_slice_root = selected.str_of("platformSliceRoot").to_string();
+    let native_receipt_root = status.str_of("nativeReceiptRoot").to_string();
+    let native_manifest_path =
+        PathBuf::from(selected.str_of("productRoot")).join("upgrade/kungfu-release-manifest.json");
+    let native_manifest = read_document(&native_manifest_path)?
+        .ok_or_else(|| "selected native image has no release manifest".to_string())?;
+    if !valid_root(&release_cut_root)
+        || !valid_root(&platform_slice_root)
+        || !valid_root(&native_receipt_root)
+        || native_manifest.str_of("sourceCommit") != source_commit
+        || native_manifest.str_of("productVersion") != product_version
+        || native_manifest.str_of("releaseCutRoot") != release_cut_root
+        || native_manifest.str_of("platformSliceRoot") != platform_slice_root
+        || native_manifest
+            .get("releaseCut")
+            .and_then(|cut| cut.get("publicationPolicy"))
+            .map(|policy| policy.str_of("trustDomain"))
+            != Some("shifu-local")
+    {
+        return Err(
+            "installed desktop and native inventory do not share one exact source identity"
+                .to_string(),
+        );
+    }
+    let artifact_digest = artifact_sha256(&app)?;
+    let build_id = format!(
+        "adopted-{}-{}",
+        &source_commit[..12],
+        &artifact_digest[..12]
+    );
+    Ok(InstalledAdoption {
+        app,
+        artifact: entry.artifact.clone(),
+        build_id,
+        source_commit,
+        artifact_digest,
+        product_version,
+        release_cut_root,
+        platform_slice_root,
+        native_receipt_root,
+        native_updater_digest: artifact_sha256(&native_updater)?,
+        native_updater,
+    })
+}
+
+fn adopted_build_meta(adoption: &InstalledAdoption) -> String {
+    format!(
+        "KUNGFU_BUILD_SHA='{}'\n\
+         KUNGFU_BUILD_BRANCH='legacy-installed'\n\
+         KUNGFU_BUILD_REPO='installed-product'\n\
+         KUNGFU_BUILD_WORKTREE=''\n\
+         KUNGFU_BUILD_TIME='adopted'\n\
+         KUNGFU_BUILD_KIND='app'\n\
+         KUNGFU_BUILD_ARTIFACT='{}'\n\
+         KUNGFU_BUILD_SHA256='{}'\n\
+         KUNGFU_BUILD_PRODUCT_VERSION='{}'\n\
+         KUNGFU_BUILD_RELEASE_CUT_ROOT='{}'\n\
+         KUNGFU_BUILD_PLATFORM_SLICE_ROOT='{}'\n\
+         KUNGFU_BUILD_MAINLINE_REF='origin/HEAD'\n\
+         KUNGFU_BUILD_MAINLINE_SHA='{}'\n\
+         KUNGFU_BUILD_INTEGRATED='false'\n\
+         KUNGFU_BUILD_QUALIFIED='false'\n",
+        adoption.source_commit,
+        adoption.artifact,
+        adoption.artifact_digest,
+        adoption.product_version,
+        adoption.release_cut_root,
+        adoption.platform_slice_root,
+        adoption.source_commit,
+    )
+}
+
+fn adopted_installed_receipt(adoption: &InstalledAdoption) -> String {
+    format!(
+        "KUNGFU_ARTIFACT_SCHEMA='shifu.local-artifact/v1'\n\
+         KUNGFU_INSTALLED_SHA='{}'\n\
+         KUNGFU_INSTALLED_BRANCH='legacy-installed'\n\
+         KUNGFU_INSTALLED_REPO='installed-product'\n\
+         KUNGFU_INSTALLED_BUILD_ID='{}'\n\
+         KUNGFU_INSTALLED_WORKTREE=''\n\
+         KUNGFU_INSTALLED_ARTIFACT='{}'\n\
+         KUNGFU_INSTALLED_KIND='app'\n\
+         KUNGFU_INSTALLED_DIGEST='{}'\n\
+         KUNGFU_INSTALLED_MAINLINE_REF='origin/HEAD'\n\
+         KUNGFU_INSTALLED_MAINLINE_SHA='{}'\n\
+         KUNGFU_INSTALLED_INTEGRATED='false'\n\
+         KUNGFU_INSTALLED_QUALIFIED='false'\n\
+         KUNGFU_INSTALLED_MODE='legacy-adopted'\n\
+         KUNGFU_INSTALLED_PRODUCT_VERSION='{}'\n\
+         KUNGFU_INSTALLED_RELEASE_CUT_ROOT='{}'\n\
+         KUNGFU_INSTALLED_PLATFORM_SLICE_ROOT='{}'\n\
+         KUNGFU_INSTALLED_CUT_TRANSITION_ROOT=''\n\
+         KUNGFU_INSTALLED_NATIVE_RECEIPT_ROOT='{}'\n\
+         KUNGFU_INSTALLED_NATIVE_UPDATER='{}'\n\
+         KUNGFU_INSTALLED_NATIVE_UPDATER_DIGEST='{}'\n\
+         KUNGFU_ROLLBACK_BUILD_ID=''\n\
+         KUNGFU_ROLLBACK_SHA=''\n\
+         KUNGFU_ROLLBACK_RELEASE_CUT_ROOT=''\n\
+         KUNGFU_ROLLBACK_DESKTOP_PATH=''\n",
+        adoption.source_commit,
+        adoption.build_id,
+        adoption.app.display(),
+        adoption.artifact_digest,
+        adoption.source_commit,
+        adoption.product_version,
+        adoption.release_cut_root,
+        adoption.platform_slice_root,
+        adoption.native_receipt_root,
+        adoption.native_updater.display(),
+        adoption.native_updater_digest,
+    )
+}
+
+pub(super) fn adopt_installed_product_at(
+    entry: &BuildEntry,
+    execute: bool,
+    registry: &Path,
+    target_dir: &Path,
+) -> Result<String, String> {
+    let adoption = inspect_installed_adoption_at(entry, registry, target_dir)?;
+    if execute {
+        fs::create_dir_all(registry)
+            .map_err(|error| format!("cannot create Product registry: {error}"))?;
+        let slot = registry.join(&adoption.build_id);
+        if slot.exists() {
+            let snapshot = slot.join(&adoption.artifact);
+            let expected_meta = adopted_build_meta(&adoption);
+            if fs::read_to_string(slot.join("meta.env")).ok().as_deref()
+                != Some(expected_meta.as_str())
+                || !tree_exact(&adoption.app, &snapshot)?
+                || artifact_sha256(&snapshot)? != adoption.artifact_digest
+            {
+                return Err("installed adoption coordinate exists with different bytes".to_string());
+            }
+        } else {
+            let staged = registry.join(format!(
+                ".{}.tmp-{}-{}",
+                adoption.build_id,
+                std::process::id(),
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_nanos()
+            ));
+            fs::create_dir_all(&staged)
+                .map_err(|error| format!("cannot stage installed adoption: {error}"))?;
+            let staged_app = staged.join(&adoption.artifact);
+            let copy = Command::new("ditto")
+                .arg(&adoption.app)
+                .arg(&staged_app)
+                .status()
+                .map_err(|error| format!("cannot snapshot installed Product: {error}"))?;
+            if !copy.success()
+                || !tree_exact(&adoption.app, &staged_app)?
+                || artifact_sha256(&staged_app)? != adoption.artifact_digest
+            {
+                let _ = fs::remove_dir_all(&staged);
+                return Err("installed Product snapshot failed exact verification".to_string());
+            }
+            fs::write(staged.join("meta.env"), adopted_build_meta(&adoption))
+                .map_err(|error| format!("cannot stage installed adoption metadata: {error}"))?;
+            fs::rename(&staged, &slot)
+                .map_err(|error| format!("cannot publish installed adoption slot: {error}"))?;
+        }
+        write_installed_receipt_at(
+            &registry.join("installed.meta.env"),
+            &adopted_installed_receipt(&adoption),
+        )?;
+    }
+    Ok(format!(
+        "{{\"schema\":\"shifu.installed-product-adoption/v1\",\"state\":\"{}\",\"artifactId\":\"{}\",\"sourceCommit\":\"{}\",\"desktopDigest\":\"sha256:{}\",\"nativeReleaseCutRoot\":\"{}\",\"nativeReceiptRoot\":\"{}\",\"wouldWrite\":{}}}",
+        if execute { "complete" } else { "action-required" },
+        json_escape(&adoption.build_id),
+        json_escape(&adoption.source_commit),
+        json_escape(&adoption.artifact_digest),
+        json_escape(&adoption.release_cut_root),
+        json_escape(&adoption.native_receipt_root),
+        execute,
+    ))
+}
+
+pub(super) fn adopt_installed_product(entry: &BuildEntry, execute: bool) -> Result<String, String> {
+    let target_dir = install_dir(
+        PathBuf::from("/Applications"),
+        host::home_dir().join("Applications"),
+    );
+    adopt_installed_product_at(entry, execute, &registry_dir(), &target_dir)
+}
+
 fn files_equal(left: &Path, right: &Path) -> Result<bool, String> {
     let mut left = fs::File::open(left).map_err(|error| error.to_string())?;
     let mut right = fs::File::open(right).map_err(|error| error.to_string())?;
@@ -437,7 +700,8 @@ pub(super) fn retain_previous_installed_receipt(
             if !backup_updater.is_file() {
                 return Err("retained desktop has no native updater".to_string());
             }
-            (installed_updater, artifact_sha256(&backup_updater)?)
+            let digest = artifact_sha256(&backup_updater)?;
+            (backup_updater, digest)
         }
     } else {
         let source = PathBuf::from(receipt_value(&current, "KUNGFU_INSTALLED_NATIVE_UPDATER"));

--- a/crates/shifu/src/promote_tests.rs
+++ b/crates/shifu/src/promote_tests.rs
@@ -635,6 +635,7 @@ fn receipt_persistence_failure_retains_pending_recovery_material() {
 
 #[cfg(unix)]
 mod unix {
+    use super::*;
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
     use std::path::Path;
@@ -697,6 +698,79 @@ mod unix {
             ),
         )
         .unwrap();
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn installed_adoption_is_read_only_until_execute_and_snapshots_exact_bytes() {
+        let root_dir = host::unique_temp_dir("shifu-installed-adoption").unwrap();
+        let registry = root_dir.join("registry");
+        let install_dir = root_dir.join("Applications");
+        let app = install_dir.join("Kungfu Episodes.app");
+        let resources = app.join("Contents/Resources");
+        let native_root = root_dir.join("native-image");
+        let source_commit = "1".repeat(40);
+        let desktop_cut = root('a');
+        let desktop_slice = root('b');
+        let native_cut = root('c');
+        let native_slice = root('d');
+        let native_receipt = root('e');
+        fs::create_dir_all(resources.join("kungfu")).unwrap();
+        fs::create_dir_all(resources.join("upgrade")).unwrap();
+        fs::create_dir_all(app.join("Contents/MacOS")).unwrap();
+        fs::create_dir_all(native_root.join("upgrade")).unwrap();
+        fs::write(app.join("Contents/MacOS/Kungfu Episodes"), "desktop").unwrap();
+        fs::write(
+            resources.join("kungfu/kungfubuildinfo.json"),
+            format!(r#"{{"git":{{"revision":"{source_commit}"}}}}"#),
+        )
+        .unwrap();
+        fs::write(
+            resources.join("kungfu/profile-kfd3.json"),
+            r#"{"schema":"kungfu.system-profile-kfd3-manifest/v1","entries":[{"id":"work-control"}]}"#,
+        )
+        .unwrap();
+        fs::write(
+            resources.join("upgrade/kungfu-release-manifest.json"),
+            format!(r#"{{"sourceCommit":"{source_commit}","productVersion":"4.0.0-alpha.1","releaseCutRoot":"{desktop_cut}","platformSliceRoot":"{desktop_slice}","releaseCut":{{"publicationPolicy":{{"trustDomain":"shifu-local"}}}}}}"#),
+        )
+        .unwrap();
+        fs::write(
+            native_root.join("upgrade/kungfu-release-manifest.json"),
+            format!(r#"{{"sourceCommit":"{source_commit}","productVersion":"4.0.0-alpha.1","releaseCutRoot":"{native_cut}","platformSliceRoot":"{native_slice}","releaseCut":{{"publicationPolicy":{{"trustDomain":"shifu-local"}}}}}}"#),
+        )
+        .unwrap();
+        let updater = resources.join("kungfu/kungfu");
+        let status = format!(
+            r#"{{"frontendInventory":{{"selected":{{"releaseCutRoot":"{native_cut}","platformSliceRoot":"{native_slice}","productRoot":"{}"}}}},"nativeReceiptRoot":"{native_receipt}"}}"#,
+            native_root.display()
+        );
+        fs::write(
+            &updater,
+            format!("#!/bin/sh\nprintf '%s\\n' '{}'\n", status.replace('\'', "")),
+        )
+        .unwrap();
+        fs::set_permissions(&updater, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let entry = qualified_app(&root_dir.join("candidate"));
+        let plan = adopt_installed_product_at(&entry, false, &registry, &install_dir).unwrap();
+        assert!(plan.contains("\"state\":\"action-required\""));
+        assert!(!registry.exists());
+
+        let receipt = adopt_installed_product_at(&entry, true, &registry, &install_dir).unwrap();
+        assert!(receipt.contains("\"state\":\"complete\""));
+        let installed = fs::read_to_string(registry.join("installed.meta.env")).unwrap();
+        let build_id = receipt_value(&installed, "KUNGFU_INSTALLED_BUILD_ID");
+        assert!(rollback_entry_valid(&registry, &build_id, &source_commit));
+        assert_eq!(
+            artifact_sha256(&registry.join(&build_id).join(&entry.artifact)).unwrap(),
+            artifact_sha256(&app).unwrap()
+        );
+        assert!(installed.contains(&format!("KUNGFU_INSTALLED_RELEASE_CUT_ROOT='{native_cut}'")));
+        fs::remove_file(registry.join("installed.meta.env")).unwrap();
+        assert!(adopt_installed_product_at(&entry, true, &registry, &install_dir).is_ok());
+        assert!(adopt_installed_product_at(&entry, true, &registry, &install_dir).is_err());
+        let _ = fs::remove_dir_all(root_dir);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add an explicit read-only and execute path for adopting a pre-receipt local Product
- snapshot and byte-verify the exact installed Desktop before normal promotion
- bind the matching native Cut and receipt without weakening rollback or promotion gates
- retain the exact rollback updater path after promotion

## Validation

- ./shifu check: passed
- cargo test --manifest-path crates/shifu/Cargo.toml: 55 passed plus source_cli 1 passed
- cargo clippy --manifest-path crates/shifu/Cargo.toml --all-targets -- -D warnings: passed
- live adoption check: read-only and action-required

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded local promotion bootstrap restores an existing rollback invariant for a pre-receipt Product and changes no ADR authority."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] none of the above