### PR TITLE
fix(product): externalize native worker bytecode cache

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "c40f7a1a4149140558c655fa940d923bcc3c4154",
+    "sourceSha": "9faee1ff05d03cc62b86760e8568fa10b0defe08",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:225b692b65f126352d9ee96e9afe9e83d0d8bf78f3a17e365d0456a0654b359b"
   },

--- a/crates/trunk/src/launch.rs
+++ b/crates/trunk/src/launch.rs
@@ -137,8 +137,7 @@ fn runtime_build_id_from_json(contents: &str) -> Result<String, String> {
 }
 
 fn runtime_build_id() -> Result<String, String> {
-    let Some(manifest_path) = env::var_os("KUNGFU_UPGRADE_MANIFEST").filter(|v| !v.is_empty())
-    else {
+    let Some(manifest_path) = resolved_upgrade_manifest_path() else {
         return Ok(DEVELOPMENT_RUNTIME_BUILD_ID.to_string());
     };
     let contents = fs::read_to_string(&manifest_path).map_err(|e| {
@@ -150,6 +149,24 @@ fn runtime_build_id() -> Result<String, String> {
     runtime_build_id_from_json(&contents)
 }
 
+fn adjacent_upgrade_manifest(executable: &Path) -> Option<PathBuf> {
+    executable.parent()?.parent().map(|resources| {
+        resources
+            .join("upgrade")
+            .join("kungfu-release-manifest.json")
+    })
+}
+
+fn resolved_upgrade_manifest_path() -> Option<PathBuf> {
+    if let Some(explicit) = env::var_os("KUNGFU_UPGRADE_MANIFEST").filter(|v| !v.is_empty()) {
+        return Some(PathBuf::from(explicit));
+    }
+    env::current_exe()
+        .ok()
+        .and_then(|executable| adjacent_upgrade_manifest(&executable))
+        .filter(|manifest| manifest.is_file())
+}
+
 fn python_cache_environment() -> Result<PythonCacheEnvironment, String> {
     let cache_home = product_cache_home()?;
     let pycache_prefix = cache_home.join("python").join(runtime_build_id()?);
@@ -157,6 +174,24 @@ fn python_cache_environment() -> Result<PythonCacheEnvironment, String> {
         cache_home,
         pycache_prefix,
     })
+}
+
+/// Establish the product cache contract in this process before a native
+/// runtime variant takes ownership. Normal CLI and GUI launches already pass
+/// these variables to children, but a detached Node worker can enter through
+/// `variant::dispatch` directly and must not depend on its parent having done
+/// so. This also protects workers that survive an in-place App upgrade.
+pub fn configure_product_cache_environment() -> Result<(), String> {
+    let manifest = resolved_upgrade_manifest_path();
+    let cache = python_cache_environment()?;
+    if env::var_os("KUNGFU_UPGRADE_MANIFEST").is_none() {
+        if let Some(manifest) = manifest {
+            env::set_var("KUNGFU_UPGRADE_MANIFEST", manifest);
+        }
+    }
+    env::set_var("KF_CACHE_HOME", cache.cache_home);
+    env::set_var("PYTHONPYCACHEPREFIX", cache.pycache_prefix);
+    Ok(())
 }
 
 /// Whether this process was invoked under the product entry name rather than
@@ -459,6 +494,14 @@ mod tests {
         );
         assert!(runtime_build_id_from_json(r#"{"runtimeBuildId":"../escape"}"#).is_err());
         assert!(runtime_build_id_from_json(r#"{"version":"4.0.0"}"#).is_err());
+        assert_eq!(
+            adjacent_upgrade_manifest(Path::new(
+                "/Applications/Kungfu Episodes.app/Contents/Resources/kungfu/kungfu"
+            )),
+            Some(PathBuf::from(
+                "/Applications/Kungfu Episodes.app/Contents/Resources/upgrade/kungfu-release-manifest.json"
+            ))
+        );
     }
 
     #[test]

--- a/crates/trunk/src/variant.rs
+++ b/crates/trunk/src/variant.rs
@@ -72,6 +72,13 @@ pub fn dispatch() -> Option<i32> {
                 env::args_os().nth(1).as_deref(),
             ) =>
         {
+            // This fast path bypasses the normal product launch functions, so
+            // the worker itself must establish the external Python cache
+            // contract before it can launch any bundled interpreter child.
+            if let Err(message) = crate::launch::configure_product_cache_environment() {
+                eprintln!("kungfu: {message}");
+                return Some(1);
+            }
             run_node()
         }
         Some("node") => {

--- a/product/scripts/qualify-product-cache-home.mjs
+++ b/product/scripts/qualify-product-cache-home.mjs
@@ -152,8 +152,80 @@ export function qualifyProductCacheHome(options = {}) {
     fail('packaged GUI did not report its qualification-ready marker');
   }
 
+  // Detached Agent Session workers enter the native Node variant before the
+  // normal CLI/GUI launchers. Exercise that exact cold path without inherited
+  // cache variables, then have it start the bundled interpreter directly. The
+  // native executable itself must recover the adjacent release manifest and
+  // establish the external, versioned bytecode cache contract.
+  const nativeNodeHome = path.join(cacheHome, 'native-node-home');
+  const nativeNodeCacheHome = path.join(
+    nativeNodeHome,
+    'Library',
+    'Caches',
+    'kungfu',
+  );
+  fs.mkdirSync(nativeNodeHome, { recursive: true });
+  const nativeNodeProbe = path.join(cacheHome, 'native-node-cache-probe.mjs');
+  const bundledPython = path.join(
+    app,
+    'Contents',
+    'Resources',
+    'kungfu',
+    'python',
+    'bin',
+    'python3',
+  );
+  fs.writeFileSync(
+    nativeNodeProbe,
+    [
+      "import { spawnSync } from 'node:child_process';",
+      'if (!process.env.KF_CACHE_HOME || !process.env.PYTHONPYCACHEPREFIX) process.exit(91);',
+      "const child = spawnSync(process.argv[2], ['-c', 'import pkgutil'], { env: process.env, encoding: 'utf8' });",
+      "if (child.status !== 0) { process.stderr.write(child.stderr || 'python cache probe failed'); process.exit(child.status ?? 92); }",
+      "process.stdout.write('KF_NATIVE_NODE_CACHE_READY\\n');",
+    ].join('\n'),
+  );
+  const nativeNodeEnv = {
+    ...Object.fromEntries(
+      Object.entries(ambientEnv).filter(
+        ([key]) =>
+          ![
+            'KF_CACHE_HOME',
+            'KF_INSTANCE_HOME',
+            'PYTHONPYCACHEPREFIX',
+            'KUNGFU_UPGRADE_MANIFEST',
+          ].includes(key),
+      ),
+    ),
+    HOME: nativeNodeHome,
+    KUNGFU_AS_VARIANT: 'node',
+    KUNGFU_NODE_VARIANT_ENTRY: nativeNodeProbe,
+  };
+  const nativeNodeInvocation = runCommand(
+    cli,
+    [nativeNodeProbe, bundledPython],
+    {
+      cwd: cacheHome,
+      env: nativeNodeEnv,
+      encoding: 'utf8',
+      timeout: 60_000,
+      maxBuffer: 16 * 1024 * 1024,
+    },
+  );
+  if (nativeNodeInvocation.status !== 0) {
+    fail(
+      `native Node cache probe exited ${nativeNodeInvocation.status ?? nativeNodeInvocation.signal}: ${(nativeNodeInvocation.stderr || '').trim()}`,
+    );
+  }
+  if (!nativeNodeInvocation.stdout.includes('KF_NATIVE_NODE_CACHE_READY')) {
+    fail('native Node cache probe did not report its ready marker');
+  }
+
   const afterDigest = treeDigest(app);
   const cacheBytecode = bytecodePaths(path.join(cacheHome, 'python'));
+  const nativeNodeBytecode = bytecodePaths(
+    path.join(nativeNodeCacheHome, 'python'),
+  );
   const finalBytecode = bytecodePaths(app);
   if (beforeDigest !== afterDigest)
     fail('application tree changed after CLI use');
@@ -162,6 +234,9 @@ export function qualifyProductCacheHome(options = {}) {
   }
   if (cacheBytecode.length === 0) {
     fail('CLI use did not create Python bytecode under KF_CACHE_HOME/python');
+  }
+  if (nativeNodeBytecode.length === 0) {
+    fail('native Node worker did not externalize bundled Python bytecode');
   }
   if (verifySignature) verifyCodesign(app, runCommand);
 
@@ -177,6 +252,7 @@ export function qualifyProductCacheHome(options = {}) {
       immutableAppTree: true,
       noPackagedPythonBytecode: true,
       externalVersionedPythonCache: true,
+      nativeNodeWorkerCacheBootstrap: true,
       packagedGuiBoot: true,
     },
   };

--- a/product/scripts/qualify-product-cache-home.test.mjs
+++ b/product/scripts/qualify-product-cache-home.test.mjs
@@ -42,16 +42,26 @@ test('qualification proves external bytecode without changing the app tree', () 
     app,
     verifySignature: false,
     runCommand: (_command, args, options) => {
-      const prefix = path.join(
-        options.env.KF_CACHE_HOME,
-        'python',
-        'runtime-fixture',
-      );
+      const nativeNode = options.env.KUNGFU_AS_VARIANT === 'node';
+      const prefix = nativeNode
+        ? path.join(
+            options.env.HOME,
+            'Library',
+            'Caches',
+            'kungfu',
+            'python',
+            'runtime-fixture',
+          )
+        : path.join(options.env.KF_CACHE_HOME, 'python', 'runtime-fixture');
       fs.mkdirSync(prefix, { recursive: true });
       fs.writeFileSync(path.join(prefix, 'module.pyc'), 'bytecode');
       return {
         status: 0,
-        stdout: args.length === 0 ? 'KF_GUI_QUALIFICATION_READY\n' : 'brief',
+        stdout: nativeNode
+          ? 'KF_NATIVE_NODE_CACHE_READY\n'
+          : args.length === 0
+            ? 'KF_GUI_QUALIFICATION_READY\n'
+            : 'brief',
         stderr: '',
       };
     },
@@ -60,6 +70,7 @@ test('qualification proves external bytecode without changing the app tree', () 
   assert.equal(report.appDigest, before);
   assert.equal(report.pythonBytecodeFiles, 1);
   assert.equal(report.checks.packagedGuiBoot, true);
+  assert.equal(report.checks.nativeNodeWorkerCacheBootstrap, true);
   assert.equal(treeDigest(app), before);
 });
 


### PR DESCRIPTION
## Summary

Ensure a packaged GUI/native Node worker establishes the external Kungfu Python bytecode cache before it can launch the bundled interpreter. This prevents first-run or long-lived workers from writing `.pyc` files into the signed macOS App bundle.

This is the Product cache leaf split from #2816. It follows the merged Runtime/PTY leaf #2822 and is intentionally limited to one source commit.

## Related issue

None.

## Changes

- resolve the adjacent packaged upgrade manifest when no explicit manifest environment is inherited
- initialize `KF_CACHE_HOME` and `PYTHONPYCACHEPREFIX` in the direct native Node variant path
- exercise the exact cold native-worker path with no inherited cache variables
- require bundled Python bytecode to appear under the isolated Kungfu cache while the App tree digest remains unchanged
- regenerate the required KFD collaboration projection

## Verification

- `cargo test --manifest-path crates/Cargo.toml -p kungfu-trunk`: 55 passed
- `node --test product/scripts/qualify-product-cache-home.test.mjs`: 2 passed
- staged Rust/JS/KFD gate: passed
- `./shifu check:source`: passed, including zero-write audit
- Project Cut merge-queue admission: qualified against `dev/v4/v4.0` at `9faee1ff05d03cc62b86760e8568fa10b0defe08`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded bug fix enforces the existing external product cache contract without changing architecture or release authority"
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The release boundary is limited to packaged runtime cache qualification. No artifact is published by this PR.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
