### PR TITLE
perf(docs): batch ADR evidence reachability checks

### DIFF
--- a/docs/adr/KF-ADR-019f86da-4f90-74fb-9f80-970c3db586d0.md
+++ b/docs/adr/KF-ADR-019f86da-4f90-74fb-9f80-970c3db586d0.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: KF-ADR-019f86da-4f90-74fb-9f80-970c3db586d0
 decision_status: accepted
 implementation_status: implemented
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/741, https://github.com/kungfu-systems/kungfu/pull/750]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/741, https://github.com/kungfu-systems/kungfu/pull/750, https://github.com/kungfu-systems/kungfu/pull/2592]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/750
 qualification_refs: [scripts/adr-audit.test.mjs, scripts/document-metadata-contract.test.mjs, scripts/check-docs.test.mjs]
 review_state: maintainer-reviewed
@@ -14,7 +14,7 @@ period: ongoing
 theme: canonical-adr-authority-and-lifecycle-audit
 confidence: high
 evidence_grade: A
-last_reviewed: 2026-07-13
+last_reviewed: 2026-08-08
 ---
 
 # KF-ADR-019f86da-4f90-74fb-9f80-970c3db586d0: Canonical ADR authority and lifecycle audit

--- a/docs/adr/KF-ADR-019f86da-4f90-7f1b-87cd-06e3787a116a.md
+++ b/docs/adr/KF-ADR-019f86da-4f90-7f1b-87cd-06e3787a116a.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: KF-ADR-019f86da-4f90-7f1b-87cd-06e3787a116a
 decision_status: accepted
 implementation_status: implemented
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/745, https://github.com/kungfu-systems/kungfu/pull/746, https://github.com/kungfu-systems/kungfu/pull/750]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/745, https://github.com/kungfu-systems/kungfu/pull/746, https://github.com/kungfu-systems/kungfu/pull/750, https://github.com/kungfu-systems/kungfu/pull/2592]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/750
 qualification_refs: [docs.contract.json, scripts/check-docs.test.mjs, scripts/document-metadata-contract.test.mjs]
 review_state: maintainer-reviewed
@@ -14,7 +14,7 @@ period: ongoing
 theme: documentation-directory-authority
 confidence: high
 evidence_grade: A
-last_reviewed: 2026-07-13
+last_reviewed: 2026-08-08
 ---
 
 # KF-ADR-019f86da-4f90-7f1b-87cd-06e3787a116a: Documentation directory authority

--- a/scripts/document-metadata-contract.mjs
+++ b/scripts/document-metadata-contract.mjs
@@ -354,17 +354,103 @@ export function validateReachableCommit(root, commit, pullRequestBaseCommit) {
   return `is not reachable from ${reachability.label}`;
 }
 
-/** @param {string} value @param {string} field @param {string} rel @param {number} line @param {string} root @param {Finding[]} findings @param {string | undefined} pullRequestBaseCommit */
-function checkCommit(
-  value,
-  field,
-  rel,
-  line,
-  root,
-  findings,
-  pullRequestBaseCommit,
-) {
-  const problem = validateReachableCommit(root, value, pullRequestBaseCommit);
+/**
+ * Resolve every evidence commit in one Git cut. The previous per-reference
+ * validation spawned up to three Git processes for every SHA, which made a
+ * complete ADR authority pass disproportionately expensive.
+ *
+ * @param {string} root
+ * @param {Set<string>} commits
+ * @param {string | undefined} pullRequestBaseCommit
+ */
+function batchReachableCommitProblems(root, commits, pullRequestBaseCommit) {
+  const candidates = [...commits].filter((commit) =>
+    /^[0-9a-f]{40}$/.test(commit),
+  );
+  /** @type {Map<string, string | null>} */
+  const problems = new Map();
+  if (candidates.length === 0) return problems;
+
+  const env = isolatedGitEnvironment();
+  const reachability = reachabilityRoots(root, pullRequestBaseCommit);
+  const objects = childProcess.spawnSync(
+    'git',
+    ['cat-file', '--batch-check=%(objectname) %(objecttype)'],
+    {
+      cwd: root,
+      env,
+      encoding: 'utf8',
+      input: `${candidates.map((commit) => `${commit}^{commit}`).join('\n')}\n`,
+    },
+  );
+  const objectLines = String(objects.stdout || '')
+    .trimEnd()
+    .split('\n');
+
+  /** @type {Map<string, string>} */
+  const commitObjects = new Map();
+  for (const [index, commit] of candidates.entries()) {
+    const match = /^([0-9a-f]{40}) commit$/.exec(objectLines[index] || '');
+    if (objects.status !== 0 || !match) {
+      problems.set(commit, 'does not identify a commit in this checkout');
+      continue;
+    }
+    commitObjects.set(commit, match[1]);
+  }
+
+  const history = childProcess.spawnSync(
+    'git',
+    ['rev-list', ...reachability.roots],
+    { cwd: root, env, encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 },
+  );
+  const reachable = new Set(
+    history.status === 0
+      ? String(history.stdout || '')
+          .split('\n')
+          .filter(Boolean)
+      : [],
+  );
+  for (const [commit, object] of commitObjects) {
+    problems.set(
+      commit,
+      reachable.has(object)
+        ? null
+        : `is not reachable from ${reachability.label}`,
+    );
+  }
+  return problems;
+}
+
+/** @param {string} root @param {string[]} files @param {MetadataContract} contract */
+function evidenceCommitCandidates(root, files, contract) {
+  const commits = new Set();
+  const evidence = contract.adrEvidence;
+  if (!evidence) return commits;
+  const fields = [
+    ...evidence.commitFields,
+    evidence.closureCommitField,
+    evidence.qualificationRefField,
+  ];
+  for (const rel of files) {
+    const text = fs.readFileSync(path.join(root, rel), 'utf8');
+    for (const line of text.split(/\r?\n/)) {
+      if (!fields.some((field) => line.startsWith(`${field}:`))) continue;
+      for (const match of line.matchAll(
+        /(?<![0-9a-f])[0-9a-f]{40}(?![0-9a-f])/g,
+      ))
+        commits.add(match[0]);
+    }
+  }
+  return commits;
+}
+
+/** @param {string} value @param {string} field @param {string} rel @param {number} line @param {Finding[]} findings @param {Map<string, string | null>} commitProblems */
+function checkCommit(value, field, rel, line, findings, commitProblems) {
+  const problem = /^[0-9a-f]{40}$/.test(value)
+    ? commitProblems.has(value)
+      ? commitProblems.get(value)
+      : 'does not identify a commit in this checkout'
+    : 'must be a full 40-character lowercase Git SHA';
   if (problem) {
     findings.push({
       code: 'adr-evidence-commit',
@@ -375,14 +461,14 @@ function checkCommit(
   }
 }
 
-/** @param {Map<string, {value: unknown, line: number}>} fields @param {string} rel @param {string} root @param {MetadataContract} contract @param {Finding[]} findings @param {string | undefined} pullRequestBaseCommit */
+/** @param {Map<string, {value: unknown, line: number}>} fields @param {string} rel @param {string} root @param {MetadataContract} contract @param {Finding[]} findings @param {Map<string, string | null>} commitProblems */
 function validateAdrEvidence(
   fields,
   rel,
   root,
   contract,
   findings,
-  pullRequestBaseCommit,
+  commitProblems,
 ) {
   const evidence = contract.adrEvidence;
   if (!evidence) return;
@@ -468,9 +554,8 @@ function validateAdrEvidence(
         evidence.commitFields[0],
         rel,
         commits.line,
-        root,
         findings,
-        pullRequestBaseCommit,
+        commitProblems,
       );
   }
   if (closureCommit) {
@@ -479,9 +564,8 @@ function validateAdrEvidence(
       evidence.closureCommitField,
       rel,
       closureCommit.line,
-      root,
       findings,
-      pullRequestBaseCommit,
+      commitProblems,
     );
   }
   const prPattern = new RegExp(evidence.pullRequestPattern);
@@ -514,9 +598,8 @@ function validateAdrEvidence(
           evidence.qualificationRefField,
           rel,
           qualifications.line,
-          root,
           findings,
-          pullRequestBaseCommit,
+          commitProblems,
         );
       } else if (
         path.isAbsolute(value) ||
@@ -555,6 +638,11 @@ export function validateDocumentMetadata(options) {
   const fileSet = new Set(options.files);
   const adrIds = new Set();
   const adrRecords = new Map();
+  const commitProblems = batchReachableCommitProblems(
+    root,
+    evidenceCommitCandidates(root, options.files, contract),
+    pullRequestBaseCommit,
+  );
 
   for (const rel of options.files) {
     const text = fs.readFileSync(path.join(root, rel), 'utf8');
@@ -838,7 +926,7 @@ export function validateDocumentMetadata(options) {
         root,
         contract,
         findings,
-        pullRequestBaseCommit,
+        commitProblems,
       );
     }
   }

--- a/scripts/document-metadata-contract.test.mjs
+++ b/scripts/document-metadata-contract.test.mjs
@@ -862,6 +862,42 @@ test('accepts reachable full-SHA implementation and closure evidence', () => {
   assert.deepEqual(findings, []);
 });
 
+test('batches ADR evidence reachability into a constant number of Git processes', () => {
+  const { root, file, commit } = evidenceFixture();
+  const missing = Array.from({ length: 32 }, (_, index) =>
+    (index + 1).toString(16).padStart(40, '0'),
+  );
+  const target = path.join(root, file);
+  fs.writeFileSync(
+    target,
+    fs
+      .readFileSync(target, 'utf8')
+      .replace(
+        /^implementation_commits:.*$/m,
+        `implementation_commits: [${[commit, ...missing].join(', ')}]`,
+      ),
+  );
+
+  const originalSpawnSync = childProcess.spawnSync;
+  let gitSpawns = 0;
+  childProcess.spawnSync = (...args) => {
+    if (args[0] === 'git') gitSpawns += 1;
+    return originalSpawnSync(...args);
+  };
+  let findings;
+  try {
+    findings = validateDocumentMetadata({ root, files: [file], contract });
+  } finally {
+    childProcess.spawnSync = originalSpawnSync;
+  }
+
+  assert.equal(
+    findings.filter((finding) => finding.code === 'adr-evidence-commit').length,
+    missing.length,
+  );
+  assert.equal(gitSpawns, 3);
+});
+
 test('pins PR evidence reachability to the source-acceptance base SHA', () => {
   const base = 'a'.repeat(40);
   const documentation = sourceAcceptancePlan([], base).find(


### PR DESCRIPTION
## Summary

- batch ADR evidence object and reachability validation per metadata cut
- preserve fail-closed findings for malformed, missing, and unreachable commits
- add a regression proving 32 missing SHAs use exactly three Git subprocesses

## Validation

- `./shifu adr:identity:test` (42/42)
- `./shifu docs:check` (143/143)
- changed-file Biome gate passed
- protected Candidate source acceptance passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": [
    "KF-ADR-019f86da-4f90-74fb-9f80-970c3db586d0",
    "KF-ADR-019f86da-4f90-7f1b-87cd-06e3787a116a"
  ],
  "summary": "Bound ADR evidence reachability validation to one batched Git cut without weakening fail-closed findings",
  "verification": [
    "ADR identity tests 42/42",
    "documentation checks 143/143",
    "32 invalid SHAs produce 32 findings with exactly three Git subprocesses"
  ]
}
-->

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces

This change only optimizes validation execution; it does not publish or relax release evidence.