### PR TITLE
fix(release): repin Alpha recovery runtime

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -413,7 +413,7 @@ jobs:
       issues: write
       id-token: write
       pull-requests: write
-    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@c49897528e04f38124869d0e5a6ce73acfb9d7ca
+    uses: kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@3d46b490748b87a7163fab6da6b77ef0c86a4460
     with:
       buildchain-channel: auto
       buildchain-ref: ${{ inputs.resume-buildchain-runtime-sha }}

--- a/docs/qualification/gates/release-admission-policy.json
+++ b/docs/qualification/gates/release-admission-policy.json
@@ -23,7 +23,7 @@
       "alpha": {
         "ref": "v3-alpha",
         "runtimeSha": "dd702f22e6afef137c86c5456e167e6db20e88f2",
-        "publicationRuntimeSha": "c49897528e04f38124869d0e5a6ce73acfb9d7ca",
+        "publicationRuntimeSha": "3d46b490748b87a7163fab6da6b77ef0c86a4460",
         "contractDigest": "sha256:15d9f6feaa7f774b7223943de4326285d4a02db459e8ddda4a20418552e65d96",
         "publicationContractDigests": [
           "sha256:15d9f6feaa7f774b7223943de4326285d4a02db459e8ddda4a20418552e65d96",

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -982,9 +982,9 @@
           "authority": "release-control",
           "publication": "channel",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:2915e4c0bbcc8a52667736d604b22d59146491c1cd148eebaf1362f5ef878137",
+          "definitionDigest": "sha256:3cec42b5b346eec35c07ef0cf3c82a078309c2130de7143518007648e46f6aae",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["BUILDCHAIN_ISSUE_APP_ID","BUILDCHAIN_ISSUE_APP_PRIVATE_KEY","KUNGFU_ALPHA_CHANNEL_SIGNING_PRIVATE_KEY","KUNGFU_GITHUB_TOKEN","KUNGFU_GOVERNANCE_AUDITOR_APP_PRIVATE_KEY"],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@c49897528e04f38124869d0e5a6ce73acfb9d7ca"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@3d46b490748b87a7163fab6da6b77ef0c86a4460"],
           "steps": []
         },
         {

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -655,7 +655,7 @@
       "adapter": {
         "type": "buildchain-release-candidate-recovery",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@c49897528e04f38124869d0e5a6ce73acfb9d7ca",
+        "uses": "kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@3d46b490748b87a7163fab6da6b77ef0c86a4460",
         "job": {
           "needs": "recovery-preflight",
           "if": "${{ always() && github.event_name == 'workflow_dispatch' && inputs.resume-candidate-run-id != '' && needs.recovery-preflight.result == 'success' }}"

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -329,7 +329,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:ada6ff9e164d74c7ef96caaf2ac08bccde83765557d69ce2a8f57ad9c11b6c34"
+          "sourceRoot": "sha256:fd2b272b93f278d4a0e1494955940144eb514ed14e6035caf235421eb2961cc7"
         },
         {
           "path": ".github/workflows/release-shifu.yml",
@@ -860,5 +860,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:ff33c9e166f620786cef943f521899af09419ef5a338a3951fd4bb67ae4b41a1"
+  "registryRoot": "sha256:001c7bcf4e44b201f3f108c0ad54fb7a58046bc16253905541c3b5f5e4645c1d"
 }

--- a/scripts/verify-kungfu-release-admission.test.mjs
+++ b/scripts/verify-kungfu-release-admission.test.mjs
@@ -39,7 +39,7 @@ import {
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SOURCE_SHA = '1'.repeat(40);
 const RUNTIME_SHA = 'dd702f22e6afef137c86c5456e167e6db20e88f2';
-const PUBLICATION_RUNTIME_SHA = 'c49897528e04f38124869d0e5a6ce73acfb9d7ca';
+const PUBLICATION_RUNTIME_SHA = '3d46b490748b87a7163fab6da6b77ef0c86a4460';
 const RETIRED_PUBLICATION_RUNTIME_SHA =
   '21030efd277301d642fd9baaa1bd75f02dd3ddc6';
 const STABLE_RUNTIME_SHA = '380b2d8c2a660b07ed785e71276f71dc6a9184f7';


### PR DESCRIPTION
## Summary

- repin the Alpha recovery publication shell to the protected Buildchain merge `3d46b490748b87a7163fab6da6b77ef0c86a4460`
- retain the immutable candidate, source, transaction, contract, and public asset coordinates
- refresh the workflow authority and release-publication source-root projections

## Verification

- release admission tests: 9 passed, 1 intentionally skipped
- release publication control-plane tests: 10/10 passed
- promotion rehearsal: passed without tracked, ref, credential, or remote mutation
- Gate catalog and generated workflow authority: current
- staged commit gate: passed
- `check:source`: 1079 passed, 11 skipped; the sole failure is the unrelated local cold-fixture prerequisite `pytest is not available on PATH`
- exact Atlas work admission root: `sha256:7713a69b0b3b779eb8cfb25614f734dc50dae0c72e97c1684cadcad1483685fe`
- no candidate, release, installer, channel, Passport, signature, or public asset bytes changed

## Recovery coordinates

- source candidate run: `31051528142`
- immutable source SHA: `ad7c7db6df076f969c5939728bcbe70ccd4771b3`
- immutable source tree: `67a93b5831596555e7c29104421de3a0b97eb865`
- immutable release SHA: `f9e6b0e34bcdd6407b2a18206ace7982d64de2c8`
- recovery Buildchain runtime: `3d46b490748b87a7163fab6da6b77ef0c86a4460`
- sealed candidate contract digest: `sha256:5a6dc69d8905ed852260076da13d3aa3fa63533007dba706c164fe86f8b8f1e6`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded recovery runtime repin changes only the exact reviewed publication controller and its generated authority projections; it does not change release architecture or candidate bytes."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation projections updated with behavior

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA4LTA2LWt1bmdmdS1hbHBoYTEtY2FuZGlkYXRlLXJlY292ZXJ5LXJlbGVhc2UiLCJkZWxpdmVyeUNsYXNzIjoibmF0aXZlLXByb29mLXJlcXVpcmVkIiwiZGV2SGVhZCI6IjgwNzgwNjUxYzk0NDcxYWQxMzVhMjMxYWY5YmZiMjBlMDg3YmQ1MjgiLCJwdWxsUmVxdWVzdEhlYWQiOiI1MjAwOTdkOWFiMzZhZGQyYmRmNzVjZWFhMjA4OTA3NmEyN2JhZGM2IiwicmVwbGF5ZWRDYW5kaWRhdGUiOiJhYzU2ZWNiZmJiZDRiN2Y0ZmRiNDQ2OTg3ZGMxZWFhNzkwZWZiZGU3IiwicmVwbGF5ZWRUcmVlIjoiZTJlOTg1MmMzNGViZTIyYjBlODEyYjM5MTM4NDUyMWE4YmE5Y2M5ZSIsInF1ZXVlQXR0ZW1wdCI6IjUyMDA5N2Q5YWIzNmFkZDJiZGY3NWNlYWEyMDg5MDc2YTI3YmFkYzZAODA3ODA2NTFjOTQ0NzFhZDEzNWEyMzFhZjliZmIyMGUwODdiZDUyOCIsImFkbWlzc2lvblByb29mUm9vdCI6InNoYTI1NjoyMTExMDA2Y2U2ODIyOWJmNWI5OTkzOGM2NGY2NGZiNGJhMjI3MzhlZmZjNGRhNTkyNDQ3YWIwNmJkMTc4MDI3IiwiYWRtaXNzaW9uUHJvb2ZSb290cyI6WyJzaGEyNTY6MjExMTAwNmNlNjgyMjliZjViOTk5MzhjNjRmNjRmYjRiYTIyNzM4ZWZmYzRkYTU5MjQ0N2FiMDZiZDE3ODAyNyIsInNoYTI1Njo3NzEzYTY5YjBiM2I3NzllYjhjZmIyNTYxNGY3MzRkYzUwZGFlMGM3MmU5N2MxNjg0Y2FkY2FkMTQ4MzY4NWZlIl0sInN0YXR1c0NvbnRleHQiOiJRdWV1ZSBmYW1pbHkgbGVhc2UvZDk5ZjNhOTE2NjczOWUwZCIsImxlYXNlUm9vdCI6InNoYTI1Njo5ZDNiOWVhMmU1ZTdjOTJkYzZkZjNmOTExMWQ3MGY2YWE1N2QxZjI3YTkxNjdlNGRlZTdkNDQxN2VlZGFiZDdhIn0 -->