### PR TITLE
fix(release): admit sealed recovery contract digest

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "991f899b9d97a4f18c3f029148d900be1f9618be",
+    "sourceSha": "365094695d0ca69cb0fae3471292ebb1320aca07",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:225b692b65f126352d9ee96e9afe9e83d0d8bf78f3a17e365d0456a0654b359b"
   },

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "b65932a12106f080d8036b9a7bc1d9b64e5c6685",
+    "sourceSha": "991f899b9d97a4f18c3f029148d900be1f9618be",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:225b692b65f126352d9ee96e9afe9e83d0d8bf78f3a17e365d0456a0654b359b"
   },

--- a/docs/qualification/gates/dev-queue-admission.contract.json
+++ b/docs/qualification/gates/dev-queue-admission.contract.json
@@ -15,7 +15,7 @@
   },
   "requiredContext": "Queue admission lease",
   "authority": {
-    "pullRequestHead": "atlas-serialized-wrapper",
+    "pullRequestHead": "buildchain-serialized-pr-head",
     "mergeGroup": ".github/workflows/queue-admission-lease.yml",
     "dequeueRevocation": ".github/workflows/cancel-dequeued-merge-group.yml",
     "dequeueControllerSource": "current-protected-pull-request-base-ref",

--- a/docs/qualification/gates/release-admission-policy.json
+++ b/docs/qualification/gates/release-admission-policy.json
@@ -25,6 +25,10 @@
         "runtimeSha": "dd702f22e6afef137c86c5456e167e6db20e88f2",
         "publicationRuntimeSha": "c49897528e04f38124869d0e5a6ce73acfb9d7ca",
         "contractDigest": "sha256:15d9f6feaa7f774b7223943de4326285d4a02db459e8ddda4a20418552e65d96",
+        "publicationContractDigests": [
+          "sha256:15d9f6feaa7f774b7223943de4326285d4a02db459e8ddda4a20418552e65d96",
+          "sha256:5a6dc69d8905ed852260076da13d3aa3fa63533007dba706c164fe86f8b8f1e6"
+        ],
         "contractLock": ".buildchain/alpha-contract-lock.json"
       },
       "release": {
@@ -32,6 +36,9 @@
         "runtimeSha": "380b2d8c2a660b07ed785e71276f71dc6a9184f7",
         "publicationRuntimeSha": "380b2d8c2a660b07ed785e71276f71dc6a9184f7",
         "contractDigest": "sha256:900b03120a2ae9b7e7e67fdb854039849339f96bd6285a13c2ced30b9b02f2c0",
+        "publicationContractDigests": [
+          "sha256:900b03120a2ae9b7e7e67fdb854039849339f96bd6285a13c2ced30b9b02f2c0"
+        ],
         "contractLock": ".buildchain/contract-lock.json"
       }
     }

--- a/scripts/kungfu-release-qualification.mjs
+++ b/scripts/kungfu-release-qualification.mjs
@@ -68,6 +68,31 @@ export function kungfuBuildchainRuntimePolicy(policy, channel) {
       `Kungfu Buildchain publication runtime SHA is invalid for ${channel}`,
     );
   normalizeDigest(runtime.contractDigest, `${channel} contract digest`);
+  if (
+    !Array.isArray(runtime.publicationContractDigests) ||
+    runtime.publicationContractDigests.length === 0
+  )
+    throw new Error(
+      `Kungfu Buildchain publication contract digests are missing for ${channel}`,
+    );
+  const publicationContractDigests = runtime.publicationContractDigests.map(
+    (value) => normalizeDigest(value, `${channel} publication contract digest`),
+  );
+  if (
+    new Set(publicationContractDigests).size !==
+    publicationContractDigests.length
+  )
+    throw new Error(
+      `Kungfu Buildchain publication contract digests contain duplicates for ${channel}`,
+    );
+  if (
+    !publicationContractDigests.includes(
+      normalizeDigest(runtime.contractDigest, `${channel} contract digest`),
+    )
+  )
+    throw new Error(
+      `Kungfu Buildchain publication contract digests omit the current ${channel} contract`,
+    );
   if (!runtime.ref || !runtime.contractLock)
     throw new Error(
       `Kungfu Buildchain runtime metadata is incomplete for ${channel}`,
@@ -197,8 +222,16 @@ export async function createKungfuConsumerPublicationDecision({
   exact(capability?.target, policy.publication.target, 'target');
   exact(capability?.runtimeSha, runtime.publicationRuntimeSha, 'runtime SHA');
   if (
-    normalizeDigest(capability?.contractDigest, 'capability.contractDigest') !==
-    normalizeDigest(runtime.contractDigest, 'policy.contractDigest')
+    !runtime.publicationContractDigests
+      .map((value) =>
+        normalizeDigest(value, 'policy.publicationContractDigests'),
+      )
+      .includes(
+        normalizeDigest(
+          capability?.contractDigest,
+          'capability.contractDigest',
+        ),
+      )
   )
     throw new Error('Buildchain contract digest policy mismatch');
   if (!policy.publication.channels.includes(capability?.channel))

--- a/scripts/queue-admission-lease.test.mjs
+++ b/scripts/queue-admission-lease.test.mjs
@@ -29,7 +29,10 @@ const CONTRACT = JSON.parse(
 test('queue admission lease has distinct PR-head and merge-group authorities', () => {
   assert.equal(CONTRACT.schema, 'kungfu.dev-queue-admission/v1');
   assert.equal(CONTRACT.requiredContext, 'Queue admission lease');
-  assert.equal(CONTRACT.authority.pullRequestHead, 'atlas-serialized-wrapper');
+  assert.equal(
+    CONTRACT.authority.pullRequestHead,
+    'buildchain-serialized-pr-head',
+  );
   assert.equal(
     CONTRACT.authority.mergeGroup,
     '.github/workflows/queue-admission-lease.yml',

--- a/scripts/verify-kungfu-release-admission.mjs
+++ b/scripts/verify-kungfu-release-admission.mjs
@@ -34,6 +34,15 @@ function requiredFile(value, label) {
   return value;
 }
 
+function normalizeDigest(value, label) {
+  const digest = String(value || '')
+    .replace(/^sha256:/, '')
+    .toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(digest))
+    throw new Error(`${label} must be a SHA-256 digest`);
+  return digest;
+}
+
 function exactKeys(value, keys, label) {
   if (!value || typeof value !== 'object' || Array.isArray(value))
     throw new Error(`${label} must be an object`);
@@ -173,6 +182,7 @@ function validatePolicy(root, policy) {
         'runtimeSha',
         'publicationRuntimeSha',
         'contractDigest',
+        'publicationContractDigests',
         'contractLock',
       ],
       `buildchain.runtimes.${channel}`,
@@ -306,7 +316,6 @@ export async function verifyKungfuReleaseAdmission({
     repository: policy.repository,
     publisherWorkflowPath: policy.publication.publisherWorkflowPath,
     runtimeSha: runtime.publicationRuntimeSha,
-    contractDigest: runtime.contractDigest.replace(/^sha256:/, ''),
     environment: policy.publication.environment,
     product: policy.publication.product,
     target: policy.publication.target,
@@ -316,6 +325,16 @@ export async function verifyKungfuReleaseAdmission({
       throw new Error(
         `Kungfu release admission expected ${key} policy mismatch`,
       );
+  if (
+    !runtime.publicationContractDigests
+      .map((value) => normalizeDigest(value, 'publication contract digest'))
+      .includes(
+        normalizeDigest(expected?.contractDigest, 'expected contract digest'),
+      )
+  )
+    throw new Error(
+      'Kungfu release admission expected contractDigest policy mismatch',
+    );
   if (!policy.publication.channels.includes(expected?.channel))
     throw new Error('Kungfu release admission channel is not allowed');
   if (admission?.workflowPath !== policy.publication.workflowPath)

--- a/scripts/verify-kungfu-release-admission.test.mjs
+++ b/scripts/verify-kungfu-release-admission.test.mjs
@@ -46,6 +46,8 @@ const STABLE_RUNTIME_SHA = '380b2d8c2a660b07ed785e71276f71dc6a9184f7';
 const SOURCE_TREE_SHA = 'a'.repeat(40);
 const CONTRACT_DIGEST =
   '15d9f6feaa7f774b7223943de4326285d4a02db459e8ddda4a20418552e65d96';
+const RECOVERED_CONTRACT_DIGEST =
+  '5a6dc69d8905ed852260076da13d3aa3fa63533007dba706c164fe86f8b8f1e6';
 const STABLE_CONTRACT_DIGEST =
   '900b03120a2ae9b7e7e67fdb854039849339f96bd6285a13c2ced30b9b02f2c0';
 const PREDICATE_COMMAND = 'node scripts/kungfu-release-qualification.mjs';
@@ -388,6 +390,11 @@ test('Kungfu independently accepts only a durable sealed qualifying capability',
   assert.equal(result.capability.runtimeSha, PUBLICATION_RUNTIME_SHA);
   assert.match(result.consumerPolicyDigest, /^[0-9a-f]{64}$/);
 
+  const recovered = await verifyKungfuReleaseAdmission(
+    fixture({ contractDigest: RECOVERED_CONTRACT_DIGEST }),
+  );
+  assert.equal(recovered.capability.contractDigest, RECOVERED_CONTRACT_DIGEST);
+
   const stable = await verifyKungfuReleaseAdmission(
     fixture({
       channel: 'release',
@@ -405,6 +412,11 @@ test('Kungfu independently accepts only a durable sealed qualifying capability',
         }),
       ),
     /runtimeSha policy mismatch/,
+  );
+  await assert.rejects(
+    async () =>
+      verifyKungfuReleaseAdmission(fixture({ contractDigest: 'f'.repeat(64) })),
+    /contractDigest policy mismatch/,
   );
 });
 
@@ -464,7 +476,7 @@ test('Kungfu rejects policy, runner, control-plane, and artifact substitution', 
 });
 
 test('Kungfu consumer qualification seals only an exact current handoff', async () => {
-  const input = fixture();
+  const input = fixture({ contractDigest: RECOVERED_CONTRACT_DIGEST });
   const capability = (await verifyKungfuReleaseAdmission(input)).capability;
   const gateAggregate = input.publicationEvidence.gateAggregate;
   const decision = await createKungfuConsumerPublicationDecision({
@@ -479,6 +491,22 @@ test('Kungfu consumer qualification seals only an exact current handoff', async 
   assert.equal(decision.decision, 'allow');
   assert.equal(decision.sourceSha, SOURCE_SHA);
   assert.equal(decision.artifactDigest, capability.artifactDigest);
+
+  const unlistedContract = structuredClone(capability);
+  unlistedContract.contractDigest = 'f'.repeat(64);
+  await assert.rejects(
+    async () =>
+      createKungfuConsumerPublicationDecision({
+        root: ROOT,
+        capability: unlistedContract,
+        gateAggregate,
+        predicateId: KUNGFU_PUBLICATION_PREDICATE_ID,
+        predicateDigest: PREDICATE_DIGEST,
+        createDecision: createConsumerPublicationDecision,
+        now: input.now,
+      }),
+    /Buildchain contract digest policy mismatch/,
+  );
 
   const receipt = createPublicationQualificationReceipt({
     capability,


### PR DESCRIPTION
## Summary

- admit the exact sealed Buildchain contract digest carried by the immutable Alpha candidate
- replace the single publication digest comparison with a bounded, per-runtime allowlist
- keep the current runtime digest mandatory and fail closed on duplicate, malformed, or unknown digests
- align the declared PR-head authority with the current Buildchain-serialized queue controller
- supersede #2791 and #2799 after managed history and moving-base guards required an immutable r2 successor

## Verification

- targeted release-admission suites: 59/59 passed
- queue-admission authority contract tests: 6/6 passed
- exact failed-run capability from recovery `31342469171` replayed to `allow`
- complete staged commit gate and KFD evidence checks passed
- exact Atlas work admission root: `sha256:99d7b829fbc1ea607afc265472d35c2cce4d039f8e107e4f0364eca236a843ed`
- failed recovery run `31342469171` stopped before any publication write
- no candidate, release, installer, channel, Passport, signature, or public asset bytes changed

## Recovery coordinates

- source candidate run: `31051528142`
- immutable source SHA: `ad7c7db6df076f969c5939728bcbe70ccd4771b3`
- immutable source tree: `67a93b5831596555e7c29104421de3a0b97eb865`
- immutable release SHA: `f9e6b0e34bcdd6407b2a18206ace7982d64de2c8`
- recovery Buildchain runtime: `c49897528e04f38124869d0e5a6ce73acfb9d7ca`
- sealed candidate contract digest: `sha256:5a6dc69d8905ed852260076da13d3aa3fa63533007dba706c164fe86f8b8f1e6`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded recovery policy recognizes an already sealed candidate contract without changing the accepted release architecture or immutable candidate bytes."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed