### PR TITLE
test(product): align Work fixtures with Runtime authority

### DIFF
--- a/tests/fixtures/kfx-demo-atlas-capability/roundtrip.mjs
+++ b/tests/fixtures/kfx-demo-atlas-capability/roundtrip.mjs
@@ -5,7 +5,15 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { openProfile } from '../../../framework/api/src/capability/profile.ts';
 import { openWorkControlProfile } from '../../../extensions/work-dashboard/src/view/work-control-profile.ts';
-import { fail, locate, tmpDir, uvPython } from '../_harness.mjs';
+import {
+  corePython,
+  fail,
+  json,
+  kfc,
+  locate,
+  tmpDir,
+  uvPython,
+} from '../_harness.mjs';
 
 const { fixtureDir, coreDir } = locate(import.meta.url);
 const repoDir = path.resolve(fixtureDir, '..', '..', '..');
@@ -15,10 +23,20 @@ const sampleRoot = path.resolve(
   'atlas-demo-import',
   'sample-root',
 );
-const runtimeDir = path.join(tmpDir('atlas-capability-'), 'runtime');
-const bin = path.join(repoDir, 'framework', 'core', 'dist', 'kungfu', 'kungfu');
+const home = tmpDir('atlas-capability-');
+const runtimeDir = path.join(home, 'runtime');
+const assembledBin = path.join(
+  repoDir,
+  'framework',
+  'core',
+  'dist',
+  'kungfu',
+  'kungfu',
+);
+const python = corePython(coreDir);
+const devCli = path.join(coreDir, '.devtools', 'kungfu_cli.py');
 
-if (!fs.existsSync(bin)) {
+if (!fs.existsSync(assembledBin)) {
   fail('kungfu CLI is not assembled (run ./shifu freeze first)');
 }
 
@@ -27,12 +45,16 @@ uvPython(coreDir, [
   runtimeDir,
   path.join(repoDir, 'extensions', 'work-control'),
 ]);
+const imported = json(
+  kfc(coreDir, home, ['atlas', 'import', '--repo', sampleRoot, '--json']),
+);
 
 const profile = openProfile({
   runtimeDir,
-  execFileSync,
+  execFileSync: (_file, args, options) =>
+    execFileSync(python, [devCli, '-H', home, ...args], options),
   env: { ...process.env, KUNGFU_ATLAS_REPO: sampleRoot },
-  bin,
+  bin: python,
 });
 const atlas = openWorkControlProfile(profile, sampleRoot);
 
@@ -42,7 +64,6 @@ function ck(label, ok) {
 
 ck('default repo root is exposed', atlas.defaultRepoRoot === sampleRoot);
 
-const imported = await atlas.importRepo(sampleRoot);
 ck('import counted one mission', imported.missions === 1);
 ck('import counted two goals', imported.goals === 2);
 ck('import counted one marker', imported.markers === 1);

--- a/tests/fixtures/kfx-demo-install/check_install.py
+++ b/tests/fixtures/kfx-demo-install/check_install.py
@@ -35,7 +35,7 @@ if os.path.isfile(manifest_path):
     check("key is work-dashboard", config.get("key") == "work-dashboard")
     check(
         "view declares capabilities",
-        view.get("capabilities") == ["storage", "projects"],
+        view.get("capabilities") == ["storage", "projects", "assignmentRuntime"],
     )
     check(
         "package name is the published one",

--- a/tests/fixtures/kfx-demo-work-dashboard-atlas-live/render-live.mjs
+++ b/tests/fixtures/kfx-demo-work-dashboard-atlas-live/render-live.mjs
@@ -6,7 +6,15 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import { openProfile } from '../../../framework/api/src/capability/profile.ts';
 import { openWorkControlProfile } from '../../../extensions/work-dashboard/src/view/work-control-profile.ts';
-import { fail, locate, tmpDir, uvPython } from '../_harness.mjs';
+import {
+  corePython,
+  fail,
+  json,
+  kfc,
+  locate,
+  tmpDir,
+  uvPython,
+} from '../_harness.mjs';
 
 const { fixtureDir, coreDir } = locate(import.meta.url);
 const repoDir = path.resolve(fixtureDir, '..', '..', '..');
@@ -16,8 +24,18 @@ const sampleRoot = path.resolve(
   'atlas-demo-import',
   'sample-root',
 );
-const runtimeDir = path.join(tmpDir('atlas-view-live-'), 'runtime');
-const bin = path.join(repoDir, 'framework', 'core', 'dist', 'kungfu', 'kungfu');
+const home = tmpDir('atlas-view-live-');
+const runtimeDir = path.join(home, 'runtime');
+const assembledBin = path.join(
+  repoDir,
+  'framework',
+  'core',
+  'dist',
+  'kungfu',
+  'kungfu',
+);
+const python = corePython(coreDir);
+const devCli = path.join(coreDir, '.devtools', 'kungfu_cli.py');
 const bundlePath = path.join(
   repoDir,
   'extensions',
@@ -30,7 +48,7 @@ const require = createRequire(
   path.join(repoDir, 'framework', 'gui', 'package.json'),
 );
 
-if (!fs.existsSync(bin)) {
+if (!fs.existsSync(assembledBin)) {
   fail('kungfu CLI is not assembled (run ./shifu freeze first)');
 }
 if (!fs.existsSync(bundlePath)) {
@@ -42,15 +60,18 @@ uvPython(coreDir, [
   runtimeDir,
   path.join(repoDir, 'extensions', 'work-control'),
 ]);
+const imported = json(
+  kfc(coreDir, home, ['atlas', 'import', '--repo', sampleRoot, '--json']),
+);
 
 const profile = openProfile({
   runtimeDir,
-  execFileSync,
+  execFileSync: (_file, args, options) =>
+    execFileSync(python, [devCli, '-H', home, ...args], options),
   env: { ...process.env, KUNGFU_ATLAS_REPO: sampleRoot },
-  bin,
+  bin: python,
 });
 const atlas = openWorkControlProfile(profile, sampleRoot);
-const imported = await atlas.importRepo(sampleRoot);
 if (imported.missions !== 1 || imported.goals !== 2 || imported.markers !== 1) {
   fail(`unexpected import counts: ${JSON.stringify(imported)}`);
 }
@@ -80,6 +101,11 @@ const fakeCaps = {
     list: async () => ({ schema: 'kungfu.projects.catalog/v1', projects: [] }),
     runs: () => [],
     subscribeRuns: () => () => undefined,
+  },
+  assignmentRuntime: {
+    discover: async () => ({ status: 'ok' }),
+    snapshot: async () => ({ status: 'ok', revision: { value: 'fixture' } }),
+    watch: async () => ({ status: 'ok' }),
   },
 };
 const fakeShell = {

--- a/tests/fixtures/kfx-demo-work-dashboard-atlas-view/run.mjs
+++ b/tests/fixtures/kfx-demo-work-dashboard-atlas-view/run.mjs
@@ -103,6 +103,11 @@ const fakeCaps = {
     runs: () => [],
     subscribeRuns: () => () => undefined,
   },
+  assignmentRuntime: {
+    discover: async () => ({ status: 'ok' }),
+    snapshot: async () => ({ status: 'ok', revision: { value: 'fixture' } }),
+    watch: async () => ({ status: 'ok' }),
+  },
 };
 
 const fakeShell = {


### PR DESCRIPTION
## Summary

Repair the four product fixtures exposed by Dev Verify Patrol so they follow the current Work Dashboard and Assignment Runtime authority boundaries on every platform.

The fixtures now import Atlas data through the exact candidate CLI/home instead of exercising a retired GUI mutation path or inheriting an installed-product Profile selection.

## Related issue

None.

## Changes

- route Atlas fixture imports through the exact development CLI and isolated home
- bind Profile member calls to that same candidate CLI/home
- provide the Assignment Runtime capability required by the current Work Dashboard view
- update the install fixture for the declared `assignmentRuntime` capability

## Verification

- `node tests/fixtures/kfx-demo-atlas-capability/run.mjs`
- `node tests/fixtures/kfx-demo-install/run.mjs`
- `node tests/fixtures/kfx-demo-work-dashboard-atlas-live/run.mjs`
- `node tests/fixtures/kfx-demo-work-dashboard-atlas-view/run.mjs`
- `./shifu check` progressed through all affected gates; it reached the pre-existing same-SHA `framework/spec/generated/registry.json` drift, reproduced unchanged in a clean worktree
- staged source, lint, format, DCO, documentation, Gate catalog, and release-contract hooks passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Align existing product fixtures with already-delivered Assignment Runtime authority without changing product semantics."
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This is a test-only repair required by the protected Dev Verify lane. Production release routing and the Buildchain v3 floating contract remain unchanged.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed