### PR TITLE
fix(agent): bind patrol finding runtime provenance

### DIFF
--- a/framework/agent-patrol/dogfood-capture.mjs
+++ b/framework/agent-patrol/dogfood-capture.mjs
@@ -1,71 +1,16 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: Apache-2.0
 
-import { spawnSync } from 'node:child_process';
-import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
+import { captureNativeFinding } from '../dogfood/native-finding-capture.mjs';
 
-const ROOT = path.resolve(
-  path.dirname(fileURLToPath(import.meta.url)),
-  '../..',
-);
 const CLASSIFICATION_SCHEMA = 'kungfu.agent-patrol.classification/v1';
 const FINDING_INTENT_SCHEMA = 'kungfu.agent-patrol.finding-intent/v1';
 const RECEIPT_SCHEMA = 'kungfu.agent-patrol.dogfood-capture-receipt/v1';
 const ROOT_PATTERN = /^sha256:[0-9a-f]{64}$/u;
-
-function outputRoot(value) {
-  return `sha256:${crypto
-    .createHash('sha256')
-    .update(String(value || ''))
-    .digest('hex')}`;
-}
-
-function sourceCli(args, options = {}) {
-  const pythonPath = [
-    path.join(ROOT, 'framework/core/src/python'),
-    path.join(ROOT, 'framework/core/build/Release'),
-    process.env.PYTHONPATH,
-  ]
-    .filter(Boolean)
-    .join(path.delimiter);
-  return spawnSync(
-    'uv',
-    [
-      'run',
-      '--project',
-      path.join(ROOT, 'framework/core'),
-      '--frozen',
-      'python',
-      '-m',
-      'kungfu',
-      ...args,
-    ],
-    {
-      cwd: ROOT,
-      env: { ...process.env, ...(options.env || {}), PYTHONPATH: pythonPath },
-      encoding: 'utf8',
-      maxBuffer: 16 * 1024 * 1024,
-      timeout: options.timeout || 120_000,
-    },
-  );
-}
-
-function parseJsonOutput(result, operation) {
-  if (result.error) throw result.error;
-  try {
-    return JSON.parse(result.stdout || '');
-  } catch {
-    throw new Error(
-      `${operation} returned non-JSON output; output root ${outputRoot(
-        `${result.stdout || ''}\n${result.stderr || ''}`,
-      )}`,
-    );
-  }
-}
 
 function validateClassification(value) {
   if (value?.schema !== CLASSIFICATION_SCHEMA)
@@ -102,6 +47,8 @@ function boundedReceipt({
   lookupRoot = null,
   nativeStatus = null,
   capturePerformed = false,
+  runtimeReceipt = null,
+  runtimeVerification = null,
 }) {
   return {
     schema: RECEIPT_SCHEMA,
@@ -112,53 +59,14 @@ function boundedReceipt({
     nativeStatus,
     capturePerformed,
     issueAdmitted: false,
+    runtimeReceipt,
+    runtimeVerification,
   };
-}
-
-function ensureDogfoodProfile(run, workspaceRoot) {
-  const doctorArgs = ['dogfood', 'doctor', '--workspace', workspaceRoot];
-  const diagnosisResult = run(doctorArgs);
-  const diagnosis = parseJsonOutput(diagnosisResult, 'dogfood doctor');
-  if (diagnosisResult.status !== 0)
-    throw new Error('dogfood doctor failed closed');
-  if (diagnosis.ok === true) return;
-
-  const planResult = run(['dogfood', 'recover', '--workspace', workspaceRoot]);
-  const plan = parseJsonOutput(planResult, 'dogfood recover plan');
-  if (
-    planResult.status !== 0 ||
-    !['ready', 'no-op'].includes(plan.status) ||
-    !ROOT_PATTERN.test(plan.plan_root || '')
-  )
-    throw new Error('dogfood recovery plan failed closed');
-  if (plan.status === 'ready') {
-    const applyResult = run([
-      'dogfood',
-      'recover',
-      '--workspace',
-      workspaceRoot,
-      '--expected-plan-root',
-      plan.plan_root,
-      '--execute',
-      '--authorized-by',
-      'agent-patrol-agent-121',
-    ]);
-    const applied = parseJsonOutput(applyResult, 'dogfood recover apply');
-    if (
-      applyResult.status !== 0 ||
-      !['recovered', 'already-current'].includes(applied.status)
-    )
-      throw new Error('dogfood recovery apply failed closed');
-  }
-  const verifiedResult = run(doctorArgs);
-  const verified = parseJsonOutput(verifiedResult, 'dogfood doctor verify');
-  if (verifiedResult.status !== 0 || verified.ok !== true)
-    throw new Error('Dogfood Profile did not reach its exact active root');
 }
 
 export function captureFinding(
   classification,
-  { run = sourceCli, intentPath, workspaceRoot },
+  { run, intentPath, workspaceRoot, inspectSource },
 ) {
   validateClassification(classification);
   if (!classification.captureRequired)
@@ -166,93 +74,16 @@ export function captureFinding(
   if (!path.isAbsolute(workspaceRoot || ''))
     throw new Error('Patrol Dogfood workspace must be an absolute path');
 
-  const findingId = classification.findingIntent.findingId;
-  const ensured = run([
-    'workspace',
-    'ensure',
-    workspaceRoot,
-    '--reason',
-    'agent-patrol-dogfood-finding',
-    '--json',
-  ]);
-  if (ensured.error || ensured.status !== 0)
-    throw new Error(
-      `Kungfu Home ensure failed; output root ${outputRoot(
-        `${ensured.stdout || ''}\n${ensured.stderr || ''}`,
-      )}`,
-    );
-
-  ensureDogfoodProfile(run, workspaceRoot);
-  const lookupResult = run([
-    'dogfood',
-    'show',
-    findingId,
-    '--workspace',
-    workspaceRoot,
-  ]);
-  const lookup = parseJsonOutput(lookupResult, 'dogfood show');
-  if (lookupResult.status === 0) {
-    const finding = lookup.matches?.[0]?.record;
-    if (
-      lookup.ok !== true ||
-      lookup.match_count !== 1 ||
-      lookup.matches?.[0]?.kind !== 'finding' ||
-      finding?.finding_id !== findingId ||
-      !ROOT_PATTERN.test(finding?.finding_root || '')
-    )
-      throw new Error('dogfood show did not resolve one exact Finding');
-    return boundedReceipt({
-      status: 'deduplicated',
-      findingId,
-      findingRoot: finding.finding_root,
-      lookupRoot: lookup.lookup_root,
-      nativeStatus: 'already-present',
-      capturePerformed: false,
-    });
-  }
-  if (
-    lookupResult.status !== 3 ||
-    lookup.ok !== false ||
-    lookup.match_count !== 0
-  )
-    throw new Error(
-      `dogfood show failed closed; output root ${outputRoot(
-        `${lookupResult.stdout || ''}\n${lookupResult.stderr || ''}`,
-      )}`,
-    );
-
-  fs.mkdirSync(path.dirname(path.resolve(intentPath)), { recursive: true });
-  fs.writeFileSync(
+  const captured = captureNativeFinding(classification.findingIntent, {
+    ...(run ? { run } : {}),
+    ...(inspectSource ? { inspectSource } : {}),
     intentPath,
-    `${JSON.stringify(classification.findingIntent.capture, null, 2)}\n`,
-  );
-  const captureResult = run([
-    'dogfood',
-    'capture',
-    intentPath,
-    '--workspace',
     workspaceRoot,
-    '--authorized-by',
-    'agent-patrol-agent-121',
-  ]);
-  const captured = parseJsonOutput(captureResult, 'dogfood capture');
-  if (
-    captureResult.status !== 0 ||
-    !['captured', 'already-present'].includes(captured.status) ||
-    captured.finding?.finding_id !== findingId ||
-    !ROOT_PATTERN.test(captured.finding?.finding_root || '')
-  )
-    throw new Error(
-      `dogfood capture failed closed; output root ${outputRoot(
-        `${captureResult.stdout || ''}\n${captureResult.stderr || ''}`,
-      )}`,
-    );
+    authorizedBy: 'agent-patrol-agent-121',
+    reason: 'agent-patrol-dogfood-finding',
+  });
   return boundedReceipt({
-    status: captured.status === 'captured' ? 'captured' : 'deduplicated',
-    findingId,
-    findingRoot: captured.finding.finding_root,
-    nativeStatus: captured.status,
-    capturePerformed: captured.status === 'captured',
+    ...captured,
   });
 }
 

--- a/scripts/agent-patrol.test.mjs
+++ b/scripts/agent-patrol.test.mjs
@@ -355,11 +355,51 @@ function result(status, value) {
   };
 }
 
+function sourceInspection() {
+  return {
+    buildInfo: {
+      version: '4.0.0-alpha.1',
+      git: { revision: '1'.repeat(40), pristine: true },
+    },
+    buildInfoRoot: ROOT_A,
+    shifuPath: '/repo/shifu',
+    shifuRoot: ROOT_B,
+    head: '1'.repeat(40),
+    tree: '2'.repeat(40),
+    dirty: false,
+    worktree: '/repo',
+  };
+}
+
+function runtimeSurfaceResult(args) {
+  if (args[0] !== 'runtime') return null;
+  if (args[2] === 'resolve')
+    return result(0, {
+      schema: 'kungfu.runtime-surface-receipt/v1',
+      operationId: 'dogfood.capture',
+      runtimeSurface: 'source-checkout',
+      selectedProvider: 'source-shifu',
+      receiptRoot: ROOT_A,
+    });
+  if (args[2] === 'verify')
+    return result(0, {
+      schema: 'kungfu.runtime-surface-verification/v1',
+      ok: true,
+      operationId: 'dogfood.capture',
+      runtimeSurface: 'source-checkout',
+      selectedProvider: 'source-shifu',
+      receiptRoot: ROOT_A,
+    });
+  return null;
+}
+
 test('capture adapter creates one Finding and exposes no Issue path', () => {
   const classification = classifyReport(baseReport(), options());
   const calls = [];
   const run = (args) => {
     calls.push(args);
+    const runtimeResult = runtimeSurfaceResult(args);
+    if (runtimeResult) return runtimeResult;
     if (args[0] === 'workspace') return result(0, { ok: true });
     if (args[1] === 'doctor') return result(0, { ok: true });
     if (args[1] === 'show')
@@ -379,11 +419,14 @@ test('capture adapter creates one Finding and exposes no Issue path', () => {
   };
   const receipt = captureFinding(classification, {
     run,
+    inspectSource: sourceInspection,
     intentPath: '/tmp/kungfu-agent-patrol-test-intent.json',
     workspaceRoot: '/tmp/kungfu-agent-patrol-test-workspace',
   });
   assert.equal(receipt.status, 'captured');
   assert.equal(receipt.issueAdmitted, false);
+  assert.equal(receipt.runtimeReceipt.receiptRoot, ROOT_A);
+  assert.equal(receipt.runtimeVerification.ok, true);
   assert.equal(
     calls.some((args) => args.includes('admit')),
     false,
@@ -399,6 +442,8 @@ test('capture adapter reuses an existing Finding without capture', () => {
   const calls = [];
   const run = (args) => {
     calls.push(args);
+    const runtimeResult = runtimeSurfaceResult(args);
+    if (runtimeResult) return runtimeResult;
     if (args[0] === 'workspace') return result(0, { ok: true });
     if (args[1] === 'doctor') return result(0, { ok: true });
     return result(0, {
@@ -418,12 +463,13 @@ test('capture adapter reuses an existing Finding without capture', () => {
   };
   const receipt = captureFinding(classification, {
     run,
+    inspectSource: sourceInspection,
     intentPath: '/tmp/kungfu-agent-patrol-test-dedup-intent.json',
     workspaceRoot: '/tmp/kungfu-agent-patrol-test-workspace',
   });
   assert.equal(receipt.status, 'deduplicated');
   assert.equal(receipt.capturePerformed, false);
-  assert.equal(calls.length, 3);
+  assert.equal(calls.length, 5);
 });
 
 test('capture adapter skips Dogfood writes after a pass', () => {

--- a/tests/qualification/agent-repository-work/kungfu-agent-patrol-real-module-snapshot-v1.manifest.json
+++ b/tests/qualification/agent-repository-work/kungfu-agent-patrol-real-module-snapshot-v1.manifest.json
@@ -6,9 +6,9 @@
     "revisionPolicy": "exact-commit",
     "trackedRegularFilesOnly": true
   },
-  "fileCount": 8,
-  "lineCount": 4001,
-  "treeRoot": "sha256:6bb34887b52f1696570b4b2208f61f0ae45b1a48de9804d5732a3a4792f3cb31",
+  "fileCount": 9,
+  "lineCount": 4297,
+  "treeRoot": "sha256:1acb5053fd6cdcb8fcd17be1ee21e6de1823758a172cb8a5bfddd07dbe56fb38",
   "files": [
     {
       "path": "framework/agent-patrol/classify.mjs",
@@ -20,9 +20,9 @@
     {
       "path": "framework/agent-patrol/dogfood-capture.mjs",
       "mode": "100644",
-      "bytes": 9177,
-      "lines": 306,
-      "root": "sha256:09bcf6c783ca074d1c4f3e50562f304742afc51e373ab8440fbefc67dbeee226"
+      "bytes": 4280,
+      "lines": 137,
+      "root": "sha256:daf2dd225bb268a42cc0e25ac190bfe4ae370e3bf0a2d4d0d1c3067287361b71"
     },
     {
       "path": "framework/agent-patrol/select.mjs",
@@ -39,11 +39,18 @@
       "root": "sha256:efbab2b60a79a328ab826004bb21e158b9a561c98d96d7509fae73351edc3d7d"
     },
     {
+      "path": "framework/dogfood/native-finding-capture.mjs",
+      "mode": "100644",
+      "bytes": 13120,
+      "lines": 419,
+      "root": "sha256:6107e0de10d835a69bfee84f257f3e2f889918722df306dc2eab5fc2e223678d"
+    },
+    {
       "path": "scripts/agent-patrol.test.mjs",
       "mode": "100644",
-      "bytes": 14820,
-      "lines": 476,
-      "root": "sha256:5d8ff34cd064cce6eb3c271c9c3e63ee39a4adab4096f5fec602e788108ef9dd"
+      "bytes": 16173,
+      "lines": 522,
+      "root": "sha256:0d6a6a406b40d1bacb58dced43cfe27ac4a4bdf474eba2717024fef4f676254a"
     },
     {
       "path": "tests/qualification/agent-repository-work/fixture-catalog.mjs",


### PR DESCRIPTION
## Summary

- route Agent Patrol Finding capture through the canonical native Dogfood adapter
- bind and retain the required runtime-surface receipt and verification
- close the deterministic real-module snapshot over the shared capture dependency

## Why

The Dogfood Finding contract now requires exact runtime-surface provenance, while Agent Patrol still used a duplicated pre-provenance capture path. The dedicated Patrol workflow therefore failed closed before running repository-work experiments.

## Changes

- remove the duplicated Patrol-native capture implementation
- delegate native Finding creation to the canonical Dogfood adapter
- retain the runtime receipt and runtime verification in Patrol evidence
- update the real-module snapshot dependency closure

## Verification

- repository staged pre-commit gate
- Agent Patrol capture adapter tests (3/3)
- shared Dogfood runtime-provenance tests (3/3)
- real-module snapshot qualification tests (2/2)
- Biome check and git diff --check
- Native Assignment run gate for source head a5a72f964b0b0e916789d46ebedd4b80ab7b05a1 (ok: true)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded Agent Patrol capture repair restores the required runtime-provenance contract and does not alter an architecture contract"
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change is confined to Agent Patrol evidence capture. Source-gate and focused contract evidence are listed above; protected CI will independently qualify the exact pushed head.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required; behavior is covered by executable contract tests)
