### PR TITLE
fix(agent): preserve first-run provider terminal

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "872e74cbbcba666698830d9251077937e7f1c09f",
+    "sourceSha": "c40f7a1a4149140558c655fa940d923bcc3c4154",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:225b692b65f126352d9ee96e9afe9e83d0d8bf78f3a17e365d0456a0654b359b"
   },

--- a/framework/core/src/python/kungfu/agent/session_surface.py
+++ b/framework/core/src/python/kungfu/agent/session_surface.py
@@ -320,6 +320,22 @@ def _validate_surface_capabilities(capabilities, *, endpoint):
     )
 
 
+def _run_worker_preserving_standard_streams(runner, *argv):
+    """Start the detached worker without changing caller stdio inheritance."""
+
+    inheritance = []
+    for descriptor in (0, 1, 2):
+        try:
+            inheritance.append((descriptor, os.get_inheritable(descriptor)))
+        except OSError:
+            pass
+    try:
+        return runner(*argv)
+    finally:
+        for descriptor, inheritable in inheritance:
+            os.set_inheritable(descriptor, inheritable)
+
+
 def ensure(runtime_dir, *, runner=None):
     """Ensure and return the runtime-scoped detached Agent Session endpoint."""
 
@@ -349,7 +365,11 @@ def ensure(runtime_dir, *, runner=None):
         import kungfu
 
         runner = kungfu.__binding__.libnode.run
-    exit_code = runner(sys.argv[0], entry)
+    # The embedded Node bootstrap marks inherited descriptors close-on-exec on
+    # some platforms. Restore the exact caller flags before a provider-native
+    # child is launched; otherwise the first provider process starts without a
+    # terminal while later attempts (which reuse the worker) happen to work.
+    exit_code = _run_worker_preserving_standard_streams(runner, sys.argv[0], entry)
     if exit_code not in (None, 0):
         raise ValueError(
             f"native Agent Session bridge exited with status {int(exit_code)}"

--- a/framework/core/tests/python/test_agent_native_first_run_pty.py
+++ b/framework/core/tests/python/test_agent_native_first_run_pty.py
@@ -10,7 +10,9 @@ import time
 import pytest
 
 
-def _run_provider_probe(tmp_path, provider, probe, *, input_bytes=b""):
+def _run_provider_probe(
+    tmp_path, provider, probe, *, input_bytes=b"", cold_start_worker=False
+):
     profile = {
         "id": f"kungfu.agent-runtime.{provider}.pty-probe",
         "provider": provider,
@@ -23,8 +25,37 @@ def _run_provider_probe(tmp_path, provider, probe, *, input_bytes=b""):
             "shellMode": False,
         },
     }
+    cold_start = ""
+    if cold_start_worker:
+        capabilities = {
+            "schema": "kungfu.agent-session.surface-capabilities/v1",
+            "actions": [
+                "capabilities",
+                "show",
+                "plan-native-start",
+                "start-native",
+                "heartbeat-native",
+                "project-native-work",
+                "end-native",
+            ],
+        }
+        cold_start = (
+            "from kungfu.agent import session_surface;"
+            "os.environ.pop('KUNGFU_AGENT_SESSION_ENDPOINT',None);"
+            "surface_calls=[];"
+            "surface_invoke=lambda *_args,**_kwargs: "
+            "((_ for _ in ()).throw(FileNotFoundError('cold start')) "
+            "if not surface_calls and not surface_calls.append(True) "
+            f"else {capabilities!r});"
+            "session_surface.invoke=surface_invoke;"
+            "worker=lambda *_args: "
+            "([os.set_inheritable(fd,False) for fd in (0,1,2)] and 0);"
+            f"session_surface.ensure({str(tmp_path / 'runtime')!r},runner=worker);"
+        )
     wrapper = (
+        "import os;"
         "from kungfu.agent import run_agent;"
+        f"{cold_start}"
         f"profile={profile!r};"
         "raise SystemExit(run_agent.run_native_interactive("
         "profile,"
@@ -103,7 +134,11 @@ def test_codex_first_project_trust_prompt_round_trips_through_the_provider_pty(
         "raise SystemExit(0 if answer=='y' else 1)"
     )
     return_code, output = _run_provider_probe(
-        tmp_path, "codex", probe, input_bytes=b"y\n"
+        tmp_path,
+        "codex",
+        probe,
+        input_bytes=b"y\n",
+        cold_start_worker=True,
     )
     assert return_code == 0, output
     assert "Trust this project? [y/N]" in output

--- a/framework/core/tests/python/test_agent_native_terminal_contract.py
+++ b/framework/core/tests/python/test_agent_native_terminal_contract.py
@@ -213,6 +213,47 @@ def test_agent_session_ensure_reuses_an_explicit_product_endpoint(
     assert runners == []
 
 
+def test_agent_session_worker_launch_restores_standard_stream_inheritance(
+    monkeypatch, tmp_path
+):
+    monkeypatch.delenv("KUNGFU_AGENT_SESSION_ENDPOINT", raising=False)
+    calls = []
+
+    def invoke(*_args, **_kwargs):
+        calls.append(True)
+        if len(calls) == 1:
+            raise FileNotFoundError("cold worker")
+        return NATIVE_SURFACE_CAPABILITIES
+
+    inheritance = {0: True, 1: False, 2: True}
+
+    def run_worker(*_args):
+        for descriptor in inheritance:
+            inheritance[descriptor] = False
+        return 0
+
+    monkeypatch.setattr(session_surface, "invoke", invoke)
+    monkeypatch.setattr(session_surface, "_resolve_native_entry", lambda: "/entry.mjs")
+    monkeypatch.setattr(
+        session_surface, "_resolve_worker_executable", lambda: "/kungfu"
+    )
+    monkeypatch.setattr(
+        session_surface.os,
+        "get_inheritable",
+        lambda descriptor: inheritance[descriptor],
+    )
+    monkeypatch.setattr(
+        session_surface.os,
+        "set_inheritable",
+        lambda descriptor, value: inheritance.__setitem__(descriptor, value),
+    )
+
+    endpoint = session_surface.ensure(tmp_path / "runtime", runner=run_worker)
+
+    assert endpoint == session_surface.endpoint_for_runtime(tmp_path / "runtime")
+    assert inheritance == {0: True, 1: False, 2: True}
+
+
 def test_native_interactive_uses_controlling_terminal_before_registering_attempt(
     monkeypatch, tmp_path
 ):

--- a/scripts/shifu-documentation-surfaces.test.mjs
+++ b/scripts/shifu-documentation-surfaces.test.mjs
@@ -157,6 +157,7 @@ test(
         'kungfu-format-contract',
         'kungfu-gui',
         'kungfu-kfx-development',
+        'kungfu-kfx-service-webhook',
         'kungfu-operations',
         'kungfu-primitive-management',
         'kungfu-sdk',


### PR DESCRIPTION
## Summary

Preserve the inherited terminal contract when the native Node worker launches a provider-native UI, so first-run interactive prompts such as Codex project trust remain visible and actionable instead of collapsing into an opaque provider exit.

This is the Runtime/PTY leaf split from #2816 after canonical dev moved twice and the original 42-commit delivery hit real Project Cut replay conflicts. Keeping this leaf to two commits minimizes the protected replay surface.

## Related issue

None.

## Changes

- snapshot and restore inheritable standard I/O flags around the embedded Node runner
- add PTY and terminal-contract regressions covering first-run prompts and exit propagation
- regenerate the required KFD collaboration projection
- align the documentation webhook parity inventory introduced by the current dev base

## Verification

- targeted PTY/terminal tests: 22 passed
- `node --test scripts/shifu-documentation-surfaces.test.mjs`: 9 passed
- `./shifu check:source`: passed, including zero-write audit
- Project Cut merge-queue admission: qualified against `dev/v4/v4.0` at `c40f7a1a4149140558c655fa940d923bcc3c4154`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded bug fix restores the existing provider terminal contract without changing architecture or release authority"
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The provider boundary is limited to preserving inherited PTY/stdio behavior. No provider credentials or stored authentication data are read or changed.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
