### PR TITLE
fix(project-cut): admit complete evidence retirement

### DIFF
--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -337,7 +337,7 @@
           },
           {
             "path": "framework/project-cut/README.md",
-            "sha256": "sha256:0d7b91a5d3c04e47175e286763542a7da9e84d4d01b012451d4895b3191dc062"
+            "sha256": "sha256:270406f732b339374e136b4ed954b975da60ae17c1e309ac8b75aea3f5b51c24"
           }
         ],
         "missingGates": [

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -337,7 +337,7 @@
           },
           {
             "path": "framework/project-cut/README.md",
-            "sha256": "sha256:0d7b91a5d3c04e47175e286763542a7da9e84d4d01b012451d4895b3191dc062"
+            "sha256": "sha256:270406f732b339374e136b4ed954b975da60ae17c1e309ac8b75aea3f5b51c24"
           }
         ],
         "missingGates": [

--- a/framework/project-cut/README.md
+++ b/framework/project-cut/README.md
@@ -207,6 +207,10 @@ silently treating historical Git coordinates as semantic authority. Historical
 global reconciliation remains available separately and may still report
 orphaned or superseded observations outside the candidate scope.
 
+Removing a complete Cut bundle (both manifest and receipt) retires that Cut
+from the candidate and is a scoped no-op. Removing only one side, or removing
+Episode evidence still referenced by a surviving Cut, remains fail-closed.
+
 Before queue entry, the repository-internal admission tool recreates the
 rebase-style candidate as unreachable Git objects without changing refs, the
 index, or the worktree. It applies the PR's first-parent commits to the current

--- a/framework/project-cut/src/composition.mjs
+++ b/framework/project-cut/src/composition.mjs
@@ -287,8 +287,12 @@ function scopedManifestPaths(root, base, commit, allPaths, cuts) {
   const evidencePaths = changedEvidencePaths(root, base, commit);
   const paths = new Set();
   for (const path of evidencePaths) {
-    if (MANIFEST.test(path)) paths.add(path);
-    else if (path.startsWith(PROTOCOL_PREFIX) && path.endsWith('/receipt.json'))
+    if (MANIFEST.test(path) && allPaths.includes(path)) paths.add(path);
+    else if (
+      path.startsWith(PROTOCOL_PREFIX) &&
+      path.endsWith('/receipt.json') &&
+      allPaths.includes(posix.join(posix.dirname(path), 'manifest.json'))
+    )
       paths.add(posix.join(posix.dirname(path), 'manifest.json'));
   }
   const providerRoots = providerRootsForEvidence(

--- a/scripts/check-project-cut-composition.test.mjs
+++ b/scripts/check-project-cut-composition.test.mjs
@@ -707,6 +707,34 @@ test('receipt-only and Episode-only evidence deletion enter the scoped gate', (t
   );
 });
 
+test('complete Cut and Episode evidence retirement leaves no compatibility residue', (t) => {
+  const { root, parent } = baseline(t);
+  git(root, 'checkout', '-qb', 'retirement', parent.commit);
+  fs.writeFileSync(path.join(root, 'episode.txt'), 'episode\n');
+  const providerRoot = admittedEpisode(root);
+  git(root, 'add', '--all');
+  git(root, 'commit', '-qm', 'feat: evidence source');
+  const child = publishCut(root, [parent.cut.cutRoot], providerRoot);
+  const base = child.commit;
+  const cutDir = `.kungfu/project-cuts/sha256/${child.cut.cutRoot.slice(7, 9)}/${child.cut.cutRoot.slice(7)}`;
+  const providerManifest = git(
+    root,
+    'ls-files',
+    '*episodes/sealed/*/manifest.json',
+  );
+  git(root, 'rm', `${cutDir}/manifest.json`, `${cutDir}/receipt.json`);
+  git(root, 'rm', '-r', path.posix.dirname(providerManifest));
+  git(root, 'commit', '-qm', 'test: retire complete evidence bundle');
+  const receipt = observeComposition(root, base, 'HEAD');
+  assert.equal(
+    receipt.status,
+    'qualified',
+    JSON.stringify(receipt.diagnostics),
+  );
+  assert.deepEqual(receipt.scope.changedCutRoots, []);
+  assert.equal(verifyComposition(root, receipt).ok, true);
+});
+
 test('multiple project identities receive separate candidate projections', (t) => {
   const { root, parent, base } = baseline(t);
   feature(root, 'project-a', parent, 'src/a.txt', 'a\n', null, {


### PR DESCRIPTION
## Summary

Allow protected Project Cut composition admission to distinguish complete evidence retirement from malformed partial deletion. This is a prerequisite for #2653; this PR does not remove any evidence bundle.

## Related issue

Prerequisite for #2653.

## Changes

- scope composition checks only to Cut manifests that survive in the candidate tree
- preserve fail-closed handling for receipt-only deletion and surviving Cuts with removed Episode evidence
- add a complete-retirement regression and document the scoped no-op semantics
- refresh the exact KFD-6 precursor evidence root and its SDK projection

## Verification

- `./shifu test:project-cut-composition` (18 passed)
- `./shifu check:project-cut-composition`
- `./shifu docs:check` (144 passed)
- `./shifu kfd check --json`
- `./shifu check:source` (build-free source gate passed)
- protected N-1 queue admission from `ffe8aef4d7281babeb34ee9c867479ca9a9002a0` to exact head `3634f64c84a5fba3fa390bf5490ce86864f9cee9`: qualified with zero diagnostics

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded admission repair preserves the existing Project Cut protocol and fail-closed partial-deletion boundary while allowing a candidate to retire a complete evidence bundle."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change is limited to source-side Project Cut composition admission and content-addressed evidence projection. It adds no publication or release authority.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Tests, documentation, and generated authority projections are current