### PR TITLE
fix(release): admit recovery train override

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -376,7 +376,7 @@ jobs:
       pull-requests: write
     uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@train/v3/v3.0/resume-candidate-run
     with:
-      buildchain-channel: alpha
+      buildchain-channel: auto
       buildchain-ref: train/v3/v3.0/resume-candidate-run
       channel: alpha
       target-ref: ${{ inputs.target-ref }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -972,7 +972,7 @@
           "authority": "release-control",
           "publication": "channel",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:069119e56d0d4ab070d9d54a266b16570a646dc7eacd6d740f78e755fc66ebcd",
+          "definitionDigest": "sha256:7e868072b6bd14259bd632dcd5372ce11f2125cf3e0b0880442ca5bf574ebbe4",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["BUILDCHAIN_ISSUE_APP_ID","BUILDCHAIN_ISSUE_APP_PRIVATE_KEY","KUNGFU_ALPHA_CHANNEL_SIGNING_PRIVATE_KEY","KUNGFU_GITHUB_TOKEN","KUNGFU_GOVERNANCE_AUDITOR_APP_PRIVATE_KEY"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@train/v3/v3.0/resume-candidate-run"],
           "steps": []

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -329,7 +329,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:30b64a4886e26ad733be47c57f4c53b4cee118b9fa5ab1653d98e7a265843335"
+          "sourceRoot": "sha256:e3be08421903c813159b0cb66c9dcda7dfc9a329a02441448d4c64e59a652110"
         },
         {
           "path": ".github/workflows/release-shifu.yml",
@@ -860,5 +860,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:b9581298e4942bb0fdd8d3af85b4a26632769270bbf91a4faf3004bce0847150"
+  "registryRoot": "sha256:ce517247f2a6225f03543ca0b2891da56c090f74260f03f76fd701dbd99856fe"
 }

--- a/scripts/release-promotion-rehearsal.test.mjs
+++ b/scripts/release-promotion-rehearsal.test.mjs
@@ -158,6 +158,7 @@ test('Alpha recovery reuses the sealed candidate through the bounded Buildchain 
     /uses: kungfu-systems\/buildchain\/\.github\/workflows\/release-candidate-promote\.yml@train\/v3\/v3\.0\/resume-candidate-run/u,
   );
   for (const binding of [
+    'buildchain-channel: auto',
     'target-ref: ${{ inputs.target-ref }}',
     'target-sha: ${{ inputs.target-sha }}',
     'resume-candidate-repository: ${{ inputs.resume-candidate-repository }}',


### PR DESCRIPTION
Routes the bounded Buildchain recovery train through `buildchain-channel: auto`, as required for a train/runtime override, while retaining the Alpha publication channel and target.

Validation:
- actionlint
- release promotion rehearsal: 18/18
- gate catalog
- full `./shifu check:source` (build-free, zero-write)
- staged pre-commit gate

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Corrects the existing Alpha candidate recovery workflow caller to satisfy the Buildchain promotion router contract; no architecture or product payload semantics change."
}
-->