### PR TITLE
fix(release): repin snapshot-safe publication runtime

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "092ac9b1bb6486da29d6cbe841101597e6707b5d",
+    "sourceSha": "407dd772c6f18314651bad95a33e05b64d824c18",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:225b692b65f126352d9ee96e9afe9e83d0d8bf78f3a17e365d0456a0654b359b"
   },

--- a/docs/qualification/gates/release-admission-policy.json
+++ b/docs/qualification/gates/release-admission-policy.json
@@ -23,7 +23,7 @@
       "alpha": {
         "ref": "v3-alpha",
         "runtimeSha": "dd702f22e6afef137c86c5456e167e6db20e88f2",
-        "publicationRuntimeSha": "022d2e94c6bf908856c8dd263cb45c6b5836dc52",
+        "publicationRuntimeSha": "c49897528e04f38124869d0e5a6ce73acfb9d7ca",
         "contractDigest": "sha256:15d9f6feaa7f774b7223943de4326285d4a02db459e8ddda4a20418552e65d96",
         "contractLock": ".buildchain/alpha-contract-lock.json"
       },

--- a/scripts/verify-kungfu-release-admission.test.mjs
+++ b/scripts/verify-kungfu-release-admission.test.mjs
@@ -39,7 +39,7 @@ import {
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SOURCE_SHA = '1'.repeat(40);
 const RUNTIME_SHA = 'dd702f22e6afef137c86c5456e167e6db20e88f2';
-const PUBLICATION_RUNTIME_SHA = '022d2e94c6bf908856c8dd263cb45c6b5836dc52';
+const PUBLICATION_RUNTIME_SHA = 'c49897528e04f38124869d0e5a6ce73acfb9d7ca';
 const RETIRED_PUBLICATION_RUNTIME_SHA =
   '21030efd277301d642fd9baaa1bd75f02dd3ddc6';
 const STABLE_RUNTIME_SHA = '380b2d8c2a660b07ed785e71276f71dc6a9184f7';


### PR DESCRIPTION
## Summary

- repin the Alpha.1 publication runtime policy to protected Buildchain `c49897528e04f38124869d0e5a6ce73acfb9d7ca`
- rebind the generated KFD prebuild witness to the current protected `dev/v4/v4.0` source after queue replay
- keep the executable release-admission fixture aligned without changing candidate or public release bytes

## Related issue

Supersedes #2735 after the protected base advanced and Project Cut rejected the stale-base replay.

## Changes

- update the Alpha publication runtime SHA in the release admission policy and its test fixture
- regenerate the single stale KFD source binding required by the repository gate

## Verification

- Task Chart completed with zero required omissions at the expanded budget
- `./shifu test:release-admission`: 9 passed, 1 designed skip
- `./shifu check:staged`: passed, including 144 core tests, 22 KFD negative tests, formatting, and KFD evidence checks
- exact Atlas work admission verified for commit `763f19420a0822ab2bdeb3ebeee585d18bbab711`
- no candidate, Release, installer, channel, Passport, signature, or public asset bytes changed

## Recovery coordinates

- source candidate run: `31051528142`
- immutable source SHA: `ad7c7db6df076f969c5939728bcbe70ccd4771b3`
- immutable source tree: `67a93b5831596555e7c29104421de3a0b97eb865`
- immutable release SHA: `f9e6b0e34bcdd6407b2a18206ace7982d64de2c8`
- publication runtime: `c49897528e04f38124869d0e5a6ce73acfb9d7ca`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This policy-only recovery controller repin and generated evidence rebind do not alter an architecture contract or release payload."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA4LTA2LWt1bmdmdS1hbHBoYTEtY2FuZGlkYXRlLXJlY292ZXJ5LXJlbGVhc2UiLCJkZWxpdmVyeUNsYXNzIjoibmF0aXZlLXByb29mLXJlcXVpcmVkIiwiZGV2SGVhZCI6IjQwN2RkNzcyYzZmMTgzMTQ2NTFiYWQ5NWEzM2UwNWI2NGQ4MjRjMTgiLCJwdWxsUmVxdWVzdEhlYWQiOiI3NjNmMTk0MjBhMDgyMmFiMmJkZWIzZWJlZWU1ODVkMThiYmFiNzExIiwicmVwbGF5ZWRDYW5kaWRhdGUiOiIwMTU5OWFmZDhhY2E1YTdhODU5MjhiYjM2MmI2Nzg3Zjc0ZDUzNDg3IiwicmVwbGF5ZWRUcmVlIjoiYjk0ODU4MGUyNTk0OWMwODYxYWIxOWYxYWU3ODQ0ZWI2MmVlZWVjMCIsInF1ZXVlQXR0ZW1wdCI6Ijc2M2YxOTQyMGEwODIyYWIyYmRlYjNlYmVlZTU4NWQxOGJiYWI3MTFANDA3ZGQ3NzJjNmYxODMxNDY1MWJhZDk1YTMzZTA1YjY0ZDgyNGMxOCIsImFkbWlzc2lvblByb29mUm9vdCI6InNoYTI1Njo4NzFlNDcyNzRlODRjOTg5YWUwMWM3ZTMyMWU5YTkyOGU5MzVjNTJkMzExY2YyMzk5OWQwMTA2YmQ2YjU3MjI3IiwiYWRtaXNzaW9uUHJvb2ZSb290cyI6WyJzaGEyNTY6ODcxZTQ3Mjc0ZTg0Yzk4OWFlMDFjN2UzMjFlOWE5MjhlOTM1YzUyZDMxMWNmMjM5OTlkMDEwNmJkNmI1NzIyNyIsInNoYTI1NjpkODllY2FhMDEwNGZiZmQ2NjYwZDk3OTYxYTU1NTM1ZGJjZTJjZDBkMWRmYTgxOWRlZjJlMjdkOWQ1ZmZiYzhlIl0sInN0YXR1c0NvbnRleHQiOiJRdWV1ZSBmYW1pbHkgbGVhc2UvZDk5ZjNhOTE2NjczOWUwZCIsImxlYXNlUm9vdCI6InNoYTI1NjoyNDllMTRkYzU2NzZlNWQwZDA5NTViMjAzODhjOGQ5NGM3ZjdhYTJkNDVhMjhkYjQyNjZiNTg0YjI5Y2EyZGFhIn0 -->