### PR TITLE
chore(maintainability): rotate transition review authority

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "1d50286260f6bc9d5044a7c3b0a84db63291e941",
+    "sourceSha": "85722b0ffa119e43a67516de97afeea2f35c5b33",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:225b692b65f126352d9ee96e9afe9e83d0d8bf78f3a17e365d0456a0654b359b"
   },

--- a/framework/maintainability/code-complexity-policy.json
+++ b/framework/maintainability/code-complexity-policy.json
@@ -157,6 +157,12 @@
         "key_id": "ed25519-668812bf28659460",
         "algorithm": "ed25519",
         "public_key_pem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAgAti4fLF9HdgLlDoAiGXaKln9GZVGcYCFJG2eJ1/45Q=\n-----END PUBLIC KEY-----\n"
+      },
+      {
+        "authority_id": "kungfu-origin-complexity-transition-review-v2",
+        "key_id": "ed25519-9ff21f6e6f64c985",
+        "algorithm": "ed25519",
+        "public_key_pem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAhihl4wBSlb08qstTTlwPBHUUWbspgENqsZz5X3jnLzE=\n-----END PUBLIC KEY-----\n"
       }
     ],
     "requiredFields": [


### PR DESCRIPTION
## Summary

- add a second independently scoped Ed25519 review authority for protected complexity baseline transitions
- keep the existing authority valid; no baseline, budget, waiver, or runtime behavior changes in this PR
- prepare a separately reviewed cleanup transition without weakening protected baseline integrity

## Validation

- full staged repository gate passed
- complexity budget and all 18 governance tests passed
- Buildchain KFD evidence was regenerated at the exact candidate head

## Security

Only the public key is committed. The private key is held outside Git, will sign only the subsequent exact cleanup transition, and will be destroyed after that transition is admitted.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": [],
  "summary": "Rotate the independent complexity transition review authority",
  "verification": [
    "./shifu check:source",
    "node --test scripts/code-complexity-budget.test.mjs"
  ]
}
-->
