### PR TITLE
fix(product): preserve interpreter payload identity

### DIFF
--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -330,6 +330,8 @@ test('CLI product materializes symlinked demo executables as regular files', (t)
   assert.equal(fs.lstatSync(python).isSymbolicLink(), false);
   assert.equal(fs.readFileSync(python, 'utf8'), 'python\n');
   assert.notEqual(fs.statSync(python).mode & 0o111, 0);
+  assert.equal(fs.statSync(python).ino, fs.statSync(pythonTarget).ino);
+  assert.equal(fs.statSync(python).nlink, 2);
 });
 
 test('CLI runtime identity is stable after demo executable metadata', (t) => {

--- a/product/scripts/portable-symlinks.mjs
+++ b/product/scripts/portable-symlinks.mjs
@@ -15,8 +15,7 @@ export function materializeRegularFile(file) {
     throw new Error(`executable symlink target is not a regular file: ${file}`);
   }
   const materialized = `${file}.materialized-regular-file`;
-  fs.copyFileSync(resolved, materialized);
-  fs.chmodSync(materialized, entry.mode & 0o777);
+  fs.linkSync(resolved, materialized);
   fs.renameSync(materialized, file);
 }
 


### PR DESCRIPTION
## Summary

- materialize the bundled Python symlink as a same-filesystem hard link so the executable stays a regular file without duplicating its payload
- preserve the target mode and payload identity through inode sharing
- assert the materialized executable and target share one inode with link count two

## Evidence

- fixes Product run 30849311771 Linux x64 failure: compressed core projection exceeded the 104857600-byte ceiling after copy-based materialization
- exact protected base: af89384a3e0785481953760b4aa5c016f1ec443e
- candidate: 475634d6af07992b1b6efe36584dee81dd38bc9d
- ./shifu check:darwin-x64-retirement: 46/46 passed

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded bugfix preserves existing product packaging, demo executable, and package-size authorities without changing ADR authority."
}
-->