### PR TITLE
fix(release): parameterize recovery controller

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -195,7 +195,10 @@ jobs:
           test "$EXPECTED_WORKFLOW_NAME" = "Build"
           test "$EXPECTED_SOURCE_TREE" = "67a93b5831596555e7c29104421de3a0b97eb865"
           test "$EXPECTED_CANDIDATE_RUNTIME_SHA" = "2e7e07902ac28d8f3edcfb81098ef9ebc7a91878"
-          test "$RECOVERY_RUNTIME_SHA" = "6ba1ea6c3587af12a750dcb476b341046f32b2d2"
+          if [[ ! "$RECOVERY_RUNTIME_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::resume-buildchain-runtime-sha must be an exact lowercase 40-character commit SHA"
+            exit 1
+          fi
           test "$TARGET_REF" = "alpha/v4/v4.0"
           test "$TARGET_SHA" = "f9e6b0e34bcdd6407b2a18206ace7982d64de2c8"
           test "$PREFLIGHT_RUN_ID" = "31051197057"

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -982,10 +982,10 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:051ad0b0c0ddd7b722e432ca85b73455c59a1c6463797479d28d162858c1eb29",
+          "definitionDigest": "sha256:5cbab9b923c30bd4857d9733d5c19157558cd788bbca0ffd74b942b764a19808",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"],
-          "steps": [{"index":1,"label":"name:Require the bounded Alpha 1 recovery identity","definitionDigest":"sha256:c8ff497441e46ed9872b1bae82b45333e5a603e44b347ec5a3d64c12382471a4"},{"index":2,"label":"name:Checkout immutable candidate source","definitionDigest":"sha256:e40649f5b143d21ffd7142da1bc68a742801f31c93e3ab2ada4aee4b6c2d967b"},{"index":3,"label":"uses:actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","definitionDigest":"sha256:a869cc671103a9106dc90b4275a4148de9a5d18cd3578a2642d8ae8076d8dbf0"},{"index":4,"label":"name:Reuse exact Alpha preflight","definitionDigest":"sha256:76bc1b6cd358a7a800cb54acdee85b263411cdbd3e9f48d258448c456b6feef2"},{"index":5,"label":"name:Verify promotion target preserves the candidate tree","definitionDigest":"sha256:7fd95645898bbb9582006c899eb652152f9f411fc5a4354566c2405e7c67ba91"}]
+          "steps": [{"index":1,"label":"name:Require the bounded Alpha 1 recovery identity","definitionDigest":"sha256:3fddb76492aa49b1a96649a9141de0541e01b7e1c03d3568630a15941976f5da"},{"index":2,"label":"name:Checkout immutable candidate source","definitionDigest":"sha256:e40649f5b143d21ffd7142da1bc68a742801f31c93e3ab2ada4aee4b6c2d967b"},{"index":3,"label":"uses:actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","definitionDigest":"sha256:a869cc671103a9106dc90b4275a4148de9a5d18cd3578a2642d8ae8076d8dbf0"},{"index":4,"label":"name:Reuse exact Alpha preflight","definitionDigest":"sha256:76bc1b6cd358a7a800cb54acdee85b263411cdbd3e9f48d258448c456b6feef2"},{"index":5,"label":"name:Verify promotion target preserves the candidate tree","definitionDigest":"sha256:7fd95645898bbb9582006c899eb652152f9f411fc5a4354566c2405e7c67ba91"}]
         }
       ]
     },

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -329,7 +329,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:8e5ef6b4e6c5ff4a3e5f69c85b47fa220aa0de4e8a993ef4db2acb1cf1af63bc"
+          "sourceRoot": "sha256:64d0fc450b72c674737c93fa064570f61556648b62e6701a26e80b4f953de041"
         },
         {
           "path": ".github/workflows/release-shifu.yml",
@@ -860,5 +860,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:4807fadbdd3671dbb03d8ca0a034175a6a1356896c855e4490674afcbcc9457b"
+  "registryRoot": "sha256:80c5b0051fd26ca2d302f6253fe4ed632f01dd4641f2567bc96486cf2b5b5bc8"
 }

--- a/scripts/release-promotion-rehearsal.test.mjs
+++ b/scripts/release-promotion-rehearsal.test.mjs
@@ -164,7 +164,11 @@ test('Alpha recovery reuses the sealed candidate through the bounded Buildchain 
   assert.match(workflow, /test "\$PREFLIGHT_RUN_ID" = "31051197057"/u);
   assert.match(
     workflow,
-    /test "\$RECOVERY_RUNTIME_SHA" = "6ba1ea6c3587af12a750dcb476b341046f32b2d2"/u,
+    /\[\[ ! "\$RECOVERY_RUNTIME_SHA" =~ \^\[0-9a-f\]\{40\}\$ \]\]/u,
+  );
+  assert.doesNotMatch(
+    workflow,
+    /test "\$RECOVERY_RUNTIME_SHA" = "[0-9a-f]{40}"/u,
   );
 });
 


### PR DESCRIPTION
## Summary

- accept the Buildchain recovery controller as an exact dispatch parameter instead of a Kungfu source literal
- require a canonical lowercase 40-character commit SHA before recovery can start
- retain the public train reference while Buildchain resolves it and enforces exact equality before publication

## Verification

- `./shifu check:source` (1051 Node tests plus Python, upgrade, desktop, type and source gates passed)
- release promotion rehearsal and workflow authority tests (18 passed)
- actionlint and publication control-plane root verification
- complete Kungfu pre-commit staged gate

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This correction parameterizes the already approved recovery controller identity without changing product architecture, candidate payloads, or publication semantics."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces

The public workflow still calls the bounded Buildchain train. The train resolves its exact commit and fails closed unless it equals the supplied controller SHA; the resolved SHA remains bound into recovery evidence.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Workflow authority and publication roots refreshed
