### PR TITLE
fix(release): repin alpha recovery runtime policy

### DIFF
--- a/docs/qualification/gates/release-admission-policy.json
+++ b/docs/qualification/gates/release-admission-policy.json
@@ -23,7 +23,7 @@
       "alpha": {
         "ref": "v3-alpha",
         "runtimeSha": "2e7e07902ac28d8f3edcfb81098ef9ebc7a91878",
-        "publicationRuntimeSha": "1d9b35b75e16d492e6d8b18c32504e89f8806855",
+        "publicationRuntimeSha": "09b8ee0385cf4927687282cecdf5aea4458ee647",
         "contractDigest": "sha256:5a6dc69d8905ed852260076da13d3aa3fa63533007dba706c164fe86f8b8f1e6",
         "contractLock": ".buildchain/alpha-contract-lock.json"
       },

--- a/scripts/verify-kungfu-release-admission.test.mjs
+++ b/scripts/verify-kungfu-release-admission.test.mjs
@@ -39,7 +39,7 @@ import {
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SOURCE_SHA = '1'.repeat(40);
 const RUNTIME_SHA = '2e7e07902ac28d8f3edcfb81098ef9ebc7a91878';
-const PUBLICATION_RUNTIME_SHA = '1d9b35b75e16d492e6d8b18c32504e89f8806855';
+const PUBLICATION_RUNTIME_SHA = '09b8ee0385cf4927687282cecdf5aea4458ee647';
 const RETIRED_PUBLICATION_RUNTIME_SHA =
   '21030efd277301d642fd9baaa1bd75f02dd3ddc6';
 const STABLE_RUNTIME_SHA = '9e904de2c85dbea7c799780ee166510b3336d812';


### PR DESCRIPTION
## Summary
- repin the Alpha.1 publication runtime policy to Buildchain `09b8ee0385cf4927687282cecdf5aea4458ee647`
- keep the executable release-admission test fixture aligned

## Validation
- focused release-admission tests: 5/5
- full protected pre-commit gate passed on agent-120
- no candidate, release, channel, or public asset bytes changed

## Recovery coordinates
- source candidate run: `31051528142`
- immutable release SHA: `f9e6b0e34bcdd6407b2a18206ace7982d64de2c8`
- controller source: `33121c400da100f077c4f10b343657b2636ee980`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This policy-only recovery controller repin does not alter an architecture contract or release payload."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above