### PR TITLE
docs(readme): announce first public alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,12 @@ claim boundaries live in their own maintained routes:
 - **Evaluate the wider ecosystem thesis:** the
   [Agent Supply Chain architecture](docs/architecture/agent-supply-chain.md).
 
-Kungfu v4 is **Coming soon**. The current repository contains source-built
-capabilities and retained qualification evidence; public release artifacts are
-not available yet. Exact status and non-claims live in
+Kungfu v4.0.0-alpha.1 is the first public v4 Alpha. Download the
+[release artifacts](https://github.com/kungfu-systems/kungfu/releases/tag/v4.0.0-alpha.1)
+or follow the [installation guide](docs/guides/installing-cli.md). This is a
+prerelease, not a stable or generally available release; exact support,
+qualification, and non-claims remain in
+[Alpha Status](docs/guides/alpha-status.md) and
 [Known Limits](docs/qualification/known-limits.md).
 
 <!-- buildchain:badges:start -->


### PR DESCRIPTION
## Summary

Update the canonical repository entrypoint to reflect the already published Kungfu v4.0.0-alpha.1 release while preserving the prerelease, qualification, and non-claim boundaries.

## Related issue

None.

## Changes

- replace obsolete Coming soon and unavailable-artifacts wording
- link the exact v4.0.0-alpha.1 GitHub Release and installation guide
- retain explicit Alpha prerelease, support, qualification, and known-limit boundaries

## Verification

- `./shifu docs:check` (462 Markdown files; 144/144 tests passed)
- `./shifu docs:prose:required` (371 files; 0 findings)
- stale release-status phrase audit of `README.md`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Align the repository entrypoint with the already published v4.0.0-alpha.1 release without changing architecture or release artifacts"
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [x] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The README names the already published release tag only; no artifact, tag, package, provenance, or deployment surface changes.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed