### PR TITLE
chore(maintainability): rotate transition review authority

### DIFF
--- a/framework/maintainability/code-complexity-policy.json
+++ b/framework/maintainability/code-complexity-policy.json
@@ -157,6 +157,12 @@
         "key_id": "ed25519-668812bf28659460",
         "algorithm": "ed25519",
         "public_key_pem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAgAti4fLF9HdgLlDoAiGXaKln9GZVGcYCFJG2eJ1/45Q=\n-----END PUBLIC KEY-----\n"
+      },
+      {
+        "authority_id": "kungfu-origin-complexity-transition-review-v2",
+        "key_id": "ed25519-9ff21f6e6f64c985",
+        "algorithm": "ed25519",
+        "public_key_pem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAhihl4wBSlb08qstTTlwPBHUUWbspgENqsZz5X3jnLzE=\n-----END PUBLIC KEY-----\n"
       }
     ],
     "requiredFields": [


### PR DESCRIPTION
Provision the next independent Ed25519 review authority for the existing protected complexity-baseline transition contract. This PR changes no product command, schema, runtime, or compatibility surface.

Only the public key is committed; the authority is bounded to independently signing the exact zero-residue baseline transition.

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"Rotate an independent cryptographic review authority for the existing protected complexity-baseline transition contract without changing product or architecture semantics."}
-->