### PR TITLE
fix(spec): refresh KFX authority root

### DIFF
--- a/framework/spec/generated/registry.json
+++ b/framework/spec/generated/registry.json
@@ -96,7 +96,7 @@
       "protocol_id": "kungfu.kfx.manifest/v1",
       "source": "config/kungfu-kfx.contract.json",
       "source_role": "KFX-identity-neutral-package-declaration-schema",
-      "source_root": "sha256:f0e6cfddac711123a969d7d88c8995b95fcb397b99438674902372fb38ff8d0c",
+      "source_root": "sha256:4c17dddae597d19eb9ead4d3767669e3f8343a3b41cc9deb42c8eb5ff08a514d",
       "version_axis": "KFX package manifest schema version"
     },
     {
@@ -157,7 +157,7 @@
       },
       {
         "path": "config/kungfu-kfx.contract.json",
-        "root": "sha256:f0e6cfddac711123a969d7d88c8995b95fcb397b99438674902372fb38ff8d0c"
+        "root": "sha256:4c17dddae597d19eb9ead4d3767669e3f8343a3b41cc9deb42c8eb5ff08a514d"
       },
       {
         "path": "framework/core/src/libyijinjing/include/kungfu/yijinjing/storage/common.h",


### PR DESCRIPTION
## Summary

Refresh the generated KFX authority root recorded in the Spec registry. Formal Alpha.2 Build run 31343955724 proved that artifact transport now passes on macOS, then failed `layers.format` because `registry.json` still carried the pre-webhook-contract authority root.

## Related issue

Formal Alpha.2 Build run 31343955724.

## Changes

- replace the two stale `config/kungfu-kfx.contract.json` authority-root references in the generated Spec registry
- keep the generated surface and all source contracts otherwise unchanged

## Verification

- `node framework/spec/scripts/generate.js --check`
- `./shifu exec pnpm --filter @kungfu-tech/spec run generate:check`
- `./shifu exec pnpm --filter @kungfu-tech/spec run build`
- `./shifu exec pnpm --filter @kungfu-tech/spec run verify`
- `./shifu check`
- `./shifu build:core`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This repair refreshes generated authority metadata after an already-accepted contract change and does not alter an architecture contract."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change repairs the generated release-verification input that blocked Alpha.2. Validation above proves the generated registry is current and the full repository gate passes.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable; no behavior change)
