### PR TITLE
fix(tui): unify auditable demo Assignment Session runtime

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "b85e1d3d35d0b4227e284c86f0c8a9a3186f58d1",
+    "sourceSha": "86903b04cdcc0e4149f60a032be7fe4fa03f820f",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:225b692b65f126352d9ee96e9afe9e83d0d8bf78f3a17e365d0456a0654b359b"
   },

--- a/framework/agent-session/tests/product-surface.test.mjs
+++ b/framework/agent-session/tests/product-surface.test.mjs
@@ -999,6 +999,8 @@ test('provider exit metadata remains visible without retaining terminal output',
   });
   runtime.list()[0].child.emit('exit', { exitCode: 64, signal: 0 });
   const status = clients.cli.show(ref);
+  assert.equal(status.live || status.controllable, false);
+  assert.equal(clients.cli.list().attempts[0].live, false);
   assert.equal(status.lifecycleState, 'ended');
   assert.equal(status.inputAdmission, 'closed');
   assert.equal(status.exit.exitCode, 64);

--- a/framework/agent-session/tests/provider-adapters.test.mjs
+++ b/framework/agent-session/tests/provider-adapters.test.mjs
@@ -53,6 +53,24 @@ for (const [provider, version, filename] of [
   });
 }
 
+test('synthetic adapter accepts the current mock provider and its v1 compatibility floor', () => {
+  for (const version of ['1.0.0', '1.1.0']) {
+    const adapter = createProviderAdapter({ provider: 'synthetic', version });
+    assert.equal(adapter.compatible, true, version);
+    assert.equal(adapter.tested, true, version);
+    assert.equal(
+      adapter.inspect({
+        lines: ['mock› '],
+        lifecycleState: 'ready',
+        inputAdmission: 'open',
+        foreground: { provider: 'synthetic' },
+      }).state,
+      'ready',
+      version,
+    );
+  }
+});
+
 test('version drift and foreground mismatch fail visibly to raw human fallback', () => {
   const drifted = createProviderAdapter({
     provider: 'codex',

--- a/framework/core/src/python/kungfu/agent/managed_run.py
+++ b/framework/core/src/python/kungfu/agent/managed_run.py
@@ -30,6 +30,36 @@ def _terminal_mock_scenario(selected: Mapping[str, Any]) -> bool:
     return scenario in _TERMINAL_MOCK_SCENARIOS
 
 
+def _initial_session_boundary_reached(status: Mapping[str, Any]) -> bool:
+    interaction = status.get("interactionState")
+    if interaction in {"ready", "approval-needed", "ended"}:
+        return True
+    if interaction != "unknown":
+        return False
+    adapter = status.get("providerAdapter") or {}
+    return adapter.get("compatible") is False or adapter.get("reason") not in {
+        None,
+        "no-supported-state-signature",
+    }
+
+
+def _session_boundary_reached(
+    status: Mapping[str, Any],
+    *,
+    before_sequence: int,
+    terminal_mock: bool,
+) -> bool:
+    interaction = status.get("interactionState")
+    if terminal_mock:
+        return interaction == "ended" and status.get("live") is not True
+    if interaction in {"approval-needed", "unknown", "ended"}:
+        return True
+    return (
+        interaction == "ready"
+        and int((status.get("output") or {}).get("nextSequence") or 0) > before_sequence
+    )
+
+
 class ManagedRunCoordinator:
     """Start, instruct, observe, and snapshot one managed SessionAttempt."""
 
@@ -112,9 +142,7 @@ class ManagedRunCoordinator:
         ready = self.wait_for_session(
             invoke,
             ref,
-            lambda status: (
-                status.get("interactionState") in {"ready", "approval-needed", "ended"}
-            ),
+            _initial_session_boundary_reached,
             timeout_seconds=min(timeout_seconds, 30.0),
         )
         if ready.get("interactionState") != "ready":
@@ -142,23 +170,10 @@ class ManagedRunCoordinator:
         boundary = self.wait_for_session(
             invoke,
             ref,
-            lambda status: (
-                (
-                    terminal_mock_scenario
-                    and status.get("interactionState") == "ended"
-                    and status.get("live") is not True
-                )
-                or (
-                    not terminal_mock_scenario
-                    and status.get("interactionState")
-                    in {"approval-needed", "unknown", "ended"}
-                )
-                or (
-                    not terminal_mock_scenario
-                    and status.get("interactionState") == "ready"
-                    and int((status.get("output") or {}).get("nextSequence") or 0)
-                    > before_sequence
-                )
+            lambda status: _session_boundary_reached(
+                status,
+                before_sequence=before_sequence,
+                terminal_mock=terminal_mock_scenario,
             ),
             timeout_seconds=timeout_seconds,
         )

--- a/framework/core/src/python/kungfu/agent/session_surface.py
+++ b/framework/core/src/python/kungfu/agent/session_surface.py
@@ -323,8 +323,10 @@ def _validate_surface_capabilities(capabilities, *, endpoint):
 def ensure(runtime_dir, *, runner=None):
     """Ensure and return the runtime-scoped detached Agent Session endpoint."""
 
-    endpoint = endpoint_for_runtime(runtime_dir)
-    os.environ["KUNGFU_AGENT_SESSION_ENDPOINT"] = endpoint
+    explicit_endpoint = os.environ.get("KUNGFU_AGENT_SESSION_ENDPOINT")
+    endpoint = explicit_endpoint or endpoint_for_runtime(runtime_dir)
+    if explicit_endpoint is None:
+        os.environ["KUNGFU_AGENT_SESSION_ENDPOINT"] = endpoint
     try:
         capabilities = invoke(
             {"operation": "capabilities"}, endpoint=endpoint, timeout=0.25
@@ -332,7 +334,8 @@ def ensure(runtime_dir, *, runner=None):
         _validate_surface_capabilities(capabilities, endpoint=endpoint)
         return endpoint
     except (OSError, socket.timeout):
-        pass
+        if explicit_endpoint is not None:
+            raise
 
     entry = _resolve_native_entry()
     if entry is None:

--- a/framework/core/src/python/kungfu/cli/commands/assignment.py
+++ b/framework/core/src/python/kungfu/cli/commands/assignment.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import json
 import os
 from datetime import UTC, datetime, timedelta
-from functools import partial, reduce
 from pathlib import Path
 import uuid
 
@@ -33,22 +32,20 @@ from kungfu.workspace import prepare_workspace_write, resolve_workspace_target
 from kungfu.assignment_lifecycle.ports import AssignmentRuntime
 
 assignment_context = kfc.pass_context()
-assignment_identity_options = partial(
-    reduce,
-    lambda decorated, decorator: decorator(decorated),
-    tuple(
-        reversed(
-            [
-                click.option(
-                    "--workspace", "workspace_root", type=click.Path(file_okay=False)
-                ),
-                click.option("--home", is_flag=True),
-                click.option("--initiative-id", required=True),
-                click.option("--assignment-id", required=True),
-            ]
-        )
-    ),
-)
+
+
+def assignment_identity_options(command):
+    """Decorate every Work command with a fresh identity option set."""
+
+    decorators = (
+        click.option("--workspace", "workspace_root", type=click.Path(file_okay=False)),
+        click.option("--home", is_flag=True),
+        click.option("--initiative-id", required=True),
+        click.option("--assignment-id", required=True),
+    )
+    for decorator in reversed(decorators):
+        command = decorator(command)
+    return command
 
 
 @kfc.group(

--- a/framework/core/tests/python/test_agent_native_terminal_contract.py
+++ b/framework/core/tests/python/test_agent_native_terminal_contract.py
@@ -147,6 +147,7 @@ def test_agent_session_does_not_replace_an_explicit_environment_endpoint(
 def test_agent_session_rejects_a_live_worker_with_stale_native_operations(
     monkeypatch, tmp_path
 ):
+    monkeypatch.delenv("KUNGFU_AGENT_SESSION_ENDPOINT", raising=False)
     monkeypatch.setattr(
         session_surface,
         "invoke",
@@ -171,6 +172,7 @@ def test_agent_session_rejects_a_live_worker_with_stale_native_operations(
 def test_agent_session_accepts_the_versioned_native_operation_vocabulary(
     monkeypatch, tmp_path
 ):
+    monkeypatch.delenv("KUNGFU_AGENT_SESSION_ENDPOINT", raising=False)
     monkeypatch.setattr(
         session_surface,
         "invoke",
@@ -183,6 +185,31 @@ def test_agent_session_accepts_the_versioned_native_operation_vocabulary(
     )
 
     assert endpoint == session_surface.endpoint_for_runtime(tmp_path / "runtime")
+    assert runners == []
+
+
+def test_agent_session_ensure_reuses_an_explicit_product_endpoint(
+    monkeypatch, tmp_path
+):
+    explicit = "/tmp/product-agent-session.sock"
+    monkeypatch.setenv("KUNGFU_AGENT_SESSION_ENDPOINT", explicit)
+    calls = []
+    monkeypatch.setattr(
+        session_surface,
+        "invoke",
+        lambda request, **kwargs: (
+            calls.append((request, kwargs)) or NATIVE_SURFACE_CAPABILITIES
+        ),
+    )
+    runners = []
+
+    endpoint = session_surface.ensure(
+        tmp_path / "different-project-runtime",
+        runner=lambda *_args: runners.append(True),
+    )
+
+    assert endpoint == explicit
+    assert calls[0][1]["endpoint"] == explicit
     assert runners == []
 
 

--- a/framework/core/tests/python/test_run_product_path.py
+++ b/framework/core/tests/python/test_run_product_path.py
@@ -9,6 +9,7 @@ from click.testing import CliRunner
 from kungfu import assignment_lifecycle
 from kungfu import assignment_orchestration as orchestration
 from kungfu.agent import first_value as onboarding
+from kungfu.agent import managed_run
 from kungfu.agent import native_launch
 from kungfu.agent import run_agent
 from kungfu.cli.commands import assignment, kfc, run
@@ -274,6 +275,8 @@ def test_resumed_authority_writes_remain_visible_when_run_gate_fails(
     )
 
     def start_bound_session(**kwargs):
+        assert kwargs["work_ref"]["initiativeId"] == "project-work"
+        run_agent.session_contract.validate_work_ref(kwargs["work_ref"])
         kwargs["session_started_callback"](
             {
                 "workConsoleId": "work:kungfu.work-control:assignment:first",
@@ -1219,6 +1222,97 @@ def test_project_work_session_yields_at_deterministic_attention(tmp_path):
     )
     assert start_input["binding"] == {"kind": "work", "workRef": work}
     assert start_input["workConsoleId"] == ("work:kungfu.work-control:assignment:first")
+
+
+def test_terminal_mock_scenarios_ignore_ready_echo_until_the_process_ends():
+    recovery = {
+        "provider": "synthetic",
+        "launch": {"argv": ["/mock-provider.mjs", "--scenario", "recovery-story"]},
+    }
+    interactive = {
+        "provider": "synthetic",
+        "launch": {"argv": ["/mock-provider.mjs", "--scenario", "multi-step"]},
+    }
+    ready_after_echo = {
+        "live": True,
+        "interactionState": "ready",
+        "output": {"nextSequence": 42},
+    }
+    ended = {
+        "live": False,
+        "interactionState": "ended",
+        "output": {"nextSequence": 43},
+    }
+
+    assert managed_run._terminal_mock_scenario(recovery) is True
+    assert managed_run._terminal_mock_scenario(interactive) is False
+    assert (
+        managed_run._session_boundary_reached(
+            ready_after_echo,
+            before_sequence=10,
+            terminal_mock=True,
+        )
+        is False
+    )
+    assert (
+        managed_run._session_boundary_reached(
+            ready_after_echo,
+            before_sequence=10,
+            terminal_mock=False,
+        )
+        is True
+    )
+    assert (
+        managed_run._session_boundary_reached(
+            ended,
+            before_sequence=10,
+            terminal_mock=True,
+        )
+        is True
+    )
+
+
+def test_initial_session_wait_ignores_only_the_transient_missing_signature():
+    assert (
+        managed_run._initial_session_boundary_reached(
+            {
+                "interactionState": "unknown",
+                "providerAdapter": {
+                    "compatible": True,
+                    "reason": "no-supported-state-signature",
+                },
+            }
+        )
+        is False
+    )
+    assert (
+        managed_run._initial_session_boundary_reached(
+            {
+                "interactionState": "unknown",
+                "providerAdapter": {
+                    "compatible": False,
+                    "reason": "adapter-version-drift",
+                },
+            }
+        )
+        is True
+    )
+    assert (
+        managed_run._initial_session_boundary_reached(
+            {
+                "interactionState": "unknown",
+                "providerAdapter": {
+                    "compatible": True,
+                    "reason": "provider-reported-blocked",
+                },
+            }
+        )
+        is True
+    )
+    assert (
+        managed_run._initial_session_boundary_reached({"interactionState": "ready"})
+        is True
+    )
 
 
 def test_mock_profile_probes_the_deterministic_provider_version():

--- a/framework/core/tests/python/test_work_authority_surface.py
+++ b/framework/core/tests/python/test_work_authority_surface.py
@@ -76,6 +76,34 @@ def test_work_family_contains_only_profile_backed_orchestration_commands():
     )
 
 
+def test_reused_work_identity_decorator_preserves_every_command_signature():
+    identity_options = {
+        "--workspace",
+        "--home",
+        "--initiative-id",
+        "--assignment-id",
+    }
+    for name in {
+        "bind",
+        "claim",
+        "close",
+        "close-plan",
+        "close-resume",
+        "gate",
+        "kickoff",
+        "seal",
+        "stage",
+        "status",
+    }:
+        command = kfc.commands["work"].commands[name]
+        flags = {
+            flag
+            for parameter in command.params
+            for flag in getattr(parameter, "opts", ())
+        }
+        assert identity_options <= flags, name
+
+
 def test_start_resume_accepts_the_generic_project_work_purpose(tmp_path, monkeypatch):
     report_path = tmp_path / "agent-runs" / "run-1" / "bundle" / "report.json"
     report_path.parent.mkdir(parents=True)

--- a/framework/tui/src/main.tsx
+++ b/framework/tui/src/main.tsx
@@ -186,7 +186,6 @@ function ensureTuiAgentSession(runtimeDir: string): Promise<string> {
     },
   );
   process.env.KUNGFU_AGENT_SESSION_WORKER = workerPath;
-  process.env.KUNGFU_MOCK_AGENT_EXECUTABLE = process.execPath;
   process.env.KUNGFU_MOCK_AGENT_SCRIPT = mockPath;
   process.env.KUNGFU_PROJECT_WORK_AGENT_SESSION = '1';
   const host = createDetachedAgentSessionHost({
@@ -290,10 +289,11 @@ const EXIT_HISTORY_STATUS_FALLBACK: ExitHistoryStatus = {
   nextActions: ['kungfu exit history status --json'],
 };
 
-function openTuiAgentWorkLab(projectTour = false): AgentWorkLab {
+async function openTuiAgentWorkLab(projectTour = false): Promise<AgentWorkLab> {
   const paths = runtimePaths();
   const cli = tuiCliInvocation(paths);
   if (projectTour) {
+    await ensureTuiAgentSession(paths.runtimeDir);
     const { mockPath } = resolveTuiAgentSessionPaths({
       env: process.env,
       argvEntry: process.argv[1],
@@ -2289,7 +2289,7 @@ async function main(): Promise<void> {
     speed: projectTourSpeed,
     episode: projectTourEpisode,
   } = parseProjectTourLaunchOptions(process.argv);
-  const lab = openTuiAgentWorkLab(Boolean(projectTourRoot));
+  const lab = await openTuiAgentWorkLab(Boolean(projectTourRoot));
   const playbackMode = autoDemo || Boolean(projectTourRoot);
   const emptyState = process.argv.includes('--empty-state');
   if (process.argv.includes('--agent-work-lab-demo')) {
@@ -2310,7 +2310,6 @@ async function main(): Promise<void> {
     if (playbackMode) process.exitCode = 2;
     return;
   }
-
   const lifecycle = new TerminalLifecycle(
     process.stdin,
     process.stdout,

--- a/framework/tui/src/project-tour-view.test.ts
+++ b/framework/tui/src/project-tour-view.test.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import { Writable } from 'node:stream';
 import test from 'node:test';
 import { render } from 'ink';
@@ -35,6 +36,28 @@ import {
   projectTourSummaryTitles,
   updateProjectTourStream,
 } from './starter-project-view/index.js';
+
+test('Project tour awaits the shared Agent Session before rendering', () => {
+  const source = readFileSync(new URL('./main.tsx', import.meta.url), 'utf8');
+  const main = source.slice(source.indexOf('async function main()'));
+  assert.match(
+    main,
+    /await openTuiAgentWorkLab\(Boolean\(projectTourRoot\)\)/u,
+  );
+  assert.ok(
+    main.indexOf('await openTuiAgentWorkLab') <
+      main.indexOf('const lifecycle = new TerminalLifecycle'),
+  );
+  const lab = source.slice(
+    source.indexOf('async function openTuiAgentWorkLab'),
+  );
+  assert.match(lab, /if \(projectTour\) \{\s*await ensureTuiAgentSession/u);
+  assert.match(lab, /KUNGFU_MOCK_AGENT_EXECUTABLE \|\|= paths\.packagedBin/u);
+  assert.doesNotMatch(
+    source,
+    /KUNGFU_MOCK_AGENT_EXECUTABLE\s*=\s*process\.execPath/u,
+  );
+});
 
 test('Project tour launch options preserve defaults and validate explicit values', () => {
   assert.deepEqual(parseProjectTourLaunchOptions(['node', 'tui']), {


### PR DESCRIPTION
## Summary

- make Project Tour reuse the shared TUI Agent Session instead of attempting a second authority
- preserve an explicitly supplied mock executable and wait only through transient initial session state
- generate fresh Click decorators per command so `assignment run` and `assignment autoplay` keep their full option sets
- keep current terminal-state and provider-adapter semantics from dev while extracting one tested session-boundary helper
- refresh KFD-3 evidence on the current dev source

This fresh linear branch supersedes closed PRs #2634 and #2635 without rewriting published history.

## Validation

- `./shifu check:source` — passed at exact source `0b669be2d14818d39a425dc6a11a568f0934fac9`
- source contract tests — 1075 total, 1064 passed, 11 skipped, 0 failed
- zero-write tracked-tree audit — passed
- KFD evidence regeneration and checks — passed
- focused TUI tests — 19/19
- focused Agent Session tests — 36/36
- focused Core tests — 96/96
- native 150x28 Project Tour episode 1 qualified on the equivalent runtime patch — `sha256:a8e0b2eed03b7950567b93767a12da779733436d28a60981c1c1d91cfe8a8e46`
- native 150x28 Project Tour episode 2 qualified on the equivalent runtime patch — `sha256:7b09fdcea1fde5f3a567aa76d8d9e9f13c24d399c8668d76c43a387e914a36c7`
- native 150x28 Agent Work Lab autoplay qualified on the equivalent runtime patch — `sha256:1874beeb39959b9e6b78526a27ae6a32d3ce3e579b6385afd59196e91112c39d`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix restores the existing Agent Session, Project Work, and auditable-demo runtime boundaries without changing their architecture or release authority."
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: extends

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change affects the bounded synthetic provider/session path consumed by release evidence. Required source acceptance, cross-platform CI, and merge-group verification remain authoritative.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed

Source: `0b669be2d14818d39a425dc6a11a568f0934fac9`
Base: `86903b04cdcc0e4149f60a032be7fe4fa03f820f`
