### PR TITLE
fix(release): authorize durable Alpha runtime

### DIFF
--- a/docs/qualification/gates/release-admission-policy.json
+++ b/docs/qualification/gates/release-admission-policy.json
@@ -23,7 +23,7 @@
       "alpha": {
         "ref": "v3-alpha",
         "runtimeSha": "2e7e07902ac28d8f3edcfb81098ef9ebc7a91878",
-        "publicationRuntimeSha": "21030efd277301d642fd9baaa1bd75f02dd3ddc6",
+        "publicationRuntimeSha": "1d9b35b75e16d492e6d8b18c32504e89f8806855",
         "contractDigest": "sha256:5a6dc69d8905ed852260076da13d3aa3fa63533007dba706c164fe86f8b8f1e6",
         "contractLock": ".buildchain/alpha-contract-lock.json"
       },

--- a/scripts/verify-kungfu-release-admission.test.mjs
+++ b/scripts/verify-kungfu-release-admission.test.mjs
@@ -39,9 +39,9 @@ import {
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SOURCE_SHA = '1'.repeat(40);
 const RUNTIME_SHA = '2e7e07902ac28d8f3edcfb81098ef9ebc7a91878';
-const PUBLICATION_RUNTIME_SHA = '21030efd277301d642fd9baaa1bd75f02dd3ddc6';
+const PUBLICATION_RUNTIME_SHA = '1d9b35b75e16d492e6d8b18c32504e89f8806855';
 const RETIRED_PUBLICATION_RUNTIME_SHA =
-  'bd32d3f834f84bef1bbccc775b6edd6ad0bc6766';
+  '21030efd277301d642fd9baaa1bd75f02dd3ddc6';
 const STABLE_RUNTIME_SHA = '9e904de2c85dbea7c799780ee166510b3336d812';
 const SOURCE_TREE_SHA = 'a'.repeat(40);
 const CONTRACT_DIGEST =

--- a/scripts/verify-kungfu-release-admission.test.mjs
+++ b/scripts/verify-kungfu-release-admission.test.mjs
@@ -381,7 +381,7 @@ function fixture(options = {}) {
   };
 }
 
-test('Kungfu independently accepts only a current sealed qualifying capability', async () => {
+test('Kungfu independently accepts only a durable sealed qualifying capability', async () => {
   const result = await verifyKungfuReleaseAdmission(fixture());
   assert.equal(result.qualifying, true);
   assert.equal(result.capability.decision, 'allow');


### PR DESCRIPTION
## Summary

Authorize the exact durable Buildchain runtime `1d9b35b75e16d492e6d8b18c32504e89f8806855` for Alpha publication recovery. Candidate and release coordinates remain unchanged.

## Verification

- 5/5 focused release-admission tests
- 75/75 Alpha promotion preflight tests
- staged source checks, latency contracts, invariants, docs/ADR, Biome, and KFD evidence

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded release-policy pin authorizes an already qualified Buildchain runtime and does not alter an architecture contract"
}
-->

## Governance risk check

Release evidence and provenance are in scope; the exact runtime pin and unchanged candidate coordinates are independently verified.

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA4LTA2LWt1bmdmdS1hbHBoYTEtY2FuZGlkYXRlLXJlY292ZXJ5LXJlbGVhc2UiLCJkZWxpdmVyeUNsYXNzIjoibmF0aXZlLXByb29mLXJlcXVpcmVkIiwiZGV2SGVhZCI6IjdhMTViN2Q1ZjEzOWFmMTMxYzRjN2YyZWZjNDgyYzM0YWNlMDJlNWUiLCJwdWxsUmVxdWVzdEhlYWQiOiIwMjQ5YzlkNmQ5YTYwNDI1YjI5Mjk2ZTM5MDUyM2EzYzE1NmMzOWI2IiwicmVwbGF5ZWRDYW5kaWRhdGUiOiJjNTgwZWJkZGU3NTFjNDMyM2Q3MTgxYTQxYzBmMmEwYmU2YjdjMTMxIiwicmVwbGF5ZWRUcmVlIjoiZTBiZmUxZDkyZDJkZmNlODQzNGE1YjIzYmU1ZWVjMGM0ZGY5ZTljOSIsInF1ZXVlQXR0ZW1wdCI6IjAyNDljOWQ2ZDlhNjA0MjViMjkyOTZlMzkwNTIzYTNjMTU2YzM5YjZAN2ExNWI3ZDVmMTM5YWYxMzFjNGM3ZjJlZmM0ODJjMzRhY2UwMmU1ZSIsImFkbWlzc2lvblByb29mUm9vdCI6InNoYTI1NjplNGI2NDRiNjc4YjU4NTY3YmU4MDM0ZDQ5NzZmYjdhNzJlNzJmZDU2ZmM5NDU3NDJjNjZhYWI2YTE3Mjk3MGFlIiwiYWRtaXNzaW9uUHJvb2ZSb290cyI6WyJzaGEyNTY6ZDg5ZWNhYTAxMDRmYmZkNjY2MGQ5Nzk2MWE1NTUzNWRiY2UyY2QwZDFkZmE4MTlkZWYyZTI3ZDlkNWZmYmM4ZSIsInNoYTI1NjplNGI2NDRiNjc4YjU4NTY3YmU4MDM0ZDQ5NzZmYjdhNzJlNzJmZDU2ZmM5NDU3NDJjNjZhYWI2YTE3Mjk3MGFlIl0sInN0YXR1c0NvbnRleHQiOiJRdWV1ZSBmYW1pbHkgbGVhc2UvZDk5ZjNhOTE2NjczOWUwZCIsImxlYXNlUm9vdCI6InNoYTI1NjplMTI4YjkyYmI0YTg5NGY3YzY0MWU2ZGNjZWFlYzE3MTljMTQ3NjQ3NTkzYWE2ZTg0ZjJjNjYxODNjNmIwNDU0In0 -->