### PR TITLE
fix(release): repin snapshot-safe publication runtime

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "092ac9b1bb6486da29d6cbe841101597e6707b5d",
+    "sourceSha": "407dd772c6f18314651bad95a33e05b64d824c18",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:225b692b65f126352d9ee96e9afe9e83d0d8bf78f3a17e365d0456a0654b359b"
   },

--- a/docs/qualification/gates/release-admission-policy.json
+++ b/docs/qualification/gates/release-admission-policy.json
@@ -23,7 +23,7 @@
       "alpha": {
         "ref": "v3-alpha",
         "runtimeSha": "dd702f22e6afef137c86c5456e167e6db20e88f2",
-        "publicationRuntimeSha": "022d2e94c6bf908856c8dd263cb45c6b5836dc52",
+        "publicationRuntimeSha": "c49897528e04f38124869d0e5a6ce73acfb9d7ca",
         "contractDigest": "sha256:15d9f6feaa7f774b7223943de4326285d4a02db459e8ddda4a20418552e65d96",
         "contractLock": ".buildchain/alpha-contract-lock.json"
       },

--- a/scripts/verify-kungfu-release-admission.test.mjs
+++ b/scripts/verify-kungfu-release-admission.test.mjs
@@ -39,7 +39,7 @@ import {
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SOURCE_SHA = '1'.repeat(40);
 const RUNTIME_SHA = 'dd702f22e6afef137c86c5456e167e6db20e88f2';
-const PUBLICATION_RUNTIME_SHA = '022d2e94c6bf908856c8dd263cb45c6b5836dc52';
+const PUBLICATION_RUNTIME_SHA = 'c49897528e04f38124869d0e5a6ce73acfb9d7ca';
 const RETIRED_PUBLICATION_RUNTIME_SHA =
   '21030efd277301d642fd9baaa1bd75f02dd3ddc6';
 const STABLE_RUNTIME_SHA = '380b2d8c2a660b07ed785e71276f71dc6a9184f7';


### PR DESCRIPTION
Merge fix/alpha1-publication-runtime-repin-passport-snapshot-r2 into dev/v4/v4.0 (kungfu-systems zone dual-account PR flow).