### PR TITLE
fix(ci): preserve merged queue source runs

### DIFF
--- a/scripts/cancel-dequeued-merge-group-runs.mjs
+++ b/scripts/cancel-dequeued-merge-group-runs.mjs
@@ -873,14 +873,32 @@ export async function settleDequeuedMergeGroup({
     token,
     request,
   });
+  const cancellationPromise = removalPromise.then(
+    (observedRemoval) =>
+      observedRemoval.reason === 'merged'
+        ? {
+            pullRequest,
+            matchedRunCount: 0,
+            cancellations: [],
+          }
+        : cancelDequeuedMergeGroupRuns({
+            repository,
+            pullRequest,
+            workflow,
+            token,
+            request,
+          }),
+    () =>
+      cancelDequeuedMergeGroupRuns({
+        repository,
+        pullRequest,
+        workflow,
+        token,
+        request,
+      }),
+  );
   const results = await Promise.allSettled([
-    cancelDequeuedMergeGroupRuns({
-      repository,
-      pullRequest,
-      workflow,
-      token,
-      request,
-    }),
+    cancellationPromise,
     removalPromise.then((observedRemoval) =>
       recordDequeuedRepairMarker({
         repository,

--- a/scripts/cancel-dequeued-merge-group-runs.test.mjs
+++ b/scripts/cancel-dequeued-merge-group-runs.test.mjs
@@ -281,7 +281,7 @@ test('dequeue settlement still revokes the lease when other cleanup fails', asyn
   ]);
 });
 
-test('merged dequeue preserves the successful exact-head queue admission lease', async () => {
+test('merged dequeue preserves the exact-head run and successful queue admission lease', async () => {
   const headSha = 'e'.repeat(40);
   const requests = [];
   const request = async (url, init = {}) => {
@@ -308,9 +308,6 @@ test('merged dequeue preserves the successful exact-head queue admission lease',
         },
       });
     }
-    if (url.includes('/actions/workflows/affected-native-pr.yml/runs?')) {
-      return response(200, { workflow_runs: [] });
-    }
     throw new Error(`merged dequeue must not write status: ${url}`);
   };
   const settlement = await settleDequeuedMergeGroup({
@@ -330,6 +327,16 @@ test('merged dequeue preserves the successful exact-head queue admission lease',
   });
   assert.equal(settlement.repairMarker.repairRequired, false);
   assert.equal(settlement.evidence.dequeue.reason, 'merged');
+  assert.deepEqual(settlement.cancellation, {
+    pullRequest: 1798,
+    matchedRunCount: 0,
+    cancellations: [],
+  });
+  assert.equal(
+    requests.filter(({ url }) => url.includes('/actions/workflows/')).length,
+    0,
+  );
+  assert.equal(requests.filter(({ url }) => url.endsWith('/cancel')).length, 0);
   assert.equal(
     requests.filter(({ url }) => url.endsWith(`/statuses/${headSha}`)).length,
     0,


### PR DESCRIPTION
## Summary

Preserve an exact merge-group source run after its pull request is successfully merged, so terminal evidence can observe the run-level success that already-completed required jobs are intended to establish.

## Related issue

Parent Assignment: `2026-07-29-kungfu-terminal-review-remediation`

## Root cause and changes

- The `dequeued` settlement previously cancelled active merge-group runs before it learned that the dequeue reason was `merged`.
- Production evidence: dequeue workflow run `31281787857` accepted cancellation of source run `31281590528` while recording `reason=merged` and preserving the queue-admission lease.
- Resolve the removal reason before cancellation; a merged dequeue performs no workflow-run query or cancellation.
- Preserve the existing fail-closed cancellation path for non-merged removals and for removal-observation failures.
- Add regression coverage proving a merged dequeue makes no Actions cancellation request and retains the successful exact-head lease.

## Verification

- `node --test scripts/cancel-dequeued-merge-group-runs.test.mjs` (12 passed)
- `pnpm exec biome check scripts/cancel-dequeued-merge-group-runs.mjs scripts/cancel-dequeued-merge-group-runs.test.mjs`
- `./shifu check source`
- `git diff --check`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix corrects the ordering of existing merge-queue cleanup semantics without changing an architecture contract."
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change affects exact-source CI evidence preservation only; it adds no publication or deployment authority.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
