### PR TITLE
fix(product): preserve interpreter payload identity

### DIFF
--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -330,6 +330,8 @@ test('CLI product materializes symlinked demo executables as regular files', (t)
   assert.equal(fs.lstatSync(python).isSymbolicLink(), false);
   assert.equal(fs.readFileSync(python, 'utf8'), 'python\n');
   assert.notEqual(fs.statSync(python).mode & 0o111, 0);
+  assert.equal(fs.statSync(python).ino, fs.statSync(pythonTarget).ino);
+  assert.equal(fs.statSync(python).nlink, 2);
 });
 
 test('CLI runtime identity is stable after demo executable metadata', (t) => {

--- a/product/scripts/portable-symlinks.mjs
+++ b/product/scripts/portable-symlinks.mjs
@@ -15,8 +15,7 @@ export function materializeRegularFile(file) {
     throw new Error(`executable symlink target is not a regular file: ${file}`);
   }
   const materialized = `${file}.materialized-regular-file`;
-  fs.copyFileSync(resolved, materialized);
-  fs.chmodSync(materialized, entry.mode & 0o777);
+  fs.linkSync(resolved, materialized);
   fs.renameSync(materialized, file);
 }
 


### PR DESCRIPTION
## Summary

Preserve the staged Python interpreter payload identity while materializing portable product layouts. The staged entry is now a hard link to the resolved payload instead of a copied file, retaining byte and inode identity without reintroducing symlinks.

This pull request non-destructively supersedes #2594 after the protected development base advanced. A new branch is used instead of rewriting the published predecessor branch.

## Related issue

Continuation of terminal review remediation for portable product distributions. Supersedes #2594.

## Changes

- Materialize resolved Python payloads with `fs.linkSync` before the existing atomic rename.
- Extend the distribution contract test to require the staged interpreter and its payload target to share an inode and report a link count of two.

## Verification

- `./shifu check:source` (exit 0; 1061 Node tests: 1050 passed, 11 expected skips; Agent Work 40; runtime upgrade 134; desktop 73)
- `./shifu check:darwin-x64-retirement` (49/49, including `product/scripts/dist.test.mjs`)
- Native Assignment run gate for source head `51d4ddedf7ffb2b0cbb14c6fa7c841597429f71c` (`ok: true`)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded product staging fix preserves an existing payload identity contract and does not alter an architecture contract"
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change is confined to portable product staging. Source-gate and retirement-contract evidence are listed above; protected CI will independently qualify the exact pushed head.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required; behavior is covered by the executable contract test)
