### PR TITLE
fix(release): repin alpha recovery runtime policy

### DIFF
--- a/docs/qualification/gates/release-admission-policy.json
+++ b/docs/qualification/gates/release-admission-policy.json
@@ -23,7 +23,7 @@
       "alpha": {
         "ref": "v3-alpha",
         "runtimeSha": "2e7e07902ac28d8f3edcfb81098ef9ebc7a91878",
-        "publicationRuntimeSha": "09b8ee0385cf4927687282cecdf5aea4458ee647",
+        "publicationRuntimeSha": "022d2e94c6bf908856c8dd263cb45c6b5836dc52",
         "contractDigest": "sha256:5a6dc69d8905ed852260076da13d3aa3fa63533007dba706c164fe86f8b8f1e6",
         "contractLock": ".buildchain/alpha-contract-lock.json"
       },

--- a/scripts/verify-kungfu-release-admission.test.mjs
+++ b/scripts/verify-kungfu-release-admission.test.mjs
@@ -39,7 +39,7 @@ import {
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SOURCE_SHA = '1'.repeat(40);
 const RUNTIME_SHA = '2e7e07902ac28d8f3edcfb81098ef9ebc7a91878';
-const PUBLICATION_RUNTIME_SHA = '09b8ee0385cf4927687282cecdf5aea4458ee647';
+const PUBLICATION_RUNTIME_SHA = '022d2e94c6bf908856c8dd263cb45c6b5836dc52';
 const RETIRED_PUBLICATION_RUNTIME_SHA =
   '21030efd277301d642fd9baaa1bd75f02dd3ddc6';
 const STABLE_RUNTIME_SHA = '9e904de2c85dbea7c799780ee166510b3336d812';


### PR DESCRIPTION
## Summary
- repin the Alpha.1 publication runtime policy to protected Buildchain `022d2e94c6bf908856c8dd263cb45c6b5836dc52`
- keep the executable release-admission test fixture aligned

## Validation
- Task Chart: pass with zero required omissions
- focused release-admission tests: 9 pass, 1 designed skip
- full staged pre-commit gate: pass
- source acceptance: 1091 tests reached; 1079 pass, 11 skip, one Mac-only cold fixture failed because `pytest` was absent from PATH; tracked and untracked roots remained unchanged
- no candidate, Release, installer, channel, Passport, signature, or public asset bytes changed

## Recovery coordinates
- source candidate run: `31051528142`
- immutable source SHA: `ad7c7db6df076f969c5939728bcbe70ccd4771b3`
- immutable source tree: `67a93b5831596555e7c29104421de3a0b97eb865`
- immutable release SHA: `f9e6b0e34bcdd6407b2a18206ace7982d64de2c8`
- policy source: `daea93b704546b874f513042c445a7db419cb742`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This policy-only recovery controller repin does not alter an architecture contract or release payload."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above