### PR TITLE
fix(release): isolate hosted acceleration inputs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,7 +179,10 @@ jobs:
       fail-fast: ${{ github.event_name == 'pull_request' || !inputs.diagnostic-mode }}
       setup-rust: true
       rust-toolchain: "1.96.0"
-      cargo-registry-index: ${{ vars.BUILDCHAIN_CARGO_REGISTRY_INDEX }}
+      # Organization Cargo mirrors are private acceleration for explicit
+      # self-hosted/custom diagnostics. Formal hosted candidates use Cargo's
+      # public default and must not depend on LAN reachability.
+      cargo-registry-index: ${{ (fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'self-hosted' || inputs.platforms-json) && vars.BUILDCHAIN_CARGO_REGISTRY_INDEX || '' }}
       artifact-name: kungfu
       artifact-paths: |
         product/release
@@ -245,8 +248,8 @@ jobs:
       # they cannot use runner-local or LAN mirrors. Explicit custom or
       # self-hosted diagnostics retain the cache route they requested.
       checkout-cache-mode: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'self-hosted' && 'auto' || (inputs.platforms-json && 'auto' || 'off') }}
-      checkout-cache-mirror-url-template: ${{ vars.BUILDCHAIN_CHECKOUT_CACHE_MIRROR_URL_TEMPLATE }}
-      checkout-cache-reference-repository-template: ${{ vars.BUILDCHAIN_CHECKOUT_CACHE_REFERENCE_REPOSITORY_TEMPLATE }}
+      checkout-cache-mirror-url-template: ${{ (fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'self-hosted' || inputs.platforms-json) && vars.BUILDCHAIN_CHECKOUT_CACHE_MIRROR_URL_TEMPLATE || '' }}
+      checkout-cache-reference-repository-template: ${{ (fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'self-hosted' || inputs.platforms-json) && vars.BUILDCHAIN_CHECKOUT_CACHE_REFERENCE_REPOSITORY_TEMPLATE || '' }}
       checkout-cache-fallback: github
       checkout-cache-timeout-seconds: 60
       checkout-history-mode: full

--- a/.github/workflows/dev-verify-patrol.yml
+++ b/.github/workflows/dev-verify-patrol.yml
@@ -74,7 +74,6 @@ jobs:
       rust-toolchain: "1.96.0"
       rustup-dist-server: https://rsproxy.cn
       rustup-update-root: https://rsproxy.cn/rustup
-      cargo-registry-index: ${{ vars.BUILDCHAIN_CARGO_REGISTRY_INDEX }}
       gate-profile: dev-patrol
       runner-preset: custom
       platforms-json: >-
@@ -87,8 +86,6 @@ jobs:
       gate-environment-json: >-
         {"SHIFU_NATIVE":"1","KUNGFU_BUILDCHAIN_NO_OPTIONAL":"1",
         "KUNGFU_BUILDCHAIN_SOURCE_BUILD":"1","VSLANG":"1033"}
-      shifu-cache-profile-ref: ${{ vars.SHIFU_CACHE_PROFILE_REF }}
-      shifu-cache-profile-digest: ${{ vars.SHIFU_CACHE_PROFILE_DIGEST }}
 
   # Keep one tracking issue in sync with the patrol result: open or refresh it
   # when dev is red, close it when dev returns to green. This is the standing

--- a/.github/workflows/linux-arm64-alpha-qualification.yml
+++ b/.github/workflows/linux-arm64-alpha-qualification.yml
@@ -75,7 +75,6 @@ jobs:
       rust-toolchain: "1.96.0"
       rustup-dist-server: https://rsproxy.cn
       rustup-update-root: https://rsproxy.cn/rustup
-      cargo-registry-index: ${{ vars.BUILDCHAIN_CARGO_REGISTRY_INDEX }}
       artifact-name: kungfu-hub-cli
       artifact-paths: |
         product/release/cli/kungfu-episodes-cli-linux-arm64.tar.gz
@@ -104,7 +103,7 @@ jobs:
       publish-channel: ${{ github.event_name == 'pull_request' && (startsWith(github.base_ref, 'release/') && 'release' || 'alpha') || 'none' }}
       artifact-transfer-mode: s3-to-github-artifacts
       artifact-retention-days: 14
-      checkout-cache-mode: auto
+      checkout-cache-mode: off
       checkout-cache-fallback: github
       checkout-cache-timeout-seconds: 60
       checkout-cache-github-timeout-seconds: 1200

--- a/docs/development/buildchain.md
+++ b/docs/development/buildchain.md
@@ -76,18 +76,23 @@ exists to hold.
 
 ## CI source checkout cache
 
-The release-candidate build uses Buildchain's locked source checkout cache in
-`auto` mode. Self-hosted runners first try the trusted local/LAN Git object cache
-declared by repository or organization variables, then fall back to GitHub if the
-cache is unavailable:
+Formal Alpha and Release candidates plus the Dev Verify consumed by Candidate
+Patrol use fresh GitHub-hosted runners with checkout-cache mode `off`. They fetch
+the immutable source directly from GitHub and do not receive private Cargo
+registry, Shifu cache-profile, Git mirror, or reference-repository inputs.
+Self-hosted and explicit custom diagnostics may instead use Buildchain's locked
+source checkout cache in `auto` mode. Those runners first try the trusted
+local/LAN Git object cache declared by repository or organization variables,
+then fall back to GitHub if the cache is unavailable:
 
 - `BUILDCHAIN_CHECKOUT_CACHE_MIRROR_URL_TEMPLATE`
 - `BUILDCHAIN_CHECKOUT_CACHE_REFERENCE_REPOSITORY_TEMPLATE`
 
-These values are intentionally not checked into this repository. They describe
-private runner or local-network topology. Buildchain still resolves and verifies
-the immutable source commit and tree before running lifecycle commands, and it
-writes sanitized `source-checkout.json` diagnostics into the platform artifacts.
+These values are intentionally not checked into this repository or projected
+into formal hosted jobs. They describe private runner or local-network topology.
+Buildchain still resolves and verifies the immutable source commit and tree
+before running lifecycle commands, and it writes sanitized
+`source-checkout.json` diagnostics into the platform artifacts.
 
 ## Alpha and release artifact relay
 

--- a/docs/qualification/gates/release-and-promotion.md
+++ b/docs/qualification/gates/release-and-promotion.md
@@ -30,6 +30,9 @@ self-hosted workspace history, retained toolchains, and runner inventory state
 cannot alter formal release routing or qualification prerequisites.
 Formal lanes fetch the immutable source directly from GitHub instead of probing
 LAN or runner-local mirrors that are unreachable from hosted infrastructure.
+They also omit organization-level private Cargo registries and remote Shifu
+cache profiles; public/default dependency endpoints and checked-in portable
+profiles are the only inputs allowed on the formal hosted boundary.
 
 Buildchain still seals exact-source unsigned artifacts and detached signing
 requests in the functional matrix. Signing and notarization execute only in
@@ -45,7 +48,8 @@ self-hosted platform matrix for explicit diagnostics. The manual macOS
 overflow controller also retains its independent self-hosted and GitHub-hosted
 candidate identities, always with `publish-channel: none`; neither path is the
 default formal Alpha route. Explicit self-hosted or custom diagnostics may
-still opt into the bounded checkout-cache policy.
+still opt into the bounded checkout-cache policy and private acceleration
+variables.
 
 ### Queue-aware macOS overflow
 

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -301,7 +301,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:a2ca960deedb318436bd14cd1ba86ca5540940ca33c6f613292081901f3dfa8d",
+          "definitionDigest": "sha256:15bf19158f3a566294cc96ccfeeeb54727d93d916501879d669c9815663bb479",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN","KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@825f596fe4a5ed8a4b2bb4f7c5a1b44cb9a075a3"],
           "steps": []
@@ -621,7 +621,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:cb68df807c17306aa4d51cd9cde0d5a3a59e40bbb588a927aec742463c784d96",
+          "definitionDigest": "sha256:f31e339a6ab1aa1add41e5d7a365e269858a3aba947aef96f9f40b5e74534f6e",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@825f596fe4a5ed8a4b2bb4f7c5a1b44cb9a075a3"],
           "steps": []
@@ -780,7 +780,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:e7014e962c7d92dc5e39467025aae54fdfd622162cf813b7506ae6d3cdc212a6",
+          "definitionDigest": "sha256:05a579aed425ab3f19ea8f79bd2ff77b2aaec2e89588f607217f62e5649e3d58",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@bfe43b0fe5577f15d2af01bc542de8a8ce587457"],
           "steps": []

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -344,7 +344,6 @@
         "uses": "kungfu-systems/buildchain/.github/workflows/.gate-profile.yml@825f596fe4a5ed8a4b2bb4f7c5a1b44cb9a075a3",
         "with": {
           "buildchain-ref": "${{ github.event_name == 'workflow_dispatch' && inputs.buildchain-ref || '' }}",
-          "cargo-registry-index": "${{ vars.BUILDCHAIN_CARGO_REGISTRY_INDEX }}",
           "checkout-cache-fallback": "github",
           "checkout-cache-mode": "off",
           "gate-profile": "dev-patrol",

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -122,7 +122,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:85ad96b5b4e86dad51acd41d67fd34eefc4f21449238d6cd614f903bb0ced6fd"
+          "sourceRoot": "sha256:a6319e7e2229ebedb478dabe4fdee7d1c2f7e90d75d52a4c9913af1bdc828e23"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",
@@ -220,7 +220,7 @@
             "product-alpha",
             "product-stable"
           ],
-          "sourceRoot": "sha256:2fbcd9972d32f3bbd14b6ac8f6ccd07923c1481ceb5893332172e771b5c1ee5b"
+          "sourceRoot": "sha256:769c5e5530ec13628376dc178ebf52355351ff69bb4e8ec7b8add88ed65d5d91"
         },
         {
           "path": ".github/workflows/docs-check.yml",
@@ -272,7 +272,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:62743a6b64d9b897792c572d6b8e3ad3eafd54b5ea330cb246b0467308ee8d3f"
+          "sourceRoot": "sha256:20618795b9bafbb08a12b41a48fe139549d76f9bedc2d14791d28956a7c4c63a"
         },
         {
           "path": ".github/workflows/kungfu-agent-patrol.yml",
@@ -860,5 +860,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:f3232f07a436ec202615c3f3b4026c252a06ae33eb8135aaaa5c1f23f8c14650"
+  "registryRoot": "sha256:9353b6077e518ebeae43d9aeb0701c0f904433f6a05f5b4e55ca54adf2313122"
 }

--- a/scripts/alpha-macos-overflow.test.mjs
+++ b/scripts/alpha-macos-overflow.test.mjs
@@ -471,6 +471,19 @@ test('workflow contract keeps candidates exact-source, independent, and publish-
     workflow,
     /checkout-cache-mode: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.mode == 'self-hosted' && 'auto' \|\| \(inputs\.platforms-json && 'auto' \|\| 'off'\) \}\}/u,
   );
+  for (const input of [
+    'cargo-registry-index',
+    'checkout-cache-mirror-url-template',
+    'checkout-cache-reference-repository-template',
+  ]) {
+    assert.match(
+      workflow,
+      new RegExp(
+        `${input}: \\$\\{\\{ \\(fromJSON\\(inputs\\.macos-overflow-request-json \\|\\| '\\{\\}'\\)\\.mode == 'self-hosted' \\|\\| inputs\\.platforms-json\\) && vars\\.`,
+        'u',
+      ),
+    );
+  }
   assert.match(workflow, /self-hosted-offline-fallback: false/u);
   for (const runner of [
     String.raw`runner":"[\"ubuntu-24.04\"]"`,

--- a/scripts/linux-arm64-alpha-qualification-workflow.test.mjs
+++ b/scripts/linux-arm64-alpha-qualification-workflow.test.mjs
@@ -70,6 +70,8 @@ test('Linux ARM64 runs artifact qualification with an independent budget', () =>
     'node product/scripts/verify-cli-surface-qualification.mjs --qualification product/release/cli/kungfu-episodes-cli-linux-arm64.qualification.json --archive product/release/cli/kungfu-episodes-cli-linux-arm64.tar.gz --platform linux-arm64',
   );
   assert.equal(inputs['lifecycle-timeout-minutes'], 240);
+  assert.equal(inputs['checkout-cache-mode'], 'off');
+  assert.equal(inputs['cargo-registry-index'], undefined);
   assert.equal(
     inputs['shifu-cache-profile-ref'],
     'docs/shifu/linux-arm64-qualification-portable-off.cache-profile.json',
@@ -89,5 +91,9 @@ test('Linux ARM64 runs artifact qualification with an independent budget', () =>
   assert.doesNotMatch(
     fs.readFileSync(ARM_WORKFLOW, 'utf8'),
     /run-release-qualification/u,
+  );
+  assert.doesNotMatch(
+    fs.readFileSync(ARM_WORKFLOW, 'utf8'),
+    /BUILDCHAIN_CARGO_REGISTRY_INDEX/u,
   );
 });

--- a/scripts/source-acceptance.test.mjs
+++ b/scripts/source-acceptance.test.mjs
@@ -428,6 +428,10 @@ test('dev patrol normalizes MSVC diagnostics for bounded Gate output', () => {
     'utf8',
   );
   assert.match(workflow, /"VSLANG":"1033"/);
+  assert.doesNotMatch(workflow, /BUILDCHAIN_CARGO_REGISTRY_INDEX/u);
+  assert.doesNotMatch(workflow, /SHIFU_CACHE_PROFILE_(?:REF|DIGEST)/u);
+  assert.doesNotMatch(workflow, /cargo-registry-index:/u);
+  assert.doesNotMatch(workflow, /shifu-cache-profile-(?:ref|digest):/u);
 });
 
 test('Python source checks use uvx when a bare ruff is unavailable', () => {


### PR DESCRIPTION
## Summary

- prevent formal GitHub-hosted Dev Verify and Alpha qualification from inheriting private LAN Cargo registry or Shifu cache profiles
- keep private acceleration available only for explicit self-hosted/custom diagnostic runs
- refresh the release publication workflow roots for the exact changed workflows

## Validation

- targeted runner-layering and Alpha authority tests: 70/70
- docs check: pass
- gate catalog: 38 gates, 6 profiles, 27 structured invocations, 36 workflows
- release publication control plane: qualifying
- source acceptance reaches the publication control plane successfully; the remaining local-only pytest discovery failure is absent in hosted source acceptance because that controller provisions its exact pytest tool

## Evolution impact

No accepted ADR changes. This is an ADR-neutral reliability repair: public hosted release lanes remain authoritative and cannot inherit private self-hosted acceleration.

## Governance risk

The protected PR, Dev Delivery Warrant, exact queue admission, hosted Dev Verify, and Alpha publication gates remain fail-closed. No release credential or publication authority is added to this PR.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This repair preserves accepted release authority while isolating formal GitHub-hosted workflows from private self-hosted acceleration inputs."
}
-->