### PR TITLE
fix(release): route promotion through recovery train

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -242,7 +242,7 @@ jobs:
       issues: write
       id-token: write
       pull-requests: write
-    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@2e7e07902ac28d8f3edcfb81098ef9ebc7a91878 # signing workflow path readback authority
+    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@train/v3/v3.0/resume-candidate-run
     with:
       channel: ${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') && 'alpha' || 'release' }}
       buildchain-ref: 2e7e07902ac28d8f3edcfb81098ef9ebc7a91878

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -952,9 +952,9 @@
           "authority": "release-control",
           "publication": "channel",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:12e2a53afb453c36d3fc4887c83186db37e34572e2189b8762ba266dabf1e079",
+          "definitionDigest": "sha256:957b56e833d554d80ca456b7ff18ff9f33a94af595ded93a4d511eff1206d38f",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["BUILDCHAIN_ISSUE_APP_ID","BUILDCHAIN_ISSUE_APP_PRIVATE_KEY","KUNGFU_ALPHA_CHANNEL_SIGNING_PRIVATE_KEY","KUNGFU_GITHUB_TOKEN","KUNGFU_GOVERNANCE_AUDITOR_APP_PRIVATE_KEY"],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@2e7e07902ac28d8f3edcfb81098ef9ebc7a91878"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@train/v3/v3.0/resume-candidate-run"],
           "steps": []
         },
         {

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -610,7 +610,7 @@
       "adapter": {
         "type": "buildchain-release-admission",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@2e7e07902ac28d8f3edcfb81098ef9ebc7a91878",
+        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@train/v3/v3.0/resume-candidate-run",
         "job": {
           "needs": "promotion-contract",
           "if": "${{ (github.event_name == 'workflow_dispatch' && inputs.resume-candidate-run-id == '') || github.event.pull_request.merged == true }}"

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -329,7 +329,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:64d0fc450b72c674737c93fa064570f61556648b62e6701a26e80b4f953de041"
+          "sourceRoot": "sha256:f1c05c9b1a5741ef8865987fc663f19f187e3fcdea26db1cef9639b7f795845d"
         },
         {
           "path": ".github/workflows/release-shifu.yml",
@@ -860,5 +860,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:80c5b0051fd26ca2d302f6253fe4ed632f01dd4641f2567bc96486cf2b5b5bc8"
+  "registryRoot": "sha256:9ecc0d1ea9f9e639fd3f5b6aa5b324e1d91ac385b04c16523a3a6f93386c79b9"
 }

--- a/scripts/kungfu-workflow-authority.mjs
+++ b/scripts/kungfu-workflow-authority.mjs
@@ -154,15 +154,15 @@ function immutableReference(reference) {
   return marker > 0 && /^[0-9a-f]{40}$/.test(reference.slice(marker + 1));
 }
 
-const ALPHA1_RECOVERY_TRAIN_ACTION =
+const ALPHA_RELEASE_TRAIN_ACTION =
   'kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@train/v3/v3.0/resume-candidate-run';
 
 function authorityReferenceAllowed(workflowPath, jobId, reference) {
   return (
     immutableReference(reference) ||
     (workflowPath.endsWith('/release-new-version.yml') &&
-      jobId === 'recover' &&
-      reference === ALPHA1_RECOVERY_TRAIN_ACTION)
+      ['promote', 'recover'].includes(jobId) &&
+      reference === ALPHA_RELEASE_TRAIN_ACTION)
   );
 }
 

--- a/scripts/release-promotion-rehearsal.mjs
+++ b/scripts/release-promotion-rehearsal.mjs
@@ -190,11 +190,9 @@ export function validateWorkflowSources(root, contract, overrides = {}) {
   );
   requirePattern(
     promote,
-    new RegExp(
-      `uses: kungfu-systems/buildchain/\\.github/workflows/release-candidate-promote\\.yml@${contract.buildchain.workflow_shell_sha}`,
-    ),
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/release-candidate-promote\.yml@train\/v3\/v3\.0\/resume-candidate-run/u,
     findings,
-    'promotion must consume the stable Buildchain workflow shell',
+    'promotion must consume the bounded Buildchain Alpha recovery train',
   );
   requirePattern(
     promote,

--- a/scripts/release-promotion-rehearsal.test.mjs
+++ b/scripts/release-promotion-rehearsal.test.mjs
@@ -132,6 +132,20 @@ test('promotion caller grants the write permissions required by Buildchain', () 
   }
 });
 
+test('promotion caller uses the same bounded Buildchain train as recovery', () => {
+  const workflow = fs.readFileSync(
+    path.join(ROOT, CONTRACT.workflows.promotion),
+    'utf8',
+  );
+  const promote = extractWorkflowJob(workflow, 'promote');
+  assert.ok(promote);
+  assert.match(
+    promote,
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/release-candidate-promote\.yml@train\/v3\/v3\.0\/resume-candidate-run/u,
+  );
+  assert.doesNotMatch(promote, /release-candidate-promote\.yml@[0-9a-f]{40}/u);
+});
+
 test('Alpha recovery reuses the sealed candidate through the bounded Buildchain train', () => {
   const workflow = fs.readFileSync(
     path.join(ROOT, CONTRACT.workflows.promotion),


### PR DESCRIPTION
## Summary

- route both normal promotion and candidate recovery through the bounded Buildchain recovery train
- keep the exact Buildchain controller identity as a dispatch/runtime parameter and receipt field
- remove the legacy exact-SHA reusable workflow call that GitHub statically rejected before job creation

## Verification

- `./shifu check:source` (build-free source gate passed)
- `./shifu release:promotion:rehearse` (ok=true, no remote mutations)
- workflow authority, gate catalog, publication surface, YAML duplicate-key, caller/callee input and secret parity checks
- complete Kungfu pre-commit staged gate

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This correction changes only the static reusable-workflow routing needed for GitHub validation; the exact recovery controller remains a dispatch parameter and the sealed product candidate is unchanged."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces

The public `uses:` target is the bounded named train required by GitHub syntax. Buildchain resolves the train and enforces equality with the exact `resume-buildchain-runtime-sha` supplied at dispatch; evidence records the resolved exact identity.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Workflow authority and publication roots refreshed
