### PR TITLE
fix(product): restore Linux node-pty closure

### DIFF
--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -1026,16 +1026,13 @@ export function stageNodePtyForCli(
     const nativeDirectory = path.join('build', 'Release');
     const targetNativeDirectory = path.join(target, nativeDirectory);
     fs.mkdirSync(targetNativeDirectory, { recursive: true });
-    for (const runtime of ['pty.node', 'spawn-helper']) {
-      const input = path.join(source, nativeDirectory, runtime);
-      if (!fs.existsSync(input) || !fs.lstatSync(input).isFile()) {
-        throw new Error(
-          `required Linux node-pty runtime not found: ${rel(input)}`,
-        );
-      }
-      fs.copyFileSync(input, path.join(targetNativeDirectory, runtime));
+    const input = path.join(source, nativeDirectory, 'pty.node');
+    if (!fs.existsSync(input) || !fs.lstatSync(input).isFile()) {
+      throw new Error(
+        `required Linux node-pty runtime not found: ${rel(input)}`,
+      );
     }
-    fs.chmodSync(path.join(targetNativeDirectory, 'spawn-helper'), 0o755);
+    fs.copyFileSync(input, path.join(targetNativeDirectory, 'pty.node'));
   } else if (platform === 'darwin') {
     fs.chmodSync(
       path.join(

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -473,12 +473,8 @@ test('Linux CLI staging restores only the exact node-pty native runtime closure'
     'native-addon\n',
   );
   assert.equal(
-    fs.readFileSync(path.join(target, 'build/Release/spawn-helper'), 'utf8'),
-    'native-helper\n',
-  );
-  assert.notEqual(
-    fs.statSync(path.join(target, 'build/Release/spawn-helper')).mode & 0o111,
-    0,
+    fs.existsSync(path.join(target, 'build/Release/spawn-helper')),
+    false,
   );
   assert.equal(fs.existsSync(path.join(target, 'build/Debug')), false);
   assert.equal(
@@ -523,24 +519,6 @@ test('Linux CLI staging fails closed when the node-pty native addon is missing',
   assert.throws(
     () => stageNodePtyForCli(source, target, 'linux', 'x64'),
     /required Linux node-pty runtime not found/u,
-  );
-});
-
-test('Linux CLI staging fails closed when the node-pty spawn helper is missing', (t) => {
-  const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-node-pty-'));
-  t.after(() => fs.rmSync(parent, { recursive: true, force: true }));
-  const source = path.join(parent, 'source');
-  const target = path.join(parent, 'target');
-  fs.mkdirSync(path.join(source, 'build', 'Release'), { recursive: true });
-  fs.writeFileSync(path.join(source, 'package.json'), '{}\n');
-  fs.writeFileSync(
-    path.join(source, 'build', 'Release', 'pty.node'),
-    'native-addon\n',
-  );
-
-  assert.throws(
-    () => stageNodePtyForCli(source, target, 'linux', 'x64'),
-    /required Linux node-pty runtime not found: .*spawn-helper/u,
   );
 });
 


### PR DESCRIPTION
## Summary

Restore the actual Linux node-pty runtime closure after Product Build run 31303771464 proved that node-pty 1.1.0 does not build a Linux spawn-helper. Linux bundles now require and stage only build/Release/pty.node; the existing macOS helper contract and executable-bit enforcement remain unchanged.

## Related issue

Follow-up to #2661 and Product Build run 31303771464.

## Changes

- stage only pty.node for the Linux CLI runtime
- keep Darwin spawn-helper staging and chmod behavior unchanged
- assert that a stray Linux helper is not copied
- keep missing Linux pty.node fail-closed coverage

## Verification

- ./shifu test:cli-surface-qualification (62 passed, 0 failed)
- exact candidate ace1b1d07d085df2686f1ada52d4db17a9c19406 is linearly based on dev/v4/v4.0@bdba12bdb4cbbd295955bea4dc36c35e949142c0
- clean GitHub source acceptance is required before merge

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix restores the existing platform-specific node-pty runtime closure and does not alter an architecture contract."
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change is limited to the Linux CLI product staging closure. It does not publish artifacts or weaken isolation; exact-head Product qualification remains required after protected merge.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed