### PR TITLE
docs(install): clarify the version-independent setup path

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ same Work across Codex, Claude, OpenCode, Amp, or your own execution surface.
 
 ## Start where you already work
 
-Once the `kungfu` command is on your
-[`PATH`](docs/guides/installing-cli.md#make-kungfu-available-in-path), choose the
-entry that matches how you already work.
+First, [install Kungfu and make the `kungfu` command available on your
+`PATH`](docs/guides/installing-cli.md), then choose the entry that matches how
+you already work.
 
 **Stay in your current Agent.** Paste this sentence into Codex, Claude, OpenCode,
 Amp, or another Agent that can run local commands:

--- a/docs/README.md
+++ b/docs/README.md
@@ -129,8 +129,9 @@ public execution vocabulary.
 - [Durability Configuration](guides/durability-configuration.md) — choose a
   requested persistence profile and understand admission, effects, costs,
   receipts, timeouts, and recovery.
-- [Make the Kungfu command available](guides/installing-cli.md) — expose the
-  desktop CLI to an existing Agent, or bootstrap and verify a standalone CLI.
+- [Install the Kungfu CLI](guides/installing-cli.md) — use the version-independent
+  public routes, expose the desktop CLI to an existing Agent, or verify a pinned
+  standalone installation.
 - [Upgrade Kungfu](guides/upgrading.md) — check, download, install, defer,
   activate, recover, and retain versioned desktop/CLI runtime images safely.
 - [Exit, Migration, and Version Compatibility](guides/exit-and-version-compatibility.md)

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -17,7 +17,7 @@ review the plan from `kungfu recover`.
 - [Configuration](config.md)
 - [Native Agent adapters](native-agent-adapters.md)
 - [Durability Configuration](durability-configuration.md)
-- [Make the Kungfu command available and install the standalone CLI](installing-cli.md)
+- [Install the Kungfu CLI](installing-cli.md)
 - [Upgrade Kungfu](upgrading.md)
 - [Exit, Migration, and Version Compatibility](exit-and-version-compatibility.md)
 - [Debugging](debugging.md)

--- a/docs/guides/installing-cli.md
+++ b/docs/guides/installing-cli.md
@@ -1,6 +1,38 @@
 # Install the standalone Kungfu CLI
 
+## Quick install
+
+The public routes below stay the same across Kungfu versions. They resolve the
+release currently selected by the Buildchain publication state rendered on the
+public [installation page](https://kungfu.tech/install/). That page owns the
+current version, channel, Desktop GUI downloads, byte sizes, and SHA-256
+digests.
+
+macOS and Linux use the reviewed POSIX installer:
+
+```sh
+curl -fsSL https://kungfu.tech/install.sh | sh
+```
+
+Windows PowerShell uses the reviewed PowerShell installer:
+
+```powershell
+irm https://kungfu.tech/install.ps1 | iex
+```
+
+These are convenience forms, not a claim that TLS alone proves the release.
+Each friendly route is a Buildchain-bound projection of the selected signed
+release channel. It cannot reinterpret a version, change channels, or authorize
+product bytes on its own.
+
+Stable and Alpha remain distinct. An Alpha-only public launch must say `alpha`
+in the page, installer plan, installed status, and retained receipts. A missing
+qualified Stable channel fails honestly instead of silently selecting Alpha.
+
 ## Make Kungfu available in PATH
+
+Standalone archive installations print their per-user bin directory. Add that
+exact directory to the environment used by your shell and agent.
 
 If you installed the desktop app on macOS, open **Kungfu → Install 'kungfu'
 Command in PATH**. The app creates `/usr/local/bin/kungfu` as a launcher for the
@@ -19,41 +51,9 @@ prompt includes the exact local CLI path, so the agent does not have to guess
 where the app was installed. Do not hand-create a symlink to a guessed app
 bundle path; moving or replacing the app would leave that guess stale.
 
-Standalone archive installations print their per-user bin directory. Add that
-exact directory to the environment used by your shell and agent, then run the
-same verification commands above. The release and ownership boundary for that
-installer follows below.
+The release and ownership boundary for both installation paths follows below.
 
-> **Current publication:** `v4.0.0-alpha.1` is available through the
-> Buildchain-qualified installers below and the public installation page. It is
-> an Alpha prerelease, not a Stable channel. If a future request returns a 404,
-> an explicit unavailable result, or evidence that does not bind the requested
-> version and channel, fail closed rather than substituting a source fixture.
-
-## Convenience commands
-
-Unix-like systems use the reviewed POSIX installer:
-
-```sh
-curl --fail --proto '=https' --tlsv1.2 https://kungfu.tech/install.sh | sh
-```
-
-Windows PowerShell uses the reviewed PowerShell installer:
-
-```powershell
-irm https://kungfu.tech/install.ps1 | iex
-```
-
-These are convenience forms, not a claim that TLS alone proves the release.
-The friendly route is a Buildchain-bound projection of one signed release
-channel. It cannot reinterpret a version, change channels, or authorize product
-bytes on its own.
-
-Stable and Alpha remain distinct. An Alpha-only public launch must say `alpha`
-in the page, installer plan, installed status, and retained receipts. A missing
-qualified Stable channel fails honestly instead of silently selecting Alpha.
-
-## Download, inspect, pin, then run
+## Higher assurance: download, inspect, pin, then run
 
 For higher-assurance or automated use:
 
@@ -68,14 +68,14 @@ Example shape:
 ```sh
 curl --fail --proto '=https' --tlsv1.2 \
   --output install.sh \
-  https://kungfu.tech/installers/v1/alpha/CHANNEL_ROOT/install.sh
+  https://kungfu.tech/installers/v1/CHANNEL/CHANNEL_ROOT/install.sh
 shasum -a 256 install.sh
 sed -n '1,240p' install.sh
-sh install.sh --channel alpha --version VERSION
+sh install.sh --channel CHANNEL --version VERSION
 ```
 
-The installation page supplies the concrete `CHANNEL_ROOT`, `VERSION`, byte
-size, and digest. Never copy placeholders from this guide.
+The installation page supplies the concrete `CHANNEL`, `CHANNEL_ROOT`,
+`VERSION`, byte size, and digest. Never copy placeholders from this guide.
 
 ## Options and filesystem ownership
 
@@ -112,9 +112,8 @@ and checks:
   `archive` install source;
 - release-manifest and artifact roots;
 - archive byte size and SHA-256 digest;
-- retained signing evidence plus macOS code-signing where applicable; the first
-  Windows Alpha is intentionally unsigned and relies on the exact signed-channel
-  digest instead of Authenticode; and
+- retained platform-signing evidence where required by the selected release,
+  together with any explicit signing exception bound to that publication; and
 - the extracted product and bundled runtime identity.
 
 The staged CLI repeats the signed-channel and product checks through

--- a/scripts/check-project-work-agent-product.test.mjs
+++ b/scripts/check-project-work-agent-product.test.mjs
@@ -107,9 +107,10 @@ test('Project, Work, and Agent are the complete first-layer object model', () =>
 
 test('README first-use paths converge on Agent-first onboarding', () => {
   const readme = fs.readFileSync(path.join(ROOT, 'README.md'), 'utf8');
-  const pathGuide = readme.indexOf(
-    'docs/guides/installing-cli.md#make-kungfu-available-in-path',
+  const explicitInstallEntry = readme.indexOf(
+    'install Kungfu and make the `kungfu` command available',
   );
+  const installGuide = readme.indexOf('docs/guides/installing-cli.md');
   const agentBrief = readme.indexOf('Run `kungfu agent brief`');
   const runAgent = readme.indexOf('kungfu run codex');
   const demoStart = readme.indexOf(
@@ -134,10 +135,14 @@ test('README first-use paths converge on Agent-first onboarding', () => {
   const firstUseEnd = readme.indexOf('\n## What Kungfu preserves', demoEnd);
 
   assert.ok(
-    pathGuide > 0,
-    'README must protect app-only users with PATH setup',
+    explicitInstallEntry > 0,
+    'README must present installation as an explicit first-use action',
   );
-  assert.ok(agentBrief > pathGuide, 'Agent brief must follow PATH setup');
+  assert.ok(
+    installGuide > explicitInstallEntry,
+    'The explicit installation action must link to the installation guide',
+  );
+  assert.ok(agentBrief > installGuide, 'Agent brief must follow installation');
   assert.ok(
     runAgent > agentBrief,
     'run <agent> must follow the one-line brief',

--- a/scripts/run-docs-readonly.mjs
+++ b/scripts/run-docs-readonly.mjs
@@ -75,6 +75,7 @@ try {
       'pnpm-lock.yaml',
       'pnpm-workspace.yaml',
       '.npmrc',
+      'patches/**',
     ])
       .split('\0')
       .filter(Boolean);


### PR DESCRIPTION
Clarifies the first-use installation action, leads the CLI guide with the short public POSIX and PowerShell routes, keeps operational examples version-independent, and includes every lockfile patch input in the read-only documentation mirror.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This documentation and read-only manifest correction does not alter an architecture contract"
}
-->