### PR TITLE
fix(product): preserve interpreter payload identity

### DIFF
--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -330,6 +330,8 @@ test('CLI product materializes symlinked demo executables as regular files', (t)
   assert.equal(fs.lstatSync(python).isSymbolicLink(), false);
   assert.equal(fs.readFileSync(python, 'utf8'), 'python\n');
   assert.notEqual(fs.statSync(python).mode & 0o111, 0);
+  assert.equal(fs.statSync(python).ino, fs.statSync(pythonTarget).ino);
+  assert.equal(fs.statSync(python).nlink, 2);
 });
 
 test('CLI runtime identity is stable after demo executable metadata', (t) => {

--- a/product/scripts/portable-symlinks.mjs
+++ b/product/scripts/portable-symlinks.mjs
@@ -15,8 +15,7 @@ export function materializeRegularFile(file) {
     throw new Error(`executable symlink target is not a regular file: ${file}`);
   }
   const materialized = `${file}.materialized-regular-file`;
-  fs.copyFileSync(resolved, materialized);
-  fs.chmodSync(materialized, entry.mode & 0o777);
+  fs.linkSync(resolved, materialized);
   fs.renameSync(materialized, file);
 }
 


### PR DESCRIPTION
## Summary

- materialize the portable interpreter alias as a hard link to its in-tree target
- preserve payload identity without duplicating compressed package bytes
- assert inode identity and link count in the product distribution test

## Validation

- `./shifu check:darwin-x64-retirement` (46/46 passed)

## Exact fork

- protected base: `b00e813f1dd22847168b9fbe7bea5842c5515f96`
- candidate: `bf417c700bc8c0100cea74a399277ce506d29517`

This replaces the earlier exact-fork attempt after protected-base drift.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded bugfix preserves existing product packaging, demo executable, and package-size authorities without changing ADR authority."
}
-->