### PR TITLE
fix(release): repin snapshot-safe publication runtime

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "1d50286260f6bc9d5044a7c3b0a84db63291e941",
+    "sourceSha": "85722b0ffa119e43a67516de97afeea2f35c5b33",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:225b692b65f126352d9ee96e9afe9e83d0d8bf78f3a17e365d0456a0654b359b"
   },

--- a/docs/qualification/gates/release-admission-policy.json
+++ b/docs/qualification/gates/release-admission-policy.json
@@ -23,7 +23,7 @@
       "alpha": {
         "ref": "v3-alpha",
         "runtimeSha": "2e7e07902ac28d8f3edcfb81098ef9ebc7a91878",
-        "publicationRuntimeSha": "022d2e94c6bf908856c8dd263cb45c6b5836dc52",
+        "publicationRuntimeSha": "c49897528e04f38124869d0e5a6ce73acfb9d7ca",
         "contractDigest": "sha256:5a6dc69d8905ed852260076da13d3aa3fa63533007dba706c164fe86f8b8f1e6",
         "contractLock": ".buildchain/alpha-contract-lock.json"
       },

--- a/scripts/verify-kungfu-release-admission.test.mjs
+++ b/scripts/verify-kungfu-release-admission.test.mjs
@@ -39,7 +39,7 @@ import {
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SOURCE_SHA = '1'.repeat(40);
 const RUNTIME_SHA = '2e7e07902ac28d8f3edcfb81098ef9ebc7a91878';
-const PUBLICATION_RUNTIME_SHA = '022d2e94c6bf908856c8dd263cb45c6b5836dc52';
+const PUBLICATION_RUNTIME_SHA = 'c49897528e04f38124869d0e5a6ce73acfb9d7ca';
 const RETIRED_PUBLICATION_RUNTIME_SHA =
   '21030efd277301d642fd9baaa1bd75f02dd3ddc6';
 const STABLE_RUNTIME_SHA = '9e904de2c85dbea7c799780ee166510b3336d812';


### PR DESCRIPTION
## Summary

- repin the Alpha.1 publication runtime policy to protected Buildchain `c49897528e04f38124869d0e5a6ce73acfb9d7ca`
- rebind the generated KFD prebuild witness to the current protected `dev/v4/v4.0` source after queue replay
- keep the executable release-admission fixture aligned without changing candidate or public release bytes

## Related issue

None.

## Changes

- update the Alpha publication runtime SHA in the release admission policy and its test fixture
- regenerate the single stale KFD source binding required by the repository gate

## Verification

- Task Chart completed with zero required omissions at the expanded budget
- `./shifu test:release-admission`: 9 passed, 1 designed skip
- `./shifu check:staged`: passed, including 144 core tests, 22 KFD negative tests, formatting, and KFD evidence checks
- exact Atlas work admission verified for commit `ed3279e9861cf3ef94ac786209cbfc4697ed46d2`
- no candidate, Release, installer, channel, Passport, signature, or public asset bytes changed

## Recovery coordinates

- source candidate run: `31051528142`
- immutable source SHA: `ad7c7db6df076f969c5939728bcbe70ccd4771b3`
- immutable source tree: `67a93b5831596555e7c29104421de3a0b97eb865`
- immutable release SHA: `f9e6b0e34bcdd6407b2a18206ace7982d64de2c8`
- publication runtime: `c49897528e04f38124869d0e5a6ce73acfb9d7ca`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This policy-only recovery controller repin and generated evidence rebind do not alter an architecture contract or release payload."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
