### PR TITLE
fix(product): keep reference KFX outside assembly

### DIFF
--- a/extensions/github-webhook-reference-suite/package.json
+++ b/extensions/github-webhook-reference-suite/package.json
@@ -3,5 +3,8 @@
   "version": "0.1.0",
   "description": "Maintained GitHub webhook ingress, evidence view, and optional Dogfood Finding bridge",
   "license": "Apache-2.0",
-  "private": true
+  "private": true,
+  "kungfuProduct": {
+    "assembly": "reference-only"
+  }
 }

--- a/product/scripts/dist.mjs
+++ b/product/scripts/dist.mjs
@@ -579,12 +579,17 @@ function parseJsonOutput(output, label) {
   }
 }
 
-function listKfxPackages() {
+export function listKfxPackages() {
   const packages = [];
   const visit = (dir, depth) => {
     if (depth > 2 || !fs.existsSync(dir)) return;
+    const packagePath = path.join(dir, 'package.json');
+    if (fs.existsSync(packagePath)) {
+      const pkg = readJson(packagePath);
+      if (pkg.kungfuProduct?.assembly === 'reference-only') return;
+    }
     if (fs.existsSync(path.join(dir, 'kungfu.kfx.json'))) {
-      const pkg = readJson(path.join(dir, 'package.json'));
+      const pkg = readJson(packagePath);
       const manifest = readJson(path.join(dir, 'kungfu.kfx.json'));
       if (manifest?.name && manifest?.kungfuConfig) {
         packages.push({

--- a/product/scripts/dist.test.mjs
+++ b/product/scripts/dist.test.mjs
@@ -20,6 +20,7 @@ import {
   installedKungfuInvocation,
   isShippedKfdSupport,
   kfxBundleExternalModules,
+  listKfxPackages,
   materializeProductRuntimeEntrypoints,
   requiresManagedEsbuildPlatform,
   runInstalledKungfuAgentHubSmoke,
@@ -53,6 +54,16 @@ const {
   esmEntrypointArgs,
   toEsmEntrypointSpecifier,
 } = require('../../framework/gui/scripts/before-pack.cjs');
+
+test('reference-only KFX suites stay outside product assembly', () => {
+  const packageNames = listKfxPackages().map((pkg) => pkg.name);
+  assert.ok(packageNames.includes('@kungfu-tech/kfx-suite-agent-work-lab'));
+  assert.ok(
+    packageNames.every((name) => !name.includes('github-webhook')),
+    packageNames.join(', '),
+  );
+  assert.ok(!packageNames.includes('@kungfu-kfx/github-dogfood-bridge'));
+});
 
 test('Intel macOS is rejected by the product-wide host policy', () => {
   for (const architecture of ['x64', 'x86_64']) {


### PR DESCRIPTION
## Summary

- declare the maintained GitHub webhook KFX suite as reference-only product material
- prune a reference-only suite before recursive product KFX discovery and assembly
- prove ordinary product KFX still assemble while the excluded reference members stay outside the release

## Validation

- `node --test product/scripts/dist.test.mjs` (44/44)
- `node scripts/alpha-promotion-preflight.mjs fast-sentinel --kind auditable-demo --out /tmp/runtime-hub-auditable-demo-sentinel.json`
- `node --check product/scripts/dist.mjs`
- `node --check product/scripts/dist.test.mjs`
- `git diff --check`

This repairs the exact Build failure observed at `product/package.json must declare every product-assembled KFX dependency` without turning installed-only reference members into product dependencies.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This corrective product-packaging boundary prevents an explicitly reference-only example suite from entering assembly and does not alter a released architecture contract."
}
-->

## Evolution Map impact

Evolution impact: none
