### PR TITLE
docs(readme): explain the project-local Kungfu directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ already use. Pass a task to create the first Work directly:
 kungfu run codex "Prepare the release notes"
 ```
 
+**When `.kungfu/` appears.** It is Kungfu's project-local workspace for durable
+Work and runtime state. Do not delete it or add the whole directory to Git. Ask
+your Agent to run `kungfu agent map --json` and follow its `workspaceGit` policy
+before staging anything. Most contents stay local; Kungfu never stages,
+commits, or pushes files for you.
+
 **Open the optional global view later.** The Kungfu TUI and GUI can show and
 manage Kungfu Projects and Work across Agent Sessions. They are sidecar views,
 not a requirement for every Agent conversation.


### PR DESCRIPTION
## Summary

Explain the project-local `.kungfu/` directory at first use and direct Agents to the installed `workspaceGit` policy before staging.

## Verification

- `./shifu docs validate --json`
- `./shifu docs:check`
- `./shifu check:source`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This README clarification does not alter an architecture contract or release boundary"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed