### PR TITLE
fix(product): stage node-pty spawn helper for Linux CLI

### DIFF
--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -1024,13 +1024,16 @@ export function stageNodePtyForCli(
     const nativeDirectory = path.join('build', 'Release');
     const targetNativeDirectory = path.join(target, nativeDirectory);
     fs.mkdirSync(targetNativeDirectory, { recursive: true });
-    const input = path.join(source, nativeDirectory, 'pty.node');
-    if (!fs.existsSync(input) || !fs.lstatSync(input).isFile()) {
-      throw new Error(
-        `required Linux node-pty runtime not found: ${rel(input)}`,
-      );
+    for (const runtime of ['pty.node', 'spawn-helper']) {
+      const input = path.join(source, nativeDirectory, runtime);
+      if (!fs.existsSync(input) || !fs.lstatSync(input).isFile()) {
+        throw new Error(
+          `required Linux node-pty runtime not found: ${rel(input)}`,
+        );
+      }
+      fs.copyFileSync(input, path.join(targetNativeDirectory, runtime));
     }
-    fs.copyFileSync(input, path.join(targetNativeDirectory, 'pty.node'));
+    fs.chmodSync(path.join(targetNativeDirectory, 'spawn-helper'), 0o755);
   } else if (platform === 'darwin') {
     fs.chmodSync(
       path.join(

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -453,6 +453,7 @@ test('Linux CLI staging restores only the exact node-pty native runtime closure'
     ['package.json', '{}\n'],
     ['index.js', 'export {};\n'],
     ['build/Release/pty.node', 'native-addon\n'],
+    ['build/Release/spawn-helper', 'native-helper\n'],
     ['build/Debug/pty.node', 'debug-addon\n'],
     ['build/Release/obj.target/unshipped.o', 'object\n'],
   ]) {
@@ -472,8 +473,12 @@ test('Linux CLI staging restores only the exact node-pty native runtime closure'
     'native-addon\n',
   );
   assert.equal(
-    fs.existsSync(path.join(target, 'build/Release/spawn-helper')),
-    false,
+    fs.readFileSync(path.join(target, 'build/Release/spawn-helper'), 'utf8'),
+    'native-helper\n',
+  );
+  assert.notEqual(
+    fs.statSync(path.join(target, 'build/Release/spawn-helper')).mode & 0o111,
+    0,
   );
   assert.equal(fs.existsSync(path.join(target, 'build/Debug')), false);
   assert.equal(
@@ -518,6 +523,24 @@ test('Linux CLI staging fails closed when the node-pty native addon is missing',
   assert.throws(
     () => stageNodePtyForCli(source, target, 'linux', 'x64'),
     /required Linux node-pty runtime not found/u,
+  );
+});
+
+test('Linux CLI staging fails closed when the node-pty spawn helper is missing', (t) => {
+  const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-node-pty-'));
+  t.after(() => fs.rmSync(parent, { recursive: true, force: true }));
+  const source = path.join(parent, 'source');
+  const target = path.join(parent, 'target');
+  fs.mkdirSync(path.join(source, 'build', 'Release'), { recursive: true });
+  fs.writeFileSync(path.join(source, 'package.json'), '{}\n');
+  fs.writeFileSync(
+    path.join(source, 'build', 'Release', 'pty.node'),
+    'native-addon\n',
+  );
+
+  assert.throws(
+    () => stageNodePtyForCli(source, target, 'linux', 'x64'),
+    /required Linux node-pty runtime not found: .*spawn-helper/u,
   );
 });
 


### PR DESCRIPTION
## Summary

Restore the complete node-pty runtime closure in Linux CLI product bundles so PTY-backed terminal processes can start from the packaged product.

## Related issue

None.

## Changes

- Stage both pty.node and its sibling spawn-helper on Linux.
- Mark the staged spawn-helper executable.
- Fail closed when either required runtime file is missing.
- Preserve the existing Darwin behavior and Docker isolation boundary.

## Verification

- ./shifu test:cli-surface-qualification (58 passed)
- ./shifu check
- ./shifu check:source at 08a7163232fee9a528e3474c9c2ef3f2ab3ff57d against dc5b118c9e19d711c484ecbf29c4bf3b571bb4c8 (1085 tests; 1074 passed, 11 explicit skips, 0 failed)
- ./shifu project-cut:queue-admission -- --base dc5b118c9e19d711c484ecbf29c4bf3b571bb4c8 --head 08a7163232fee9a528e3474c9c2ef3f2ab3ff57d (qualified; replayedCommitCount=1; diagnostics=[])

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix restores a required existing node-pty runtime companion binary without changing an architecture contract or product authority boundary."
}
-->