### PR TITLE
fix(release): resume sealed alpha candidate

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -18,6 +18,51 @@ on:
         required: false
         default: ""
         type: string
+      resume-candidate-repository:
+        description: "Exact repository that owns an existing sealed candidate run"
+        required: false
+        default: ""
+        type: string
+      resume-candidate-run-id:
+        description: "Exact successful Build run to recover without rebuilding"
+        required: false
+        default: ""
+        type: string
+      resume-candidate-source-sha:
+        description: "Exact source commit recorded by the existing candidate"
+        required: false
+        default: ""
+        type: string
+      resume-expected-workflow-file:
+        description: "Exact Build workflow file recorded by the existing candidate"
+        required: false
+        default: ""
+        type: string
+      resume-expected-workflow-name:
+        description: "Exact Build workflow display name recorded by the existing candidate"
+        required: false
+        default: ""
+        type: string
+      resume-expected-source-tree:
+        description: "Exact source tree recorded by the existing candidate"
+        required: false
+        default: ""
+        type: string
+      resume-expected-candidate-runtime-sha:
+        description: "Exact Buildchain runtime recorded by the existing candidate"
+        required: false
+        default: ""
+        type: string
+      resume-buildchain-runtime-sha:
+        description: "Exact Buildchain tooling SHA resolved by the recovery train"
+        required: false
+        default: ""
+        type: string
+      publish-transaction-override:
+        description: "Allow only the matching durable transaction to resume"
+        required: false
+        default: false
+        type: boolean
   pull_request:
     types: [closed]
     branches:
@@ -29,7 +74,7 @@ permissions:
 
 jobs:
   promotion-contract:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.resume-candidate-run-id == '') || github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -119,9 +164,72 @@ jobs:
           ./shifu release:publication:admit -- --surface "$surface" --operation rehearsal
           ./shifu release:promotion:rehearse
 
+  recovery-preflight:
+    name: Verify immutable Alpha recovery coordinates
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.resume-candidate-run-id != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Require the bounded Alpha 1 recovery identity
+        env:
+          CANDIDATE_REPOSITORY: ${{ inputs.resume-candidate-repository }}
+          CANDIDATE_RUN_ID: ${{ inputs.resume-candidate-run-id }}
+          CANDIDATE_SOURCE_SHA: ${{ inputs.resume-candidate-source-sha }}
+          EXPECTED_WORKFLOW_FILE: ${{ inputs.resume-expected-workflow-file }}
+          EXPECTED_WORKFLOW_NAME: ${{ inputs.resume-expected-workflow-name }}
+          EXPECTED_SOURCE_TREE: ${{ inputs.resume-expected-source-tree }}
+          EXPECTED_CANDIDATE_RUNTIME_SHA: ${{ inputs.resume-expected-candidate-runtime-sha }}
+          RECOVERY_RUNTIME_SHA: ${{ inputs.resume-buildchain-runtime-sha }}
+          TARGET_REF: ${{ inputs.target-ref }}
+          TARGET_SHA: ${{ inputs.target-sha }}
+          PREFLIGHT_RUN_ID: ${{ inputs.preflight-run-id }}
+          TRANSACTION_OVERRIDE: ${{ inputs.publish-transaction-override }}
+        run: |
+          set -euo pipefail
+          test "$CANDIDATE_REPOSITORY" = "kungfu-systems/kungfu"
+          test "$CANDIDATE_RUN_ID" = "31051528142"
+          test "$CANDIDATE_SOURCE_SHA" = "ad7c7db6df076f969c5939728bcbe70ccd4771b3"
+          test "$EXPECTED_WORKFLOW_FILE" = "build.yml"
+          test "$EXPECTED_WORKFLOW_NAME" = "Build"
+          test "$EXPECTED_SOURCE_TREE" = "67a93b5831596555e7c29104421de3a0b97eb865"
+          test "$EXPECTED_CANDIDATE_RUNTIME_SHA" = "2e7e07902ac28d8f3edcfb81098ef9ebc7a91878"
+          test "$RECOVERY_RUNTIME_SHA" = "c62ab3fca2a63b5cc30d90ba9a72b61c709bac0d"
+          test "$TARGET_REF" = "alpha/v4/v4.0"
+          test "$TARGET_SHA" = "f9e6b0e34bcdd6407b2a18206ace7982d64de2c8"
+          test "$PREFLIGHT_RUN_ID" = "31051197057"
+          test "$TRANSACTION_OVERRIDE" = "true"
+
+      - name: Checkout immutable candidate source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.resume-candidate-source-sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+
+      - name: Reuse exact Alpha preflight
+        uses: ./.github/actions/require-alpha-preflight
+        with:
+          source-sha: ${{ inputs.resume-candidate-source-sha }}
+          receipt-run-id: ${{ inputs.preflight-run-id }}
+
+      - name: Verify promotion target preserves the candidate tree
+        env:
+          TARGET_SHA: ${{ inputs.target-sha }}
+          EXPECTED_TREE: ${{ inputs.resume-expected-source-tree }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "$TARGET_SHA"
+          test "$(git rev-parse "$TARGET_SHA^{tree}")" = "$EXPECTED_TREE"
+
   promote:
     needs: promotion-contract
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.resume-candidate-run-id == '') || github.event.pull_request.merged == true }}
     permissions:
       actions: write
       artifact-metadata: write
@@ -203,6 +311,108 @@ jobs:
       github-artifact-attestation-policy-json: auto
       github-artifact-attestation-environment: buildchain-artifact-attestation
       dry-run: ${{ github.event_name == 'workflow_dispatch' }}
+    secrets:
+      BUILDCHAIN_PROMOTION_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}
+      BUILDCHAIN_PUBLICATION_COMMIT_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}
+      BUILDCHAIN_PUBLICATION_COMMIT_SIGNING_KEY: ${{ secrets.KUNGFU_ALPHA_CHANNEL_SIGNING_PRIVATE_KEY }}
+      KUNGFU_GOVERNANCE_AUDITOR_APP_PRIVATE_KEY: ${{ secrets.KUNGFU_GOVERNANCE_AUDITOR_APP_PRIVATE_KEY }}
+      BUILDCHAIN_ISSUE_APP_ID: ${{ secrets.BUILDCHAIN_ISSUE_APP_ID }}
+      BUILDCHAIN_ISSUE_APP_PRIVATE_KEY: ${{ secrets.BUILDCHAIN_ISSUE_APP_PRIVATE_KEY }}
+
+  recover:
+    name: Reuse sealed Alpha candidate
+    needs: recovery-preflight
+    if: ${{ always() && github.event_name == 'workflow_dispatch' && inputs.resume-candidate-run-id != '' && needs.recovery-preflight.result == 'success' }}
+    permissions:
+      actions: write
+      artifact-metadata: write
+      attestations: write
+      checks: write
+      contents: write
+      issues: write
+      id-token: write
+      pull-requests: write
+    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@train/v3/v3.0/resume-candidate-run
+    with:
+      buildchain-channel: alpha
+      buildchain-ref: train/v3/v3.0/resume-candidate-run
+      channel: alpha
+      target-ref: ${{ inputs.target-ref }}
+      target-sha: ${{ inputs.target-sha }}
+      buildchain-contract-lock-path: .buildchain/alpha-contract-lock.json
+      buildchain-contract-compatibility-policy: major-compatible
+      buildchain-contract-drift-issue-mode: compatible-and-breaking
+      resume-candidate-repository: ${{ inputs.resume-candidate-repository }}
+      resume-candidate-run-id: ${{ inputs.resume-candidate-run-id }}
+      resume-expected-workflow-file: ${{ inputs.resume-expected-workflow-file }}
+      resume-expected-workflow-name: ${{ inputs.resume-expected-workflow-name }}
+      resume-expected-source-tree: ${{ inputs.resume-expected-source-tree }}
+      resume-expected-candidate-runtime-sha: ${{ inputs.resume-expected-candidate-runtime-sha }}
+      resume-buildchain-runtime-sha: ${{ inputs.resume-buildchain-runtime-sha }}
+      publish-transaction-override: ${{ inputs.publish-transaction-override }}
+      release-candidate-wait-seconds: 10800
+      publication-auto-admission: true
+      publication-gate-command: node scripts/assemble-kungfu-publication-gate.mjs
+      publication-consumer-qualification-command: node scripts/kungfu-release-qualification.mjs
+      publication-consumer-predicate-id: kungfu.release-admission/v1
+      publication-publisher-workflow-path: .github/workflows/release-new-version.yml
+      publication-product: Kungfu Episodes
+      publication-target: github-release:kungfu-systems/kungfu
+      publication-package-name: ""
+      package-manager: custom
+      artifact-name: kungfu
+      release-candidate-workflow-file: build.yml
+      release-candidate-workflow-name: Build
+      artifact-patterns: |
+        kungfu-*
+      required-status-check: build / Finalize build controller evidence
+      publish-target: custom
+      publish-artifact-kind: kungfu-product
+      publish-command: node scripts/buildchain-custom-publish-evidence.mjs
+      github-release-payload-patterns: |
+        kungfu-episodes-cli-*.tar.gz
+        kungfu-episodes-cli-*.zip
+        kungfu-episodes-cli-*.qualification.json
+      publication-commit-command: node scripts/alpha-publication-commit.mjs
+      publication-commit-evidence-path: .buildchain/publication-commit/evidence.json
+      release-activation-command: node scripts/activate-ungfu-release.mjs
+      release-activation-receipt-set-path: .buildchain/release-activation/receipt-set.json
+      standalone-binary-distribution: false
+      publish-mode: publish-final-version
+      publish-dist-tag: alpha
+      publish-package-set-order: as-provided
+      trusted-publishing: false
+      runner-preset: kungfu-v4-native
+      required-artifact-count: 5
+      release-passport: true
+      release-passport-product-name: Kungfu Episodes
+      release-passport-kfd-1-witness-jsons: |
+        .buildchain/kfd/kfd-1/contract-world.witness.json
+        .buildchain/kfd/kfd-1/documentation-pack.witness.json
+      release-passport-kfd-2-claim-jsons: |
+        .buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
+        .buildchain/kfd/kfd-2/claims/codex-report-receipts.json
+        .buildchain/kfd/kfd-2/claims/remote-fact-boundary.json
+      release-passport-kfd-3-prebuild-witness-jsons: |
+        .buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+      release-passport-kfd-3-artifact-verify-command: node scripts/buildchain-kfd-evidence.mjs --artifact-witness --json
+      release-passport-kfd-support-matrix-json: .buildchain/kfd/support-matrix.json
+      release-passport-kfd-product-gate-jsons: |
+        .buildchain/runtime/kfd-product-gates/kfd-4/gate.json
+        .buildchain/runtime/kfd-product-gates/kfd-5/gate.json
+        .buildchain/runtime/kfd-product-gates/kfd-7/gate.json
+      release-passport-evidence-command: >-
+        node scripts/prepare-ungfu-release-evidence.mjs --release
+        --receipts "$BUILDCHAIN_RELEASE_ACTIVATION_RECEIPTS"
+        --output "$BUILDCHAIN_RELEASE_EVIDENCE_PATH"
+        --readback --json
+      release-passport-evidence-path: .buildchain/release-evidence/ungfu-public-use.json
+      release-passport-invariant-passport-command: >-
+        node scripts/kungfu-invariant.mjs --collect-evidence .
+        --passport product/release/qualification/invariant-passport.json --json
+      github-artifact-attestation-policy-json: auto
+      github-artifact-attestation-environment: buildchain-artifact-attestation
+      dry-run: false
     secrets:
       BUILDCHAIN_PROMOTION_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}
       BUILDCHAIN_PUBLICATION_COMMIT_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/docs/qualification/gates/release-and-promotion.md
+++ b/docs/qualification/gates/release-and-promotion.md
@@ -156,7 +156,7 @@ retain the 25-minute default.
 - **Evidence:** unified Gate receipt; no separate artifact is currently required.
 - **Diagnosis:** `./shifu gate explain release.artifact-admission --profile <profile>`; reproduce with `./shifu gate run release.artifact-admission` on a capable runner.
 - **Cost:** heavy; timeout 1800 seconds.
-- **Current source:** .github/workflows/release-new-version.yml (promote; merged alpha or release pull request, or manual source-locked dry-run measurement).
+- **Current source:** .github/workflows/release-new-version.yml (promote; merged alpha or release pull request, or manual source-locked dry-run measurement); .github/workflows/release-new-version.yml (recover; manual recovery of the single pre-existing sealed Alpha 1 candidate without product rebuild).
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:release.artifact-admission -->
 

--- a/docs/qualification/gates/source-and-governance.md
+++ b/docs/qualification/gates/source-and-governance.md
@@ -54,7 +54,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Evidence:** unified Gate receipt; no separate artifact is currently required.
 - **Diagnosis:** `./shifu gate explain governance.buildchain-config --profile <profile>`; reproduce with `./shifu gate run governance.buildchain-config` on a capable runner.
 - **Cost:** light; timeout 120 seconds.
-- **Current source:** .github/workflows/affected-native-pr.yml (candidate_buildchain_config; every dev pull request and merge-group candidate before governance preflight or expensive queue work); .github/workflows/buildchain-validate.yml (validate; pull requests except dev/v*/v*, or alpha/release channel push); .github/workflows/release-new-version.yml (promote; merged alpha or release pull request, or manual source-locked dry-run measurement).
+- **Current source:** .github/workflows/affected-native-pr.yml (candidate_buildchain_config; every dev pull request and merge-group candidate before governance preflight or expensive queue work); .github/workflows/buildchain-validate.yml (validate; pull requests except dev/v*/v*, or alpha/release channel push); .github/workflows/release-new-version.yml (promote; merged alpha or release pull request, or manual source-locked dry-run measurement); .github/workflows/release-new-version.yml (recover; manual recovery of the single pre-existing sealed Alpha 1 candidate without product rebuild).
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:governance.buildchain-config -->
 

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -935,7 +935,7 @@
     {
       "path": ".github/workflows/release-new-version.yml",
       "authority": "release-control",
-      "definitionDigest": "sha256:605743db259b0bf409d49070a30a092034bee9b1e105e7f20f923fef8ce51db4",
+      "definitionDigest": "sha256:fbf1524a96d33813b55e5ca1beb42a36ddf87e308aa86fd6b7b752d9984a7e45",
       "jobs": [
         {
           "id": "alpha-timeline",
@@ -952,7 +952,7 @@
           "authority": "release-control",
           "publication": "channel",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:9c6edfce28b097a3097c3e02484588363688123813886acf253e8ddc20f529de",
+          "definitionDigest": "sha256:12e2a53afb453c36d3fc4887c83186db37e34572e2189b8762ba266dabf1e079",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["BUILDCHAIN_ISSUE_APP_ID","BUILDCHAIN_ISSUE_APP_PRIVATE_KEY","KUNGFU_ALPHA_CHANNEL_SIGNING_PRIVATE_KEY","KUNGFU_GITHUB_TOKEN","KUNGFU_GOVERNANCE_AUDITOR_APP_PRIVATE_KEY"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@2e7e07902ac28d8f3edcfb81098ef9ebc7a91878"],
           "steps": []
@@ -962,10 +962,30 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:928b92797b78a1666e40d816dd7b25e7c95478af3465dcd6620fbd2ebc857335",
+          "definitionDigest": "sha256:4e9e5ddb616e8d063176be8f6c2b810e8b05d9468d8dc1dc4b63aa370ec5b93d",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
           "steps": [{"index":1,"label":"id:candidate","definitionDigest":"sha256:b26ccd80ef6de735f425e42a2f6bc52b4d0473bf52771cc1d9c2efecb674843a"},{"index":2,"label":"name:Checkout immutable Alpha candidate","definitionDigest":"sha256:8f1ff28917c625d57760451e82ab1239ddf747a611068bf9c6ad1067ad8f6284"},{"index":3,"label":"uses:actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","definitionDigest":"sha256:a869cc671103a9106dc90b4275a4148de9a5d18cd3578a2642d8ae8076d8dbf0"},{"index":4,"label":"id:preflight","definitionDigest":"sha256:de360134fee9dbf785d19794d87d62f16b07c7bf2872c83ce97be75fa0b8a02f"},{"index":5,"label":"name:Checkout immutable promotion result","definitionDigest":"sha256:9ff1aa9f5707e1bed64e57983cf9e409bd19fc8146dd5aa1801e1f6d4b8413f4"},{"index":6,"label":"id:promotion-tree","definitionDigest":"sha256:391088f704e8df632f937c4fe9c1265efb3846849c489032170178e871bde248"},{"index":7,"label":"name:Rehearse the Kungfu promotion contract for a pull request","definitionDigest":"sha256:0af2d30832fe4041d9997fd0a331f528a62b23fba2e3c9cfc23e45dd8ab38947"},{"index":8,"label":"name:Rehearse the Kungfu promotion contract for a manual dry-run","definitionDigest":"sha256:ac10175c46721c013cdc70ec9c5db82713fabd00be703439cf665365bef6c05d"}]
+        },
+        {
+          "id": "recover",
+          "authority": "release-control",
+          "publication": "channel",
+          "receipt": "qualifying",
+          "definitionDigest": "sha256:069119e56d0d4ab070d9d54a266b16570a646dc7eacd6d740f78e755fc66ebcd",
+          "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["BUILDCHAIN_ISSUE_APP_ID","BUILDCHAIN_ISSUE_APP_PRIVATE_KEY","KUNGFU_ALPHA_CHANNEL_SIGNING_PRIVATE_KEY","KUNGFU_GITHUB_TOKEN","KUNGFU_GOVERNANCE_AUDITOR_APP_PRIVATE_KEY"],"inheritedSecrets":false,"environment":null},
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@train/v3/v3.0/resume-candidate-run"],
+          "steps": []
+        },
+        {
+          "id": "recovery-preflight",
+          "authority": "qualification",
+          "publication": "none",
+          "receipt": "diagnostic",
+          "definitionDigest": "sha256:e1bf7440015ee53c5ca74c170e91fb8657d169069ef270b66c117f617359e354",
+          "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
+          "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"],
+          "steps": [{"index":1,"label":"name:Require the bounded Alpha 1 recovery identity","definitionDigest":"sha256:0e6e6fbb8ce01581ee18c2f28ef74d3d709e794b086966ebbe0424fc1f57d050"},{"index":2,"label":"name:Checkout immutable candidate source","definitionDigest":"sha256:e40649f5b143d21ffd7142da1bc68a742801f31c93e3ab2ada4aee4b6c2d967b"},{"index":3,"label":"uses:actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","definitionDigest":"sha256:a869cc671103a9106dc90b4275a4148de9a5d18cd3578a2642d8ae8076d8dbf0"},{"index":4,"label":"name:Reuse exact Alpha preflight","definitionDigest":"sha256:76bc1b6cd358a7a800cb54acdee85b263411cdbd3e9f48d258448c456b6feef2"},{"index":5,"label":"name:Verify promotion target preserves the candidate tree","definitionDigest":"sha256:7fd95645898bbb9582006c899eb652152f9f411fc5a4354566c2405e7c67ba91"}]
         }
       ]
     },

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -114,6 +114,8 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/release-new-version.yml` | `alpha-timeline` | qualification | none | diagnostic | token:write | none | 11 |
 | `.github/workflows/release-new-version.yml` | `promote` | release-control | channel | qualifying | token:write, oidc, repo-secret:BUILDCHAIN_ISSUE_APP_ID+BUILDCHAIN_ISSUE_APP_PRIVATE_KEY+KUNGFU_ALPHA_CHANNEL_SIGNING_PRIVATE_KEY+KUNGFU_GITHUB_TOKEN+KUNGFU_GOVERNANCE_AUDITOR_APP_PRIVATE_KEY | none | 0 |
 | `.github/workflows/release-new-version.yml` | `promotion-contract` | qualification | none | diagnostic | token:read | none | 8 |
+| `.github/workflows/release-new-version.yml` | `recover` | release-control | channel | qualifying | token:write, oidc, repo-secret:BUILDCHAIN_ISSUE_APP_ID+BUILDCHAIN_ISSUE_APP_PRIVATE_KEY+KUNGFU_ALPHA_CHANNEL_SIGNING_PRIVATE_KEY+KUNGFU_GITHUB_TOKEN+KUNGFU_GOVERNANCE_AUDITOR_APP_PRIVATE_KEY | none | 0 |
+| `.github/workflows/release-new-version.yml` | `recovery-preflight` | qualification | none | diagnostic | token:read | none | 5 |
 | `.github/workflows/release-shifu.yml` | `build` | qualification | none | diagnostic | token:write, oidc | none | 7 |
 | `.github/workflows/release-shifu.yml` | `release` | product-publication | product | none | token:write, repo-secret:GITHUB_TOKEN | `adr0049-production-publication` | 3 |
 | `.github/workflows/report-projection.yml` | `exact-source-projection` | qualification | none | diagnostic | token:read | none | 6 |

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -613,7 +613,7 @@
         "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@2e7e07902ac28d8f3edcfb81098ef9ebc7a91878",
         "job": {
           "needs": "promotion-contract",
-          "if": "${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}"
+          "if": "${{ (github.event_name == 'workflow_dispatch' && inputs.resume-candidate-run-id == '') || github.event.pull_request.merged == true }}"
         },
         "with": {
           "channel": "${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}",
@@ -635,6 +635,59 @@
           "github-artifact-attestation-policy-json": "auto",
           "github-artifact-attestation-environment": "buildchain-artifact-attestation",
           "dry-run": "${{ github.event_name == 'workflow_dispatch' }}"
+        }
+      }
+    },
+    {
+      "id": "release-candidate-recovery",
+      "execution": "controller",
+      "workflow": ".github/workflows/release-new-version.yml",
+      "job": "recover",
+      "profiles": [
+        "release-promotion"
+      ],
+      "gates": [
+        "governance.buildchain-config",
+        "release.artifact-admission"
+      ],
+      "activation": "manual recovery of the single pre-existing sealed Alpha 1 candidate without product rebuild",
+      "adapter": {
+        "type": "buildchain-release-candidate-recovery",
+        "kind": "job-uses",
+        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@train/v3/v3.0/resume-candidate-run",
+        "job": {
+          "needs": "recovery-preflight",
+          "if": "${{ always() && github.event_name == 'workflow_dispatch' && inputs.resume-candidate-run-id != '' && needs.recovery-preflight.result == 'success' }}"
+        },
+        "with": {
+          "buildchain-ref": "train/v3/v3.0/resume-candidate-run",
+          "channel": "alpha",
+          "target-ref": "${{ inputs.target-ref }}",
+          "target-sha": "${{ inputs.target-sha }}",
+          "resume-candidate-repository": "${{ inputs.resume-candidate-repository }}",
+          "resume-candidate-run-id": "${{ inputs.resume-candidate-run-id }}",
+          "resume-expected-workflow-file": "${{ inputs.resume-expected-workflow-file }}",
+          "resume-expected-workflow-name": "${{ inputs.resume-expected-workflow-name }}",
+          "resume-expected-source-tree": "${{ inputs.resume-expected-source-tree }}",
+          "resume-expected-candidate-runtime-sha": "${{ inputs.resume-expected-candidate-runtime-sha }}",
+          "resume-buildchain-runtime-sha": "${{ inputs.resume-buildchain-runtime-sha }}",
+          "publish-transaction-override": "${{ inputs.publish-transaction-override }}",
+          "required-status-check": "build / Finalize build controller evidence",
+          "publication-auto-admission": true,
+          "publication-consumer-qualification-command": "node scripts/kungfu-release-qualification.mjs",
+          "publication-consumer-predicate-id": "kungfu.release-admission/v1",
+          "publish-command": "node scripts/buildchain-custom-publish-evidence.mjs",
+          "runner-preset": "kungfu-v4-native",
+          "required-artifact-count": 5,
+          "release-passport": true,
+          "release-activation-command": "node scripts/activate-ungfu-release.mjs",
+          "release-activation-receipt-set-path": ".buildchain/release-activation/receipt-set.json",
+          "release-passport-evidence-command": "node scripts/prepare-ungfu-release-evidence.mjs --release --receipts \"$BUILDCHAIN_RELEASE_ACTIVATION_RECEIPTS\" --output \"$BUILDCHAIN_RELEASE_EVIDENCE_PATH\" --readback --json",
+          "release-passport-evidence-path": ".buildchain/release-evidence/ungfu-public-use.json",
+          "release-passport-invariant-passport-command": "node scripts/kungfu-invariant.mjs --collect-evidence . --passport product/release/qualification/invariant-passport.json --json",
+          "github-artifact-attestation-policy-json": "auto",
+          "github-artifact-attestation-environment": "buildchain-artifact-attestation",
+          "dry-run": false
         }
       }
     },

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -329,7 +329,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:614e0af91d0c9b42e0ad3a06ae4a11567610c2d1b1f19047ea9213b5ebd3c15e"
+          "sourceRoot": "sha256:0d0108c41beb68e4419c3a1be84fe8acc0ce7cce748ff5f4f329188b55f4b856"
         },
         {
           "path": ".github/workflows/release-shifu.yml",
@@ -860,5 +860,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:f6d5798d32aa14c535cfc00e910cd9c71a7ed46aa5902b62ca78e79ec9b1ff24"
+  "registryRoot": "sha256:10e1c0aca3aafc398a0dc2ddfa4ef9c07ca07869c9508762cf4df9c3dc7926c6"
 }

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -233,7 +233,7 @@ test('current Kungfu catalog, docs, matrix, actions, and workflows align', () =>
   const controllers = result.workflowFacts.filter(
     (fact) => fact.execution === 'controller',
   );
-  assert.equal(controllers.length, 10);
+  assert.equal(controllers.length, 11);
   assert.ok(controllers.every((fact) => fact.gates.length > 0));
   assert.equal(result.workflowAuthority.workflows.length, 36);
   const agentPatrol = result.workflowAuthority.workflows.find(

--- a/scripts/kungfu-workflow-authority.mjs
+++ b/scripts/kungfu-workflow-authority.mjs
@@ -154,6 +154,18 @@ function immutableReference(reference) {
   return marker > 0 && /^[0-9a-f]{40}$/.test(reference.slice(marker + 1));
 }
 
+const ALPHA1_RECOVERY_TRAIN_ACTION =
+  'kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@train/v3/v3.0/resume-candidate-run';
+
+function authorityReferenceAllowed(workflowPath, jobId, reference) {
+  return (
+    immutableReference(reference) ||
+    (workflowPath.endsWith('/release-new-version.yml') &&
+      jobId === 'recover' &&
+      reference === ALPHA1_RECOVERY_TRAIN_ACTION)
+  );
+}
+
 function exactKeys(value, keys, location, issues, optional = []) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     issues.push(`[workflow-authority] ${location} must be an object`);
@@ -175,7 +187,7 @@ function initialJobPolicy(workflowPath, jobId) {
       return ['product-publication', 'product', 'none'];
   }
   if (workflowPath.endsWith('/release-new-version.yml')) {
-    if (jobId === 'promote')
+    if (['promote', 'recover'].includes(jobId))
       return ['release-control', 'channel', 'qualifying'];
   }
   if (workflowPath.endsWith('/release-shifu.yml') && jobId === 'release')
@@ -517,7 +529,8 @@ export function validateWorkflowAuthority(root = ROOT, document = null) {
       if (
         workflowCarriesAuthority &&
         actualJob.externalActions.some(
-          (reference) => !immutableReference(reference),
+          (reference) =>
+            !authorityReferenceAllowed(workflow.path, job.id, reference),
         )
       )
         issues.push(

--- a/scripts/release-promotion-rehearsal.mjs
+++ b/scripts/release-promotion-rehearsal.mjs
@@ -172,9 +172,9 @@ export function validateWorkflowSources(root, contract, overrides = {}) {
   );
   requirePattern(
     preflight,
-    /if: \$\{\{ github\.event_name == 'workflow_dispatch' \|\| github\.event\.pull_request\.merged == true \}\}/,
+    /if: \$\{\{ \(github\.event_name == 'workflow_dispatch' && inputs\.resume-candidate-run-id == ''\) \|\| github\.event\.pull_request\.merged == true \}\}/,
     findings,
-    'promotion contract preflight must run only for a merged promotion PR',
+    'promotion contract preflight must run only for a merged promotion PR or a non-recovery manual dispatch',
   );
   requirePattern(
     preflight,

--- a/scripts/release-promotion-rehearsal.test.mjs
+++ b/scripts/release-promotion-rehearsal.test.mjs
@@ -132,6 +132,42 @@ test('promotion caller grants the write permissions required by Buildchain', () 
   }
 });
 
+test('Alpha recovery reuses the sealed candidate through the bounded Buildchain train', () => {
+  const workflow = fs.readFileSync(
+    path.join(ROOT, CONTRACT.workflows.promotion),
+    'utf8',
+  );
+  const recovery = extractWorkflowJob(workflow, 'recover');
+  assert.ok(recovery);
+  assert.match(
+    recovery,
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/release-candidate-promote\.yml@train\/v3\/v3\.0\/resume-candidate-run/u,
+  );
+  for (const binding of [
+    'target-ref: ${{ inputs.target-ref }}',
+    'target-sha: ${{ inputs.target-sha }}',
+    'resume-candidate-repository: ${{ inputs.resume-candidate-repository }}',
+    'resume-candidate-run-id: ${{ inputs.resume-candidate-run-id }}',
+    'resume-expected-workflow-file: ${{ inputs.resume-expected-workflow-file }}',
+    'resume-expected-workflow-name: ${{ inputs.resume-expected-workflow-name }}',
+    'resume-expected-source-tree: ${{ inputs.resume-expected-source-tree }}',
+    'resume-expected-candidate-runtime-sha: ${{ inputs.resume-expected-candidate-runtime-sha }}',
+    'resume-buildchain-runtime-sha: ${{ inputs.resume-buildchain-runtime-sha }}',
+    'publish-transaction-override: ${{ inputs.publish-transaction-override }}',
+    'dry-run: false',
+  ]) {
+    assert.ok(recovery.includes(binding), binding);
+  }
+  assert.doesNotMatch(recovery, /release-candidate-promote\.yml@[0-9a-f]{40}/u);
+  assert.doesNotMatch(recovery, /^\s+strategy:\s*$/mu);
+  assert.match(workflow, /test "\$CANDIDATE_RUN_ID" = "31051528142"/u);
+  assert.match(workflow, /test "\$PREFLIGHT_RUN_ID" = "31051197057"/u);
+  assert.match(
+    workflow,
+    /test "\$RECOVERY_RUNTIME_SHA" = "c62ab3fca2a63b5cc30d90ba9a72b61c709bac0d"/u,
+  );
+});
+
 test('promotion rejects an event-scoped Buildchain runtime override', () => {
   const promotionPath = CONTRACT.workflows.promotion;
   const original = fs.readFileSync(path.join(ROOT, promotionPath), 'utf8');


### PR DESCRIPTION
## Summary

- add one bounded workflow_dispatch path that recovers the existing v4.0.0-alpha.1 candidate without rebuilding
- bind candidate run 31051528142 and its exact source, tree, runtime, target, and preflight coordinates
- fail closed on coordinate drift and keep the normal promotion path unchanged

## Verification

- actionlint .github/workflows/release-new-version.yml
- targeted release rehearsal and workflow authority tests
- complete Kungfu pre-commit staged gate
- Project Cut merge-queue admission qualified

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded recovery controller exposes an already-approved Buildchain resume capability and does not alter a product architecture contract."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces

The recovery is locked to the existing sealed Alpha 1 candidate and verified Buildchain recovery train; it cannot create a new candidate or enter the product build matrix.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated where controller authority changed