### PR TITLE
fix(demo): admit bounded long-form renderer runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -533,7 +533,7 @@ jobs:
       actions: read
       contents: write
       pull-requests: write
-    uses: kungfu-systems/buildchain/.github/workflows/.declarative-auditable-demo.yml@f7a98257a32624a63be2a935d7b884d6e872e07e
+    uses: kungfu-systems/buildchain/.github/workflows/.declarative-auditable-demo.yml@ba41d9c165a5d4f251a6c4af30c32b5a417865d2
     secrets:
       DEMO_UPDATE_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}
     with:

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -281,9 +281,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:fc84e9ac17018fbbc2f1feecbb1beb957b6274c9d552c19344411f6c94de9680",
+          "definitionDigest": "sha256:9da27a2cc1e4992e411e35ebf2b0b4c8a6f5f86368dfc446fb81a8e43570b98d",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.declarative-auditable-demo.yml@f7a98257a32624a63be2a935d7b884d6e872e07e"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.declarative-auditable-demo.yml@ba41d9c165a5d4f251a6c4af30c32b5a417865d2"],
           "steps": []
         },
         {

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -122,7 +122,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:0281b3ee47ae6e8406be1ed48410650e944f340081bb2e5f2219503c4d4a5e75"
+          "sourceRoot": "sha256:2a21e2bfbc638410f3b76b613faecf7d1dd5bbfe993a327cb7cfc249767b3e84"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",
@@ -860,5 +860,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:f3e35cf0ba4555555bd3df0f92a61a79e46f7d4ef24e3aae1ff56d1ff6c57985"
+  "registryRoot": "sha256:5fd557ed343d9248c4c6a600f380e82876e56cce29a48f5f376563f48ca10dcb"
 }

--- a/scripts/auditable-demo-workflow.test.mjs
+++ b/scripts/auditable-demo-workflow.test.mjs
@@ -173,7 +173,7 @@ test('the build fails the real transported binary before either upload path', ()
   );
   assert.equal(
     demo.uses,
-    'kungfu-systems/buildchain/.github/workflows/.declarative-auditable-demo.yml@f7a98257a32624a63be2a935d7b884d6e872e07e',
+    'kungfu-systems/buildchain/.github/workflows/.declarative-auditable-demo.yml@ba41d9c165a5d4f251a6c4af30c32b5a417865d2',
   );
   assert.equal(
     build.with['pre-upload-transport-smoke-scenario-path'],


### PR DESCRIPTION
## Summary

Admit the merged Buildchain long-form renderer-manifest budget into Kungfu auditable-demo materialization so the third 148.8-second native dual-rendition demo can complete.

## Related issue

Atlas goal `2026-08-08-kungfu-auditable-demo-720p-layout-repair`.

## Changes

- pin the auditable-demo reusable workflow to Buildchain merge `ba41d9c165a5d4f251a6c4af30c32b5a417865d2`
- refresh workflow-authority and publication-surface roots
- keep the 64 MiB ceiling bounded and owned by Buildchain; Kungfu only admits the qualified runtime

## Verification

- `./shifu test:auditable-demo` (8/8)
- `./shifu check:source` (1051 passed, 11 skipped; the only local failure was the cold-fixture discovery test because `pytest` is absent from the Mac PATH)
- Buildchain `pnpm run check` (1385/1385)
- exact agent-121 reproduction rendered the 37,392,553-byte third-demo manifest and all native 1920x1080 / 1280x720 media under the new bounded ceiling

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded runtime admission preserves the existing auditable-demo authority and release architecture while consuming the reviewed Buildchain long-form manifest limit."
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: extends

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change updates an exact external action pin and its generated workflow/publication authority projections. Required CI and merge-group verification cover the release boundary.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed