### PR TITLE
fix(maintainability): bind terminal evidence run attempts

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "051862fd37cc938893064a0bac35f6a4375a406b",
+    "sourceSha": "b85e1d3d35d0b4227e284c86f0c8a9a3186f58d1",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:225b692b65f126352d9ee96e9afe9e83d0d8bf78f3a17e365d0456a0654b359b"
   },

--- a/framework/maintainability/terminal-evidence-matrix.test.mjs
+++ b/framework/maintainability/terminal-evidence-matrix.test.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'node:url';
 
 import { semanticRoot } from '../project-cut/src/project-cut.mjs';
 import {
+  observeRun,
   parseCommandJson,
   parseTerminalReviewAttestation,
 } from '../terminal-evidence/live-observations.mjs';
@@ -467,6 +468,53 @@ test('live observation parser preserves object and array authority payloads', ()
   assert.equal(parseTerminalReviewAttestation('not json'), undefined);
 });
 
+test('live run observation binds run and jobs to the declared attempt', () => {
+  const calls = [];
+  const observed = observeRun(
+    matrix,
+    { role: 'source', runId: 123, runAttempt: 2 },
+    (endpoint) => {
+      calls.push(endpoint);
+      if (endpoint.endsWith('/attempts/2')) {
+        return {
+          id: 123,
+          run_attempt: 2,
+          path: '.github/workflows/affected-native-pr.yml',
+          event: 'merge_group',
+          head_sha: HEAD,
+          head_branch: matrix.sourceBinding.protectedBranch,
+          status: 'completed',
+          conclusion: 'success',
+        };
+      }
+      if (endpoint.endsWith('/attempts/2/jobs?per_page=100')) {
+        return {
+          jobs: [
+            {
+              id: 456,
+              name: 'Candidate source acceptance / check',
+              status: 'completed',
+              conclusion: 'success',
+            },
+          ],
+        };
+      }
+      return { artifacts: [] };
+    },
+  );
+  assert.deepEqual(calls, [
+    '/repos/kungfu-systems/kungfu/actions/runs/123/attempts/2',
+    '/repos/kungfu-systems/kungfu/actions/runs/123/attempts/2/jobs?per_page=100',
+    '/repos/kungfu-systems/kungfu/actions/runs/123/artifacts?per_page=100',
+  ]);
+  assert.equal(observed.runAttempt, 2);
+  assert.equal(observed.jobs[0].id, 456);
+  assert.throws(
+    () => observeRun(matrix, { role: 'source', runId: 123, runAttempt: 0 }),
+    /source run attempt must be a positive integer/u,
+  );
+});
+
 test('terminal maintainability matrix declares an exact-head v3 contract', () => {
   assert.equal(
     matrix.schema,
@@ -647,6 +695,28 @@ test('self-consistent declared runs cannot replace GitHub live truth', () => {
   assert.ok(
     issueCodes(verify(candidate)).has('run-runId-live-mismatch'),
     'positive, retained, internally consistent run id must still match live API',
+  );
+
+  const wrongAttempt = clone(evidence);
+  const attemptRun = wrongAttempt.runs.find(({ role }) => role === 'source');
+  const attemptRetained = wrongAttempt.retainedObjects.find(
+    ({ root }) => root === attemptRun.evidenceRoot,
+  );
+  const attemptSnapshot = JSON.parse(
+    retainedBytes.get(attemptRetained.path).toString('utf8'),
+  );
+  attemptSnapshot.runAttempt = 2;
+  attemptRun.runAttempt = 2;
+  const attemptRoot = semanticRoot(attemptSnapshot);
+  attemptRun.evidenceRoot = attemptRoot;
+  attemptRetained.root = attemptRoot;
+  retainedBytes.set(
+    attemptRetained.path,
+    Buffer.from(`${JSON.stringify(attemptSnapshot)}\n`),
+  );
+  assert.ok(
+    issueCodes(verify(wrongAttempt)).has('run-runAttempt-live-mismatch'),
+    'positive, retained, internally consistent attempt must still match live API',
   );
 
   const missingJob = clone(liveRuns);

--- a/framework/terminal-evidence/live-observations.mjs
+++ b/framework/terminal-evidence/live-observations.mjs
@@ -272,13 +272,15 @@ function observeTerminalReview(matrix, pullRequest, head, headTree) {
   };
 }
 
-function observeRun(matrix, declared) {
+function observeRun(matrix, declared, observe = gh) {
   const repository = matrix.sourceBinding.repository;
-  const run = gh(`/repos/${repository}/actions/runs/${declared.runId}`);
-  const jobsPayload = gh(
-    `/repos/${repository}/actions/runs/${declared.runId}/jobs?per_page=100`,
-  );
-  const artifactsPayload = gh(
+  if (!Number.isInteger(declared.runAttempt) || declared.runAttempt < 1) {
+    throw new Error(`${declared.role} run attempt must be a positive integer`);
+  }
+  const attemptEndpoint = `/repos/${repository}/actions/runs/${declared.runId}/attempts/${declared.runAttempt}`;
+  const run = observe(attemptEndpoint);
+  const jobsPayload = observe(`${attemptEndpoint}/jobs?per_page=100`);
+  const artifactsPayload = observe(
     `/repos/${repository}/actions/runs/${declared.runId}/artifacts?per_page=100`,
   );
   return {
@@ -348,5 +350,6 @@ export function collectTerminalLiveObservations(matrix, evidence) {
 
 export {
   jsonOutput as parseCommandJson,
+  observeRun,
   terminalReviewAttestation as parseTerminalReviewAttestation,
 };


### PR DESCRIPTION
## Summary

Bind terminal-evidence live observations to the declared GitHub Actions run attempt and repair the inherited protected-head KFD witness so descendants remain source-qualifiable.

## Related issue

Parent Assignment: `2026-07-29-kungfu-terminal-review-remediation`

## Changes

- Query attempt-specific run and job endpoints for every declared terminal-evidence run.
- Reject missing or non-positive declared attempts before live collection.
- Add positive endpoint-binding coverage and a self-consistent wrong-attempt negative fixture.
- Refresh the KFD-3 prebuild source witness after replaying the protected head.

## Verification

- `./shifu check`
- `PATH='<repo-venv-bin>':"$PATH" KUNGFU_READONLY_PYTEST='<repo-venv-bin>/pytest' ./shifu check:source` (1063 passed, 11 skipped, 0 failed in the comprehensive Node suite)
- `node scripts/buildchain-kfd-evidence.mjs --check`
- `git diff --check`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix tightens live evidence observation and refreshes an existing source witness without changing an architecture contract."
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change touches terminal/KFD evidence provenance only; no publication or deployment authority is added.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
