### PR TITLE
fix(release): authorize recovered alpha runtime

### DIFF
--- a/docs/qualification/gates/release-admission-policy.json
+++ b/docs/qualification/gates/release-admission-policy.json
@@ -23,7 +23,7 @@
       "alpha": {
         "ref": "v3-alpha",
         "runtimeSha": "2e7e07902ac28d8f3edcfb81098ef9ebc7a91878",
-        "publicationRuntimeSha": "bd32d3f834f84bef1bbccc775b6edd6ad0bc6766",
+        "publicationRuntimeSha": "21030efd277301d642fd9baaa1bd75f02dd3ddc6",
         "contractDigest": "sha256:5a6dc69d8905ed852260076da13d3aa3fa63533007dba706c164fe86f8b8f1e6",
         "contractLock": ".buildchain/alpha-contract-lock.json"
       },

--- a/scripts/verify-kungfu-release-admission.test.mjs
+++ b/scripts/verify-kungfu-release-admission.test.mjs
@@ -39,7 +39,9 @@ import {
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SOURCE_SHA = '1'.repeat(40);
 const RUNTIME_SHA = '2e7e07902ac28d8f3edcfb81098ef9ebc7a91878';
-const PUBLICATION_RUNTIME_SHA = 'bd32d3f834f84bef1bbccc775b6edd6ad0bc6766';
+const PUBLICATION_RUNTIME_SHA = '21030efd277301d642fd9baaa1bd75f02dd3ddc6';
+const RETIRED_PUBLICATION_RUNTIME_SHA =
+  'bd32d3f834f84bef1bbccc775b6edd6ad0bc6766';
 const STABLE_RUNTIME_SHA = '9e904de2c85dbea7c799780ee166510b3336d812';
 const SOURCE_TREE_SHA = 'a'.repeat(40);
 const CONTRACT_DIGEST =
@@ -399,7 +401,7 @@ test('Kungfu independently accepts only a current sealed qualifying capability',
       verifyKungfuReleaseAdmission(
         fixture({
           channel: 'alpha',
-          publicationRuntimeSha: STABLE_RUNTIME_SHA,
+          publicationRuntimeSha: RETIRED_PUBLICATION_RUNTIME_SHA,
         }),
       ),
     /runtimeSha policy mismatch/,


### PR DESCRIPTION
## Summary

Authorize the exact Buildchain recovery runtime that already passed candidate evidence preflight, while preserving the immutable v4.0.0-alpha.1 candidate source, tree, runtime, and bytes.

## Changes

- pin the Alpha publication runtime to Buildchain 21030efd277301d642fd9baaa1bd75f02dd3ddc6
- retain candidate runtime 2e7e07902ac28d8f3edcfb81098ef9ebc7a91878 unchanged
- reject the retired bd32d3f834f84bef1bbccc775b6edd6ad0bc6766 publication runtime in the consumer qualification regression

## Verification

- ./shifu test:npm-core-platform-distribution (106/106, 3 platform skips)
- ./shifu check:source: all product/source gates passed; one local cold-read fixture reported pytest absent from PATH (1062 pass, 1 environment failure, 11 skips)
- staged pre-commit gate passed
- live recovery run 31279751636 passed candidate preflight and reached the consumer predicate before rejecting the unpinned 21030efd runtime

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This updates the exact fail-closed Alpha recovery runtime allowlist after its bounded recovery fix, without changing architecture contracts or candidate bytes"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change only authorizes one exact recovery runtime SHA; all candidate and release evidence bindings remain fail-closed.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed