### PR TITLE
fix(release): prepare publication Gate command files

### DIFF
--- a/scripts/assemble-kungfu-publication-gate.mjs
+++ b/scripts/assemble-kungfu-publication-gate.mjs
@@ -353,6 +353,8 @@ export async function assembleKungfuPublicationGate({
   const validateBuildchainConfig = () => {
     const output = path.join(validationFiles, 'output');
     const summary = path.join(validationFiles, 'summary');
+    fs.writeFileSync(output, '');
+    fs.writeFileSync(summary, '');
     const result = spawnSync(
       process.execPath,
       [path.join(runtimeRoot, 'actions/validate-config/dist/index.js')],

--- a/scripts/assemble-kungfu-publication-gate.test.mjs
+++ b/scripts/assemble-kungfu-publication-gate.test.mjs
@@ -1,11 +1,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 import { createKungfuPublicationGateAggregate } from './assemble-kungfu-publication-gate.mjs';
 
 const SOURCE_SHA = '1'.repeat(40);
 const PLATFORMS = ['linux-x64', 'linux-arm64', 'macos-arm64', 'windows-x64'];
+const SCRIPT = fs.readFileSync(
+  path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    'assemble-kungfu-publication-gate.mjs',
+  ),
+  'utf8',
+);
 
 function fixture() {
   const registry = {
@@ -51,13 +63,89 @@ test('publication Gate aggregate binds the exact four-platform artifact set', ()
   assert.equal(aggregate.contract, 'buildchain.shifu-gate-aggregate/v1');
   assert.equal(aggregate.profile, 'release-promotion');
   assert.equal(aggregate.sourceSha, SOURCE_SHA);
+  assert.equal(aggregate.status, 'pass');
+  assert.equal(aggregate.ok, true);
+  assert.equal(aggregate.qualifying, true);
   assert.deepEqual(
     aggregate.receipts.map((receipt) => receipt.platformId),
     PLATFORMS,
   );
+  assert.equal(
+    aggregate.receipts.every(
+      (receipt) => receipt.status === 'passed' && receipt.qualifying,
+    ),
+    true,
+  );
   assert.equal(aggregate.gates[0].gateId, 'release.artifact-admission');
+  assert.equal(aggregate.gates[0].status, 'pass');
+  assert.deepEqual(aggregate.omitted, []);
+  assert.deepEqual(aggregate.issues, []);
   assert.equal(aggregate.digest, `sha256:${'5'.repeat(64)}`);
 });
+
+test('real Buildchain validation starts with empty GitHub command files', () => {
+  const output = SCRIPT.indexOf("fs.writeFileSync(output, '');");
+  const summary = SCRIPT.indexOf("fs.writeFileSync(summary, '');");
+  const validator = SCRIPT.indexOf(
+    "path.join(runtimeRoot, 'actions/validate-config/dist/index.js')",
+  );
+
+  assert.notEqual(output, -1);
+  assert.notEqual(summary, -1);
+  assert.notEqual(validator, -1);
+  assert.ok(output < validator);
+  assert.ok(summary < validator);
+});
+
+test(
+  'real Buildchain validator qualifies the current config with empty command files',
+  {
+    skip: !process.env.BUILDCHAIN_PUBLICATION_TEST_RUNTIME_ROOT,
+  },
+  () => {
+    const validationFiles = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'kungfu-buildchain-config-test-'),
+    );
+    const output = path.join(validationFiles, 'output');
+    const summary = path.join(validationFiles, 'summary');
+    fs.writeFileSync(output, '');
+    fs.writeFileSync(summary, '');
+
+    try {
+      assert.equal(fs.statSync(output).size, 0);
+      assert.equal(fs.statSync(summary).size, 0);
+      const result = spawnSync(
+        process.execPath,
+        [
+          path.join(
+            process.env.BUILDCHAIN_PUBLICATION_TEST_RUNTIME_ROOT,
+            'actions/validate-config/dist/index.js',
+          ),
+        ],
+        {
+          cwd: path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'),
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            GITHUB_OUTPUT: output,
+            GITHUB_STEP_SUMMARY: summary,
+            'INPUT_CONFIG-REQUIRED': 'true',
+            'INPUT_REQUIRE-VERSION-STATE': 'true',
+            'INPUT_REQUIRE-LIFECYCLE-STAGES': 'install,check,build,verify',
+          },
+        },
+      );
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.ok(fs.statSync(output).size > 0);
+      assert.match(
+        fs.readFileSync(summary, 'utf8'),
+        /Buildchain config validation/,
+      );
+    } finally {
+      fs.rmSync(validationFiles, { recursive: true, force: true });
+    }
+  },
+);
 
 test('publication Gate aggregate rejects an incomplete platform set', () => {
   const value = fixture();


### PR DESCRIPTION
## Summary

Prepare the GitHub command files before the publication Gate invokes the real pinned Buildchain validate-config action, and add qualifying aggregate regression coverage.

Successor to #2582. This PR is based on its merged dev/v4/v4.0 head and contains only the bounded follow-up fix.

## Related issue

- Follow-up to #2582

## Changes

- Create empty GITHUB_OUTPUT and GITHUB_STEP_SUMMARY files immediately before invoking actions/validate-config/dist/index.js.
- Assert the complete four-platform publication Gate aggregate remains passing, successful, and qualifying.
- Exercise the real pinned Buildchain validator against empty GitHub command files.

## Verification

- BUILDCHAIN_PUBLICATION_TEST_RUNTIME_ROOT=<pinned Buildchain runtime> ./shifu test:release-admission (10 passed, 0 skipped)
- ./shifu check:source (passed)
- staged repository gate and Biome checks (passed)

No Alpha publication workflow or release command was triggered.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix preserves the existing publication Gate and Buildchain validation authority while preparing required GitHub command files."
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change is limited to local publication Gate validation assembly and regression tests. It performs no publication or deployment.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required for this bounded bug fix)
