### PR TITLE
fix(gui): restore KFD-3 release application facade

### DIFF
--- a/extensions/work-dashboard/src/view/index.tsx
+++ b/extensions/work-dashboard/src/view/index.tsx
@@ -65,6 +65,8 @@ export function openProfileApplication(runtime: AssignmentRuntime) {
   return runtime;
 }
 
+export { openKfd3ProfileApplication } from './work-control-profile';
+
 type NodeHost = {
   require: NodeRequire;
   process: NodeJS.Process;

--- a/extensions/work-dashboard/src/view/work-control-profile.ts
+++ b/extensions/work-dashboard/src/view/work-control-profile.ts
@@ -1,4 +1,8 @@
-import type { Profile, QueryDefinition } from '@kungfu-tech/api/capability';
+import type {
+  Profile,
+  ProfileIntentReceipt,
+  QueryDefinition,
+} from '@kungfu-tech/api/capability';
 
 // Work Control domain client over the public, exact-root Profile surface.
 // Domain types live with this Profile KFX rather than in the generic API.
@@ -688,6 +692,17 @@ export type Atlas = {
 const PROFILE_ID = 'kungfu.work-control';
 const ADAPTER_MEMBER = 'work-control-actions';
 
+type IntentExecutionReceipt<TResult> = ProfileIntentReceipt & {
+  actionReceipt: {
+    verified: boolean;
+    coreReceipt: TResult;
+  };
+};
+
+type WorkControlProfileOptions = {
+  mutationAuthority?: 'reject' | 'kfd3-application';
+};
+
 function directMutationRejected(intentId: string): Error {
   const error = new Error(
     `Direct GUI Profile mutation is read-only compatibility: ${intentId}; use kungfu.assignment-runtime/v1`,
@@ -699,6 +714,7 @@ function directMutationRejected(intentId: string): Error {
 export function openWorkControlProfile(
   profile: Profile,
   defaultRepoRoot = '',
+  options: WorkControlProfileOptions = {},
 ): Atlas {
   let dashboardSnapshot: AtlasDashboardSnapshot | null = null;
   const source = () => profile.discover(PROFILE_ID).source;
@@ -716,10 +732,26 @@ export function openWorkControlProfile(
     ).result;
   const authorize = async <TResult>(
     intentId: string,
-    _input: unknown,
-    _authorizedBy: string,
+    input: unknown,
+    authorizedBy: string,
   ): Promise<TResult> => {
-    throw directMutationRejected(intentId);
+    if (options.mutationAuthority !== 'kfd3-application') {
+      throw directMutationRejected(intentId);
+    }
+    const profileSource = source();
+    const plan = profile.intentPlan(profileSource, intentId, input);
+    const receipt = (await profile.authorizeIntentAsync(
+      profileSource,
+      intentId,
+      plan.planId,
+      'approve',
+      authorizedBy,
+      input,
+    )) as IntentExecutionReceipt<TResult>;
+    if (!receipt.executionReceiptVerified || !receipt.actionReceipt.verified) {
+      throw new Error(`Profile intent execution was not verified: ${intentId}`);
+    }
+    return receipt.actionReceipt.coreReceipt;
   };
 
   return {
@@ -877,4 +909,59 @@ export function openWorkControlProfile(
   };
 }
 
-/** Explicit compatibility alias for callers that have not migrated yet. */
+// KFD-3 factory qualification owns this separate, explicitly injected Profile
+// application surface. It is never selected as a fallback by the production
+// Work Dashboard, whose only Assignment authority is openProfileApplication().
+export function openKfd3ProfileApplication(
+  profile: Profile,
+  defaultRepoRoot = '',
+) {
+  const application = openWorkControlProfile(profile, defaultRepoRoot, {
+    mutationAuthority: 'kfd3-application',
+  });
+  return {
+    createInitiative: (
+      ...args: Parameters<typeof application.createInitiative>
+    ) => application.createInitiative(...args),
+    createAssignment: (
+      ...args: Parameters<typeof application.createAssignment>
+    ) => application.createAssignment(...args),
+    appendAssignmentRelationEvent: (
+      ...args: Parameters<typeof application.appendAssignmentRelationEvent>
+    ) => application.appendAssignmentRelationEvent(...args),
+    claimAssignment: (
+      ...args: Parameters<typeof application.claimAssignment>
+    ) => application.claimAssignment(...args),
+    advanceAssignment: (
+      ...args: Parameters<typeof application.advanceAssignment>
+    ) => application.advanceAssignment(...args),
+    claimCompletion: (
+      ...args: Parameters<typeof application.claimCompletion>
+    ) => application.claimCompletion(...args),
+    assessInitiativeAsync: (
+      ...args: Parameters<typeof application.assessInitiativeAsync>
+    ) => application.assessInitiativeAsync(...args),
+    reviewCompletion: (
+      ...args: Parameters<typeof application.reviewCompletion>
+    ) => application.reviewCompletion(...args),
+    decideContinuation: (
+      ...args: Parameters<typeof application.decideContinuation>
+    ) => application.decideContinuation(...args),
+    importRepo: (...args: Parameters<typeof application.importRepo>) =>
+      application.importRepo(...args),
+    activateWorkControl: (
+      ...args: Parameters<typeof application.activateWorkControl>
+    ) => application.activateWorkControl(...args),
+    restoreAtlasAuthority: (
+      ...args: Parameters<typeof application.restoreAtlasAuthority>
+    ) => application.restoreAtlasAuthority(...args),
+    exportInitiative: (
+      ...args: Parameters<typeof application.exportInitiative>
+    ) => application.exportInitiative(...args),
+    importInitiative: (
+      ...args: Parameters<typeof application.importInitiative>
+    ) => application.importInitiative(...args),
+    intentPlan: (...args: Parameters<typeof profile.intentPlan>) =>
+      profile.intentPlan(...args),
+  };
+}

--- a/extensions/work-dashboard/tests/work-control-profile.test.ts
+++ b/extensions/work-dashboard/tests/work-control-profile.test.ts
@@ -148,3 +148,71 @@ test('Work Control Profile compatibility is read-only in the GUI', async () => {
   }
   assert.deepEqual(calls, ['dashboard']);
 });
+
+test('KFD-3 application authority executes an exact verified Profile intent', async () => {
+  const source = '/profiles/work-control';
+  const calls: Array<Record<string, unknown>> = [];
+  const profile = {
+    runtimeDir: '/runtime',
+    discover: () => ({ source }),
+    intentPlan: (actualSource: string, intentId: string, input: unknown) => {
+      calls.push({ stage: 'plan', actualSource, intentId, input });
+      return { planId: 'plan:create-assignment' };
+    },
+    authorizeIntentAsync: async (
+      actualSource: string,
+      intentId: string,
+      expectedPlanId: string,
+      choice: string,
+      authorizedBy: string,
+      input: unknown,
+    ) => {
+      calls.push({
+        stage: 'authorize',
+        actualSource,
+        intentId,
+        expectedPlanId,
+        choice,
+        authorizedBy,
+        input,
+      });
+      return {
+        executionReceiptVerified: true,
+        actionReceipt: {
+          verified: true,
+          coreReceipt: { assignment_id: 'assignment-a' },
+        },
+      };
+    },
+  } as unknown as Profile;
+
+  const application = openWorkControlProfile(profile, '', {
+    mutationAuthority: 'kfd3-application',
+  });
+  const input = {
+    assignmentId: 'assignment-a',
+    title: 'Assignment A',
+    objective: 'Prove the release application boundary',
+    actor: 'test-owner',
+  };
+  const receipt = await application.createAssignment('initiative-a', input);
+
+  assert.deepEqual(receipt, { assignment_id: 'assignment-a' });
+  assert.deepEqual(calls, [
+    {
+      stage: 'plan',
+      actualSource: source,
+      intentId: 'create-assignment',
+      input: { initiativeId: 'initiative-a', ...input },
+    },
+    {
+      stage: 'authorize',
+      actualSource: source,
+      intentId: 'create-assignment',
+      expectedPlanId: 'plan:create-assignment',
+      choice: 'approve',
+      authorizedBy: 'test-owner',
+      input: { initiativeId: 'initiative-a', ...input },
+    },
+  ]);
+});


### PR DESCRIPTION
## Summary

Restore the explicit KFD-3 release-application facade required by the sealed release factory while keeping the production Work Dashboard on Assignment Runtime authority.

This repairs the artifact transport failure exposed by the formal Alpha.2 Product Build without changing the production Buildchain v3 floating contract.

## Related issue

- Alpha.2 Product Build run `31339169981`, attempt 2

## Changes

- expose a separate `openKfd3ProfileApplication` factory facade for the sealed KFD-3 generator
- retain the fourteen governed Work Control operations and `intentPlan` in the generated release bundle
- require exact intent authorization plus execution and action receipt verification
- keep the default Work Control Profile path read-only and the production dashboard Runtime-only
- add regression coverage for the explicit KFD-3 mutation authority

## Verification

- `./shifu build`
- `./shifu check:source`: 1080 passed, 11 expected skips, 0 failed
- `./shifu test:kfx-profile-suite`
- `./shifu test:assignment-runtime-gui`: 21/21 passed
- `./shifu test:agent-profile-sdk`: 63 passed
- `node framework/gui/scripts/gen-system-profile-kfd3.mjs`: verified receipt, manifest root `sha256:44574bdf874b057510f006bc8bed04d8835ea54f785e43766a3445e4cad0e96c`
- clean replay onto protected dev `0c245861e432254ea9988cc5437185098bfe75e6`
- exact Atlas work admission root `sha256:31e2c86fa50100e002d84372117d69378dec2c50d7c3690bad8396c5fd7a5573`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Restore the existing sealed KFD-3 release-factory application surface without changing the accepted Work Dashboard runtime authority or release architecture."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change restores a previously required release-bundle surface. It does not publish, tag, upload, attest, activate, or alter the production Buildchain v3 floating selection.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
