### PR TITLE
fix(release): bind exact recovery Gate controller

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -58,6 +58,11 @@ on:
         required: false
         default: ""
         type: string
+      resume-publication-gate-controller-sha:
+        description: "Exact Kungfu commit that owns the read-only recovery Gate controller"
+        required: false
+        default: ""
+        type: string
       publish-transaction-override:
         description: "Allow only the matching durable transaction to resume"
         required: false
@@ -182,6 +187,7 @@ jobs:
           EXPECTED_SOURCE_TREE: ${{ inputs.resume-expected-source-tree }}
           EXPECTED_CANDIDATE_RUNTIME_SHA: ${{ inputs.resume-expected-candidate-runtime-sha }}
           RECOVERY_RUNTIME_SHA: ${{ inputs.resume-buildchain-runtime-sha }}
+          RECOVERY_GATE_CONTROLLER_SHA: ${{ inputs.resume-publication-gate-controller-sha }}
           TARGET_REF: ${{ inputs.target-ref }}
           TARGET_SHA: ${{ inputs.target-sha }}
           PREFLIGHT_RUN_ID: ${{ inputs.preflight-run-id }}
@@ -197,6 +203,10 @@ jobs:
           test "$EXPECTED_CANDIDATE_RUNTIME_SHA" = "2e7e07902ac28d8f3edcfb81098ef9ebc7a91878"
           if [[ ! "$RECOVERY_RUNTIME_SHA" =~ ^[0-9a-f]{40}$ ]]; then
             echo "::error::resume-buildchain-runtime-sha must be an exact lowercase 40-character commit SHA"
+            exit 1
+          fi
+          if [[ ! "$RECOVERY_GATE_CONTROLLER_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::resume-publication-gate-controller-sha must be an exact lowercase 40-character commit SHA"
             exit 1
           fi
           test "$TARGET_REF" = "alpha/v4/v4.0"
@@ -395,6 +405,7 @@ jobs:
       release-candidate-wait-seconds: 10800
       publication-auto-admission: true
       publication-gate-command: node scripts/assemble-kungfu-publication-gate.mjs
+      publication-gate-controller-sha: ${{ inputs.resume-publication-gate-controller-sha }}
       publication-consumer-qualification-command: node scripts/kungfu-release-qualification.mjs
       publication-consumer-predicate-id: kungfu.release-admission/v1
       publication-publisher-workflow-path: .github/workflows/release-new-version.yml

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -935,7 +935,7 @@
     {
       "path": ".github/workflows/release-new-version.yml",
       "authority": "release-control",
-      "definitionDigest": "sha256:fbf1524a96d33813b55e5ca1beb42a36ddf87e308aa86fd6b7b752d9984a7e45",
+      "definitionDigest": "sha256:f53f86b3f0108e92148e29fb5ef4d3413684d25eedd461624c0913f319f84bbb",
       "jobs": [
         {
           "id": "alpha-timeline",
@@ -972,7 +972,7 @@
           "authority": "release-control",
           "publication": "channel",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:7e868072b6bd14259bd632dcd5372ce11f2125cf3e0b0880442ca5bf574ebbe4",
+          "definitionDigest": "sha256:b7c928ed25a33cd7c3615a15aabda5855451f8ae2ecbad61929f1e14ac0f8be5",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["BUILDCHAIN_ISSUE_APP_ID","BUILDCHAIN_ISSUE_APP_PRIVATE_KEY","KUNGFU_ALPHA_CHANNEL_SIGNING_PRIVATE_KEY","KUNGFU_GITHUB_TOKEN","KUNGFU_GOVERNANCE_AUDITOR_APP_PRIVATE_KEY"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@train/v3/v3.0/resume-candidate-run"],
           "steps": []
@@ -982,10 +982,10 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:0e566d61862835c18f4a298a9bb974fd5b676b6ff5376e5ce9ee15b5df5d3e2a",
+          "definitionDigest": "sha256:411b5473ed5dcd04a7f1777b9d9167531d46b9fd0ddbe7d08c8850263479dce7",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093"],
-          "steps": [{"index":1,"label":"name:Require the bounded Alpha 1 recovery identity","definitionDigest":"sha256:3fddb76492aa49b1a96649a9141de0541e01b7e1c03d3568630a15941976f5da"},{"index":2,"label":"name:Checkout immutable candidate source","definitionDigest":"sha256:e40649f5b143d21ffd7142da1bc68a742801f31c93e3ab2ada4aee4b6c2d967b"},{"index":3,"label":"uses:actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","definitionDigest":"sha256:a869cc671103a9106dc90b4275a4148de9a5d18cd3578a2642d8ae8076d8dbf0"},{"index":4,"label":"id:recovery-preflight","definitionDigest":"sha256:928d42586c058a371bbf42e97504e267899a7b5e93e92b38f1097ab9954bc9a6"},{"index":5,"label":"name:Checkout the pinned Alpha preflight source","definitionDigest":"sha256:9a71cedbd18fda60df1b8412c351a2337187bad302098db2b110523777fe58c6"},{"index":6,"label":"name:Download the pinned Alpha preflight receipt","authority":"evidence-publication","definitionDigest":"sha256:3a7a33ef66ee436f5afbd556a303d51cd7715e270492f536c1f2569a02f64f29"},{"index":7,"label":"name:Verify the pinned Alpha preflight at its source","definitionDigest":"sha256:ec35f1079fe66c4a8ce96c1e910d6225f12070f7aef1b2f15a59791b3af1febd"},{"index":8,"label":"name:Verify promotion target preserves the candidate tree","definitionDigest":"sha256:094cc4ca0517fd5060a6e7cb51a99988b68d7ef0c64ce3b6dcc6fba5ff68e9fc"}]
+          "steps": [{"index":1,"label":"name:Require the bounded Alpha 1 recovery identity","definitionDigest":"sha256:17ede448b460c796351019720d82f495aa4ee2ad0b1c36f5bca194612c38b71f"},{"index":2,"label":"name:Checkout immutable candidate source","definitionDigest":"sha256:e40649f5b143d21ffd7142da1bc68a742801f31c93e3ab2ada4aee4b6c2d967b"},{"index":3,"label":"uses:actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","definitionDigest":"sha256:a869cc671103a9106dc90b4275a4148de9a5d18cd3578a2642d8ae8076d8dbf0"},{"index":4,"label":"id:recovery-preflight","definitionDigest":"sha256:928d42586c058a371bbf42e97504e267899a7b5e93e92b38f1097ab9954bc9a6"},{"index":5,"label":"name:Checkout the pinned Alpha preflight source","definitionDigest":"sha256:9a71cedbd18fda60df1b8412c351a2337187bad302098db2b110523777fe58c6"},{"index":6,"label":"name:Download the pinned Alpha preflight receipt","authority":"evidence-publication","definitionDigest":"sha256:3a7a33ef66ee436f5afbd556a303d51cd7715e270492f536c1f2569a02f64f29"},{"index":7,"label":"name:Verify the pinned Alpha preflight at its source","definitionDigest":"sha256:ec35f1079fe66c4a8ce96c1e910d6225f12070f7aef1b2f15a59791b3af1febd"},{"index":8,"label":"name:Verify promotion target preserves the candidate tree","definitionDigest":"sha256:094cc4ca0517fd5060a6e7cb51a99988b68d7ef0c64ce3b6dcc6fba5ff68e9fc"}]
         }
       ]
     },

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -329,7 +329,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:e3be08421903c813159b0cb66c9dcda7dfc9a329a02441448d4c64e59a652110"
+          "sourceRoot": "sha256:8221b06b7f3255d5ab23ab7347908930267071fefc6e323fbeb8d83c8adb44da"
         },
         {
           "path": ".github/workflows/release-shifu.yml",
@@ -860,5 +860,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:ce517247f2a6225f03543ca0b2891da56c090f74260f03f76fd701dbd99856fe"
+  "registryRoot": "sha256:c4ae4b94f97548ddfa6008be0e1284f410bf774cd18ff7aab45a6898f5ae8b9f"
 }

--- a/scripts/assemble-kungfu-publication-gate.mjs
+++ b/scripts/assemble-kungfu-publication-gate.mjs
@@ -205,6 +205,7 @@ export function createKungfuPublicationGateAggregate({
 
 export async function assembleKungfuPublicationGate({
   root = ROOT,
+  subjectRoot = root,
   evidenceRoot,
   runtimeRoot,
   sourceSha,
@@ -281,7 +282,7 @@ export async function assembleKungfuPublicationGate({
       `release-candidate passport is invalid: ${passportValidation.errors.join('; ')}`,
     );
   const promotionTree = execFileSync('git', ['rev-parse', 'HEAD^{tree}'], {
-    cwd: root,
+    cwd: subjectRoot,
     encoding: 'utf8',
   }).trim();
   if (passport.source?.treeHash !== promotionTree)
@@ -341,6 +342,11 @@ export async function assembleKungfuPublicationGate({
   );
 
   const registry = readJson(path.join(root, 'shifu.gates.json'));
+  const subjectRegistry = readJson(path.join(subjectRoot, 'shifu.gates.json'));
+  if (gateDigest(registry) !== gateDigest(subjectRegistry))
+    throw new Error(
+      'consumer Gate controller registry does not match the publication subject',
+    );
   const validationFiles = fs.mkdtempSync(
     path.join(os.tmpdir(), 'kungfu-buildchain-config-'),
   );
@@ -351,7 +357,7 @@ export async function assembleKungfuPublicationGate({
       process.execPath,
       [path.join(runtimeRoot, 'actions/validate-config/dist/index.js')],
       {
-        cwd: root,
+        cwd: subjectRoot,
         encoding: 'utf8',
         env: {
           ...process.env,
@@ -412,6 +418,9 @@ export async function assembleKungfuPublicationGate({
 
 async function main() {
   const aggregate = await assembleKungfuPublicationGate({
+    subjectRoot: path.resolve(
+      process.env.BUILDCHAIN_PUBLICATION_SUBJECT_ROOT || ROOT,
+    ),
     evidenceRoot: process.env.BUILDCHAIN_PUBLICATION_EVIDENCE_ROOT,
     runtimeRoot: process.env.BUILDCHAIN_PUBLICATION_AUTHORITY_RUNTIME_ROOT,
     sourceSha: process.env.BUILDCHAIN_PUBLICATION_SOURCE_SHA,

--- a/scripts/release-promotion-rehearsal.test.mjs
+++ b/scripts/release-promotion-rehearsal.test.mjs
@@ -168,6 +168,7 @@ test('Alpha recovery reuses the sealed candidate through the bounded Buildchain 
     'resume-expected-source-tree: ${{ inputs.resume-expected-source-tree }}',
     'resume-expected-candidate-runtime-sha: ${{ inputs.resume-expected-candidate-runtime-sha }}',
     'resume-buildchain-runtime-sha: ${{ inputs.resume-buildchain-runtime-sha }}',
+    'publication-gate-controller-sha: ${{ inputs.resume-publication-gate-controller-sha }}',
     'publish-transaction-override: ${{ inputs.publish-transaction-override }}',
     'dry-run: false',
   ]) {
@@ -177,6 +178,10 @@ test('Alpha recovery reuses the sealed candidate through the bounded Buildchain 
   assert.doesNotMatch(recovery, /^\s+strategy:\s*$/mu);
   assert.match(workflow, /test "\$CANDIDATE_RUN_ID" = "31051528142"/u);
   assert.match(workflow, /test "\$PREFLIGHT_RUN_ID" = "31051197057"/u);
+  assert.match(
+    workflow,
+    /resume-publication-gate-controller-sha must be an exact lowercase 40-character commit SHA/u,
+  );
   assert.match(
     workflow,
     /actions\/runs\/\$\{PREFLIGHT_RUN_ID\}[\s\S]*\.path == "\.github\/workflows\/alpha-promotion-preflight\.yml"[\s\S]*artifact-name=alpha-promotion-preflight-\$preflight_source_sha/u,


### PR DESCRIPTION
## Summary

- add an exact recovery Gate controller SHA to the bounded Alpha 1 dispatch
- pass that SHA to the refreshed Buildchain recovery train
- execute the read-only consumer Gate from the reviewed controller checkout while validating the immutable product subject separately
- bind subject and controller registries and refresh workflow authority evidence

## Safety

The existing candidate run `31051528142`, target SHA/tree, preflight, candidate artifacts, and payload bytes are unchanged. This adds no product build, install, repackaging, or manual release path.

## Validation

- targeted release/Gate tests: 44/44
- `./shifu check:staged`
- full commit hook gate
- explicit Gate aggregate probe qualified all four declared gates against the immutable target subject

## Runtime

`train/v3/v3.0/resume-candidate-run` resolves exactly to `66d360b1a91d48df468c930521782a1839934deb`.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Separates the already reviewed read-only recovery Gate controller from the immutable Alpha product subject; no architecture contract, candidate payload, or product semantics change."
}
-->