### PR TITLE
fix(release): include Linux ARM64 CLI in candidates

### DIFF
--- a/product/scripts/cli-surface-qualification.mjs
+++ b/product/scripts/cli-surface-qualification.mjs
@@ -34,6 +34,19 @@ const PROFILE_BRIEF = {
 };
 const PRODUCT_SIGNATURE = 'Kungfu UNGFU™';
 const PRODUCT_PRINCIPLE = 'Never Guess. Facts Unfold.';
+const QUALIFIED_CLI_PLATFORMS = [
+  'darwin-arm64',
+  'linux-arm64',
+  'linux-x64',
+  'windows-x64',
+];
+const QUALIFIED_CLI_SYSTEMS = [
+  { id: 'darwin', label: 'macOS' },
+  { id: 'linux', label: 'Linux' },
+  { id: 'windows', label: 'Windows' },
+];
+const SHA1_PATTERN = /^[a-f0-9]{40}$/u;
+const SHA256_PATTERN = /^sha256:[a-f0-9]{64}$/u;
 
 function stable(value) {
   if (Array.isArray(value)) return value.map(stable);
@@ -50,6 +63,28 @@ function stable(value) {
 export function cliQualificationRoot(value) {
   const bytes = JSON.stringify(stable(value));
   return `sha256:${crypto.createHash('sha256').update(bytes).digest('hex')}`;
+}
+
+export function cliQualificationPlatform(
+  platform = process.platform,
+  architecture = process.arch,
+) {
+  const publicPlatform = platform === 'win32' ? 'windows' : platform;
+  return `${publicPlatform}-${architecture}`;
+}
+
+export function cliQualificationNonClaims(qualifiedPlatform) {
+  assert(
+    QUALIFIED_CLI_PLATFORMS.includes(qualifiedPlatform),
+    `unsupported CLI qualification platform: ${qualifiedPlatform}`,
+  );
+  const qualifiedSystem = qualifiedPlatform.split('-')[0];
+  return [
+    ...QUALIFIED_CLI_SYSTEMS.filter(({ id }) => id !== qualifiedSystem).map(
+      ({ label }) => `${label} is not qualified by this receipt.`,
+    ),
+    'Availability metadata does not activate a KFX contribution.',
+  ];
 }
 
 function digest(value) {
@@ -161,6 +196,17 @@ export function qualifyCliSurface({
     expectedCatalog?.schema === 'kungfu.cli-surface-catalog/v1',
     'expected CLI surface catalog is invalid',
   );
+  if (label === 'cli-archive') {
+    assert(identity.archive, 'CLI archive qualification omitted its filename');
+    assert(
+      SHA256_PATTERN.test(identity.archiveSha256 || ''),
+      'CLI archive qualification omitted its SHA-256 digest',
+    );
+    assert(
+      SHA1_PATTERN.test(identity.sourceCommit || ''),
+      'CLI archive qualification omitted its exact source commit',
+    );
+  }
   const expectedRoots = rootsFrom(expectedCatalog);
   const tempRoot = fs.mkdtempSync(
     path.join(os.tmpdir(), 'kungfu-cli-surface-qualification-'),
@@ -423,13 +469,19 @@ export function qualifyCliSurface({
           ).length,
         ]),
     );
+    const qualifiedPlatform = cliQualificationPlatform();
     const result = {
       schema: 'kungfu.cli-installed-product-qualification/v1',
       qualified: true,
       label,
       identity,
-      platform: `${process.platform}-${process.arch}`,
+      platform: qualifiedPlatform,
+      architecture: process.arch,
       version,
+      claims: {
+        installedProduct: true,
+        qualifiedPlatform,
+      },
       productIdentity: {
         exactMark: PRODUCT_SIGNATURE,
         principle: PRODUCT_PRINCIPLE,
@@ -481,11 +533,7 @@ export function qualifyCliSurface({
         sourceCheckoutRequired: false,
         guiPrivateStateRequired: false,
       },
-      nonClaims: [
-        'Linux is not qualified by this receipt.',
-        'Windows is not qualified by this receipt.',
-        'Availability metadata does not activate a KFX contribution.',
-      ],
+      nonClaims: cliQualificationNonClaims(qualifiedPlatform),
     };
     result.qualificationRoot = cliQualificationRoot(result);
     return result;

--- a/product/scripts/cli-surface-qualification.test.mjs
+++ b/product/scripts/cli-surface-qualification.test.mjs
@@ -3,6 +3,9 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import {
+  cliQualificationNonClaims,
+  cliQualificationPlatform,
+  cliQualificationRoot,
   cliSpawnSpecification,
   qualifyCliSurface,
 } from './cli-surface-qualification.mjs';
@@ -167,11 +170,21 @@ test('qualification binds help, canonical CLI, KFD-3 and mutation receipts', () 
     identity: {
       archive: 'kungfu-episodes-cli-fixture.tar.gz',
       archiveSha256: `sha256:${'a'.repeat(64)}`,
+      sourceCommit: '1'.repeat(40),
     },
     runCommand: runner(),
   });
   assert.equal(report.qualified, true);
   assert.equal(report.version, '4.0.0');
+  assert.equal(report.architecture, process.arch);
+  assert.deepEqual(report.claims, {
+    installedProduct: true,
+    qualifiedPlatform: report.platform,
+  });
+  assert.deepEqual(
+    report.nonClaims,
+    cliQualificationNonClaims(report.platform),
+  );
   assert.deepEqual(report.productIdentity, {
     exactMark: 'Kungfu UNGFU™',
     principle: 'Never Guess. Facts Unfold.',
@@ -221,6 +234,7 @@ test('verification binds the qualification to the exact archive digest', () => {
     identity: {
       archive: 'kungfu-episodes-cli-fixture.tar.gz',
       archiveSha256: `sha256:${'a'.repeat(64)}`,
+      sourceCommit: '1'.repeat(40),
     },
     runCommand: runner(),
   });
@@ -244,6 +258,7 @@ test('verification rejects a tampered qualification root', () => {
     identity: {
       archive: 'kungfu-episodes-cli-fixture.tar.gz',
       archiveSha256: `sha256:${'a'.repeat(64)}`,
+      sourceCommit: '1'.repeat(40),
     },
     runCommand: runner(),
   });
@@ -257,6 +272,42 @@ test('verification rejects a tampered qualification root', () => {
         archiveSha256: report.identity.archiveSha256,
       }),
     /qualification semantic root mismatch/u,
+  );
+});
+
+test('verification rejects a qualified platform OS non-claim', () => {
+  const report = qualifyCliSurface({
+    cli: '/fixture/kungfu',
+    expectedCatalog: catalog(),
+    label: 'cli-archive',
+    identity: {
+      archive: 'kungfu-episodes-cli-fixture.tar.gz',
+      archiveSha256: `sha256:${'a'.repeat(64)}`,
+      sourceCommit: '1'.repeat(40),
+    },
+    runCommand: runner(),
+  });
+  const system = report.platform.split('-')[0];
+  const qualifiedSystemLabel = {
+    darwin: 'macOS',
+    linux: 'Linux',
+    windows: 'Windows',
+  }[system];
+  report.nonClaims = [
+    `${qualifiedSystemLabel} is not qualified by this receipt.`,
+    ...cliQualificationNonClaims(report.platform),
+  ];
+  Reflect.deleteProperty(report, 'qualificationRoot');
+  report.qualificationRoot = cliQualificationRoot(report);
+  assert.throws(
+    () =>
+      verifyCliSurfaceQualification({
+        report,
+        expectedPlatform: report.platform,
+        archiveName: report.identity.archive,
+        archiveSha256: report.identity.archiveSha256,
+      }),
+    /qualification non-claims contradict the qualified platform/u,
   );
 });
 
@@ -276,6 +327,20 @@ test('qualification rejects a product without the secondary signature', () => {
       }),
     /omitted the secondary product signature/u,
   );
+});
+
+test('qualification non-claims exclude the exact qualified platform', () => {
+  const claims = cliQualificationNonClaims('linux-arm64');
+  assert.deepEqual(claims, [
+    'macOS is not qualified by this receipt.',
+    'Windows is not qualified by this receipt.',
+    'Availability metadata does not activate a KFX contribution.',
+  ]);
+  assert.ok(!claims.some((claim) => claim.includes('Linux')));
+});
+
+test('qualification maps the Windows runtime name to its public platform id', () => {
+  assert.equal(cliQualificationPlatform('win32', 'x64'), 'windows-x64');
 });
 
 test('qualification fails closed when installed roots drift', () => {

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -1836,6 +1836,7 @@ export function smokeCliProductArchive({ archivePath, archiveBase }) {
           identity: {
             archive: path.basename(archivePath),
             archiveSha256: sha256File(archivePath),
+            sourceCommit: upgradeIdentity.sourceCommit,
             ...(platformVerification ? { platformVerification } : {}),
           },
           environment: smokeEnv,

--- a/product/scripts/verify-cli-surface-qualification.mjs
+++ b/product/scripts/verify-cli-surface-qualification.mjs
@@ -5,9 +5,13 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { cliQualificationRoot } from './cli-surface-qualification.mjs';
+import {
+  cliQualificationNonClaims,
+  cliQualificationRoot,
+} from './cli-surface-qualification.mjs';
 
 const ROOT_PATTERN = /^sha256:[0-9a-f]{64}$/u;
+const SOURCE_PATTERN = /^[0-9a-f]{40}$/u;
 
 function assert(condition, message) {
   if (!condition) throw new Error(message);
@@ -29,6 +33,19 @@ export function verifyCliSurfaceQualification({
     report.platform === expectedPlatform,
     `platform mismatch: expected ${expectedPlatform}, got ${report.platform}`,
   );
+  const expectedArchitecture = expectedPlatform.split('-').at(-1);
+  assert(
+    report.architecture === expectedArchitecture,
+    `architecture mismatch: expected ${expectedArchitecture}, got ${report.architecture}`,
+  );
+  assert(
+    typeof report.version === 'string' && report.version.length > 0,
+    'qualification omitted the installed version',
+  );
+  assert(
+    SOURCE_PATTERN.test(report.identity?.sourceCommit || ''),
+    'qualification omitted an exact source commit',
+  );
   assert(
     report.identity?.archive === archiveName,
     `archive name mismatch: expected ${archiveName}, got ${report.identity?.archive}`,
@@ -44,6 +61,16 @@ export function verifyCliSurfaceQualification({
   assert(
     report.productIdentity?.verifiedFromInstalledCommand === true,
     'product identity was not verified from the installed command',
+  );
+  assert(
+    report.claims?.installedProduct === true &&
+      report.claims?.qualifiedPlatform === expectedPlatform,
+    'qualification claims do not bind the qualified platform',
+  );
+  assert(
+    JSON.stringify(report.nonClaims) ===
+      JSON.stringify(cliQualificationNonClaims(expectedPlatform)),
+    'qualification non-claims contradict the qualified platform',
   );
   assert(
     report.checks?.kfd3?.linkedApiCount > 0,
@@ -72,6 +99,9 @@ export function verifyCliSurfaceQualification({
     schema: 'kungfu.cli-installed-product-qualification-verification/v1',
     verified: true,
     platform: report.platform,
+    architecture: report.architecture,
+    version: report.version,
+    sourceCommit: report.identity.sourceCommit,
     archive: report.identity.archive,
     archiveSha256: report.identity.archiveSha256,
     qualificationRoot,

--- a/scripts/run-shifu-lifecycle.mjs
+++ b/scripts/run-shifu-lifecycle.mjs
@@ -207,9 +207,9 @@ export function buildchainBuildPlan(
   return [
     // The Buildchain install stage intentionally omits optional dependencies
     // so full-product lanes cannot consume prebuilt Kungfu artifacts. The
-    // bounded native ARM64 Core lane still needs libnode's exact host package
-    // to link from source, so restore platform optionals under the frozen lock
-    // before entering the Core lifecycle.
+    // bounded native ARM64 Core and CLI lane still needs libnode's exact host
+    // package to link from source, so restore platform optionals under the
+    // frozen lock before entering the Core lifecycle.
     { args: ['install', '--frozen-lockfile'], env: {} },
     { args: ['rebuild:core'], env: {} },
     { args: ['freeze'], env: { KF_REQUIRE_NATIVE_HOST: '1' } },
@@ -219,6 +219,7 @@ export function buildchainBuildPlan(
         KF_PACKAGE_STAGE_DIR: path.join(root, 'product', 'release', 'npm'),
       },
     },
+    { args: ['dist:cli'], env: {} },
   ];
 }
 

--- a/scripts/run-shifu-lifecycle.test.mjs
+++ b/scripts/run-shifu-lifecycle.test.mjs
@@ -31,7 +31,7 @@ test('Buildchain keeps full product builds on the three established platforms', 
   }
 });
 
-test('Buildchain gives Linux ARM64 one bounded Core-only build lane', () => {
+test('Buildchain gives Linux ARM64 one bounded Core and CLI build lane', () => {
   const root = path.resolve('/repo');
   assert.deepEqual(buildchainBuildPlan('linux', 'arm64', root), [
     { args: ['install', '--frozen-lockfile'], env: {} },
@@ -43,6 +43,7 @@ test('Buildchain gives Linux ARM64 one bounded Core-only build lane', () => {
         KF_PACKAGE_STAGE_DIR: path.join(root, 'product', 'release', 'npm'),
       },
     },
+    { args: ['dist:cli'], env: {} },
   ]);
 });
 

--- a/scripts/upgrade-publication-admission.mjs
+++ b/scripts/upgrade-publication-admission.mjs
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { assertUpgradePublicationEligible } from '../product/scripts/upgrade-manifest.mjs';
+import { verifyCliSurfaceQualification } from '../product/scripts/verify-cli-surface-qualification.mjs';
 import {
   loadUpgradeQualificationContract,
   qualificationContentRoot,
@@ -28,6 +29,36 @@ const EXPECTED_CANDIDATE_PLATFORM_ROLES = {
   'product-support': ['linux-arm64'],
   'product-upgrade': ['darwin-arm64', 'linux-x64', 'win32-x64'],
 };
+const EXPECTED_CLI_PLATFORMS = [
+  {
+    bundlePlatformId: 'darwin-arm64',
+    platformId: 'darwin-arm64',
+    platform: 'darwin',
+    architecture: 'arm64',
+    archive: 'kungfu-episodes-cli-darwin-arm64.tar.gz',
+  },
+  {
+    bundlePlatformId: 'linux-arm64',
+    platformId: 'linux-arm64',
+    platform: 'linux',
+    architecture: 'arm64',
+    archive: 'kungfu-episodes-cli-linux-arm64.tar.gz',
+  },
+  {
+    bundlePlatformId: 'linux-x64',
+    platformId: 'linux-x64',
+    platform: 'linux',
+    architecture: 'x64',
+    archive: 'kungfu-episodes-cli-linux-x64.tar.gz',
+  },
+  {
+    bundlePlatformId: 'win32-x64',
+    platformId: 'windows-x64',
+    platform: 'win32',
+    architecture: 'x64',
+    archive: 'kungfu-episodes-cli-windows-x64.zip',
+  },
+];
 export const PRODUCT_UPGRADE_PUBLICATION_ADMISSION_SCHEMA =
   'kungfu.product-upgrade.publication-admission/v1';
 export const PRODUCT_UPGRADE_PUBLICATION_CAPSULE_SCHEMA =
@@ -294,10 +325,100 @@ function candidatePlatformRoot(bundles) {
   );
 }
 
+export function verifyCliPublicationPayloads({
+  payloadRoot,
+  bundles,
+  expectedVersion,
+  acceptedSources,
+}) {
+  const qualified = [];
+  for (const expected of EXPECTED_CLI_PLATFORMS) {
+    const matchingBundles = bundles.filter(
+      (bundle) => bundle.platformId === expected.bundlePlatformId,
+    );
+    if (matchingBundles.length !== 1) {
+      throw new Error(
+        `CLI publication requires exactly one ${expected.platformId} payload bundle; found ${matchingBundles.length}`,
+      );
+    }
+    const bundleRoot = path.join(payloadRoot, matchingBundles[0].name);
+    const archivePath = path.join(
+      bundleRoot,
+      'product',
+      'release',
+      'cli',
+      expected.archive,
+    );
+    const qualificationName = expected.archive.replace(
+      /\.(?:tar\.gz|zip)$/u,
+      '.qualification.json',
+    );
+    const qualificationPath = path.join(
+      bundleRoot,
+      'product',
+      'release',
+      'cli',
+      qualificationName,
+    );
+    if (!fs.existsSync(archivePath) || !fs.statSync(archivePath).isFile()) {
+      throw new Error(
+        `CLI publication is missing ${expected.platformId} archive ${expected.archive}`,
+      );
+    }
+    if (
+      !fs.existsSync(qualificationPath) ||
+      !fs.statSync(qualificationPath).isFile()
+    ) {
+      throw new Error(
+        `CLI publication is missing ${expected.platformId} qualification ${qualificationName}`,
+      );
+    }
+    const report = readJson(
+      qualificationPath,
+      `${expected.platformId} CLI qualification`,
+    );
+    const archiveRoot = fileRoot(archivePath);
+    const verification = verifyCliSurfaceQualification({
+      report,
+      expectedPlatform: expected.platformId,
+      archiveName: expected.archive,
+      archiveSha256: archiveRoot,
+    });
+    if (
+      report.architecture !== expected.architecture ||
+      report.version !== expectedVersion ||
+      !acceptedSources.has(report.identity?.sourceCommit)
+    ) {
+      throw new Error(
+        `${expected.platformId} CLI qualification identity is not bound to the release candidate`,
+      );
+    }
+    qualified.push({
+      platform: expected.platform,
+      architecture: expected.architecture,
+      platformId: expected.platformId,
+      archive: {
+        path: safeRelative(payloadRoot, archivePath, 'CLI archive'),
+        name: expected.archive,
+        digest: archiveRoot,
+      },
+      qualification: {
+        path: safeRelative(payloadRoot, qualificationPath, 'CLI qualification'),
+        root: verification.qualificationRoot,
+      },
+      version: report.version,
+      sourceCommit: report.identity.sourceCommit,
+    });
+  }
+  return qualified;
+}
+
 function toolingRoot() {
   const files = [
     'scripts/upgrade-publication-admission.mjs',
     'scripts/upgrade-qualification.mjs',
+    'product/scripts/cli-surface-qualification.mjs',
+    'product/scripts/verify-cli-surface-qualification.mjs',
     'product/scripts/upgrade-manifest.mjs',
   ].map((relativePath) => ({
     path: relativePath,
@@ -1053,6 +1174,13 @@ export function verifyUpgradePublicationPayloads({
     .filter((entry) => entry.isDirectory())
     .map((entry) => path.join(payloadRoot, entry.name))
     .sort((left, right) => left.localeCompare(right));
+  const artifacts = candidateArtifactRoot(payloadRoot);
+  const cliArtifacts = verifyCliPublicationPayloads({
+    payloadRoot,
+    bundles: artifacts.bundles,
+    expectedVersion,
+    acceptedSources,
+  });
   let admitted = bundleRoots
     .map((bundleRoot) =>
       verifyBundle({
@@ -1152,6 +1280,7 @@ export function verifyUpgradePublicationPayloads({
         ),
       ),
     credentialIsland: credentialIsland[0],
+    cliArtifacts,
   };
 }
 
@@ -1168,6 +1297,7 @@ function receiptAdmission(admission, payloadRoot) {
       architecture: entry.architecture,
       path: safeRelative(payloadRoot, entry.manifestPath, 'upgrade manifest'),
     })),
+    cliArtifacts: admission.cliArtifacts,
     credentialIsland: {
       platformId: admission.credentialIsland.platformId,
       runtimeSha: admission.credentialIsland.runtimeSha,
@@ -1195,6 +1325,8 @@ export function createUpgradePublicationAdmission({
 } = {}) {
   const resolvedPayloadRoot = fs.realpathSync(payloadRoot);
   const resolvedPassportPath = fs.realpathSync(releaseCandidatePassportPath);
+  const artifacts = candidateArtifactRoot(resolvedPayloadRoot);
+  assertCandidateBundleRoles(artifacts.bundles);
   const admission = verifyUpgradePublicationPayloads({
     payloadRoot: resolvedPayloadRoot,
     releaseCandidatePassportPath: resolvedPassportPath,
@@ -1203,8 +1335,6 @@ export function createUpgradePublicationAdmission({
   });
   const passport = readJson(resolvedPassportPath, 'release-candidate passport');
   const sources = [...releaseCandidateSources(passport)].sort();
-  const artifacts = candidateArtifactRoot(resolvedPayloadRoot);
-  assertCandidateBundleRoles(artifacts.bundles);
   const passportByteRoot = fileRoot(resolvedPassportPath);
   const roots = {
     source: contentRoot(sources),
@@ -1409,6 +1539,18 @@ export function verifyUpgradePublicationAdmission({
     throw new Error('product admission candidate file inventory drift');
   }
   assertCandidateBundleRoles(artifacts.bundles);
+  const cliArtifacts = verifyCliPublicationPayloads({
+    payloadRoot: resolvedPayloadRoot,
+    bundles: artifacts.bundles,
+    expectedVersion: receipt.identity?.version,
+    acceptedSources: new Set(sources),
+  });
+  if (
+    JSON.stringify(canonical(receipt.admission?.cliArtifacts || [])) !==
+    JSON.stringify(canonical(cliArtifacts))
+  ) {
+    throw new Error('product admission CLI publication inventory drift');
+  }
   if (
     JSON.stringify(receipt.identity?.sources || []) !== JSON.stringify(sources)
   ) {

--- a/scripts/upgrade-publication-admission.test.mjs
+++ b/scripts/upgrade-publication-admission.test.mjs
@@ -7,6 +7,7 @@ import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 
+import { cliQualificationRoot } from '../product/scripts/cli-surface-qualification.mjs';
 import {
   PRODUCT_UPGRADE_PUBLICATION_ADMISSION_FILE,
   PRODUCT_UPGRADE_PUBLICATION_ADMISSION_SCHEMA,
@@ -74,6 +75,55 @@ function contentRoot(value) {
 function writeJson(filePath, value) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function rewriteCliQualification(filePath, mutate) {
+  const report = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  Reflect.deleteProperty(report, 'qualificationRoot');
+  mutate(report);
+  report.qualificationRoot = cliQualificationRoot(report);
+  writeJson(filePath, report);
+}
+
+function cliQualification(platform, architecture, archive, archiveBytes) {
+  const qualificationPlatform = platform === 'win32' ? 'windows' : platform;
+  const platformId = `${qualificationPlatform}-${architecture}`;
+  const body = {
+    schema: 'kungfu.cli-installed-product-qualification/v1',
+    qualified: true,
+    label: 'cli-archive',
+    identity: {
+      archive,
+      archiveSha256: `sha256:${sha256(archiveBytes)}`,
+      sourceCommit: SOURCE,
+    },
+    platform: platformId,
+    architecture,
+    version: VERSION,
+    claims: { installedProduct: true, qualifiedPlatform: platformId },
+    productIdentity: { verifiedFromInstalledCommand: true },
+    checks: {
+      kfd3: { linkedApiCount: 1 },
+      mutationPlanReceipt: {
+        planReplayStable: true,
+        receiptVerified: true,
+      },
+    },
+    isolation: {
+      sourceCheckoutRequired: false,
+      guiPrivateStateRequired: false,
+    },
+    nonClaims: [
+      ...(qualificationPlatform === 'darwin'
+        ? ['Linux', 'Windows']
+        : qualificationPlatform === 'linux'
+          ? ['macOS', 'Windows']
+          : ['macOS', 'Linux']
+      ).map((candidate) => `${candidate} is not qualified by this receipt.`),
+      'Availability metadata does not activate a KFX contribution.',
+    ],
+  };
+  return { ...body, qualificationRoot: cliQualificationRoot(body) };
 }
 
 function signedEvidence(manifest) {
@@ -192,8 +242,8 @@ function platformFixture(root, platform, architecture) {
         : `Kungfu-${platform}.zip`;
   const cliName =
     platform === 'win32'
-      ? `kungfu-cli-${platform}.zip`
-      : `kungfu-cli-${platform}.tar.gz`;
+      ? `kungfu-episodes-cli-windows-${architecture}.zip`
+      : `kungfu-episodes-cli-${platform}-${architecture}.tar.gz`;
   const desktopBytes = Buffer.from(`desktop-${platform}`);
   const cliBytes = Buffer.from(`cli-${platform}`);
   const desktopPath = path.join(releaseRoot, 'desktop', desktopName);
@@ -202,6 +252,15 @@ function platformFixture(root, platform, architecture) {
   fs.mkdirSync(path.dirname(cliPath), { recursive: true });
   fs.writeFileSync(desktopPath, desktopBytes);
   fs.writeFileSync(cliPath, cliBytes);
+  const cliQualificationPath = path.join(
+    releaseRoot,
+    'cli',
+    `kungfu-episodes-cli-${platform === 'win32' ? 'windows' : platform}-${architecture}.qualification.json`,
+  );
+  writeJson(
+    cliQualificationPath,
+    cliQualification(platform, architecture, cliName, cliBytes),
+  );
   const manifest = {
     schema: 'kungfu.product-upgrade.manifest/v1',
     productVersion: VERSION,
@@ -255,6 +314,7 @@ function platformFixture(root, platform, architecture) {
     bundleRoot,
     desktopPath,
     cliPath,
+    cliQualificationPath,
     desktopManifestPath,
     cliManifestPath,
     evidencePath,
@@ -427,7 +487,21 @@ function supportFixture(root) {
     platform: { id: 'linux-arm64' },
   });
   fs.writeFileSync(path.join(bundleRoot, 'core-qualification.txt'), 'passed\n');
-  return { bundleRoot };
+  const cliRoot = path.join(bundleRoot, 'product', 'release', 'cli');
+  const cliName = 'kungfu-episodes-cli-linux-arm64.tar.gz';
+  const cliPath = path.join(cliRoot, cliName);
+  const cliBytes = Buffer.from('cli-linux-arm64');
+  fs.mkdirSync(cliRoot, { recursive: true });
+  fs.writeFileSync(cliPath, cliBytes);
+  const cliQualificationPath = path.join(
+    cliRoot,
+    'kungfu-episodes-cli-linux-arm64.qualification.json',
+  );
+  writeJson(
+    cliQualificationPath,
+    cliQualification('linux', 'arm64', cliName, cliBytes),
+  );
+  return { bundleRoot, cliPath, cliQualificationPath };
 }
 
 function fixture() {
@@ -474,7 +548,7 @@ function withFixture(callback) {
   }
 }
 
-test('publication admission verifies three native payloads plus authoritative signed macOS bytes', () => {
+test('publication admission verifies a complete four-platform CLI payload plus authoritative signed macOS bytes', () => {
   withFixture((value) => {
     const admitted = verify(value);
     assert.deepEqual(admitted.platforms, [
@@ -501,6 +575,31 @@ test('publication admission verifies three native payloads plus authoritative si
     assert.equal(admitted.credentialIsland.runtimeSha, RUNTIME);
     assert.equal(admitted.credentialIsland.certificateSha1, CERTIFICATE_SHA1);
     assert.equal(admitted.releasePassportRoot, RELEASE_CANDIDATE_PASSPORT_ROOT);
+    assert.deepEqual(
+      admitted.cliArtifacts.map(({ platformId }) => platformId),
+      ['darwin-arm64', 'linux-arm64', 'linux-x64', 'windows-x64'],
+    );
+    const linuxArm64 = admitted.cliArtifacts.find(
+      ({ platformId }) => platformId === 'linux-arm64',
+    );
+    assert.deepEqual(
+      {
+        archive: linuxArm64.archive.name,
+        platform: linuxArm64.platform,
+        architecture: linuxArm64.architecture,
+        version: linuxArm64.version,
+        sourceCommit: linuxArm64.sourceCommit,
+        digest: linuxArm64.archive.digest,
+      },
+      {
+        archive: 'kungfu-episodes-cli-linux-arm64.tar.gz',
+        platform: 'linux',
+        architecture: 'arm64',
+        version: VERSION,
+        sourceCommit: SOURCE,
+        digest: `sha256:${sha256(fs.readFileSync(value.support.cliPath))}`,
+      },
+    );
     assert.equal(admitted.campaignRoots.length, 3);
     assert.deepEqual(admitted.channelIndexRoots, [`sha256:${'7'.repeat(64)}`]);
     assert.equal(
@@ -511,6 +610,45 @@ test('publication admission verifies three native payloads plus authoritative si
           campaign.targetVersion === VERSION,
       ),
       true,
+    );
+  });
+});
+
+test('publication admission rejects an omitted Linux ARM64 CLI archive', () => {
+  withFixture((value) => {
+    fs.rmSync(value.support.cliPath);
+    assert.throws(
+      () => verify(value),
+      /missing linux-arm64 archive kungfu-episodes-cli-linux-arm64\.tar\.gz/u,
+    );
+  });
+});
+
+test('publication admission rejects an omitted Linux ARM64 CLI qualification', () => {
+  withFixture((value) => {
+    fs.rmSync(value.support.cliQualificationPath);
+    assert.throws(
+      () => verify(value),
+      /missing linux-arm64 qualification kungfu-episodes-cli-linux-arm64\.qualification\.json/u,
+    );
+  });
+});
+
+test('publication admission rejects tampered Linux ARM64 CLI bytes', () => {
+  withFixture((value) => {
+    fs.appendFileSync(value.support.cliPath, 'tampered');
+    assert.throws(() => verify(value), /archive SHA256 mismatch/u);
+  });
+});
+
+test('publication admission rejects a Linux ARM64 CLI source mismatch', () => {
+  withFixture((value) => {
+    rewriteCliQualification(value.support.cliQualificationPath, (report) => {
+      report.identity.sourceCommit = 'f'.repeat(40);
+    });
+    assert.throws(
+      () => verify(value),
+      /linux-arm64 CLI qualification identity is not bound to the release candidate/u,
     );
   });
 });
@@ -646,7 +784,10 @@ test('publication admission rejects missing retained qualification evidence', ()
 test('publication admission rejects payload byte drift after manifest creation', () => {
   withFixture((value) => {
     fs.appendFileSync(value.platforms.win32.cliPath, 'drift');
-    assert.throws(() => verify(value), /artifact size mismatch/);
+    assert.throws(
+      () => verify(value),
+      /(?:artifact size mismatch|archive SHA256 mismatch)/u,
+    );
   });
 });
 
@@ -684,7 +825,7 @@ test('publication admission rejects an incomplete platform matrix', () => {
     });
     assert.throws(
       () => verify(value),
-      /exactly one admitted linux payload; found 0/,
+      /CLI publication requires exactly one linux-x64 payload bundle; found 0/,
     );
   });
 });
@@ -734,6 +875,7 @@ test('candidate finalization seals one rooted product admission receipt into its
       written.receipt.receiptRoot,
     );
     assert.equal(written.receipt.claims.externalPublication, false);
+    assert.equal(written.receipt.admission.cliArtifacts.length, 4);
     assert.equal(written.receipt.candidate.bundleCount, 5);
     assert.deepEqual(
       written.receipt.candidate.bundles.map(({ role }) => role).sort(),


### PR DESCRIPTION
## Summary

Include the qualified Linux ARM64 CLI in the normal Kungfu release candidate and fail closed when any required four-platform CLI payload or its exact qualification evidence is missing or inconsistent. This PR does not publish, promote, tag, or otherwise trigger alpha.2.

## Related issue

None.

## Changes

- Run the existing `dist:cli` product path in the Linux ARM64 Buildchain lane.
- Bind each CLI archive to its exact public platform, architecture, version, source identity, digest, claims, and non-claims.
- Require the complete Darwin ARM64, Linux ARM64, Linux x64, and Windows x64 CLI payload in publication admission while preserving the existing five-bundle candidate topology.
- Add fail-closed coverage for omitted, tampered, source-mismatched, and contradictory Linux ARM64 evidence.

## Verification

- `SHIFU_NATIVE=0 ./shifu test:cli-surface-qualification` — 63 passed, 0 failed.
- `SHIFU_NATIVE=0 ./shifu test:upgrade-qualification` — 56 passed, 0 failed.
- `SHIFU_NATIVE=0 ./shifu test:npm-core-platform-distribution` — 103 passed, 3 Windows-only skips, 0 failed.
- `SHIFU_NATIVE=0 ./shifu test:alpha-promotion-preflight` — 78 passed, 0 failed.
- Biome 1.9.4 checked all eight changed files successfully in an arm64 Linux container.
- The release Task Chart classified 507 paths with no unclassified paths or context-admission omissions.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded release-candidate completeness fix applies the existing exact artifact and qualification contract without changing architecture authority or opening a release channel."
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: extends

This extends the current v4 release-readiness evidence to the qualified Linux ARM64 CLI without opening, settling, or superseding a Stage.

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change is limited to release candidate assembly and fail-closed qualification/admission. Verification binds the exact source, archive paths, bytes, digests, public platform identities, and receipt roots; no publication workflow was dispatched.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (the executable release contract and regression fixtures were updated; no user-facing documentation change is required)