### PR TITLE
fix(release): align transport rendition contract

### DIFF
--- a/scripts/alpha-promotion-preflight.mjs
+++ b/scripts/alpha-promotion-preflight.mjs
@@ -77,6 +77,24 @@ const NON_REUSABLE_EVIDENCE = [
   'signing',
 ];
 const EXACT_BUILDCHAIN_SHA = /^[0-9a-f]{40}$/u;
+const BUILDCHAIN_V3_NATIVE_RENDITIONS = [
+  {
+    id: '1080p',
+    role: 'primary',
+    columns: 150,
+    rows: 36,
+    width: 1920,
+    height: 1080,
+  },
+  {
+    id: '720p',
+    role: 'responsive',
+    columns: 150,
+    rows: 28,
+    width: 1280,
+    height: 720,
+  },
+];
 const WINDOWS_CONTINUITY_FILES = [
   'framework/core/src/python/kungfu/peer_lifecycle.py',
   'framework/core/tests/python/test_peer_lifecycle.py',
@@ -213,6 +231,8 @@ export function inspectAuditableDemoFastSentinel({
     transportScenarioValue?.schema !==
       'buildchain.declarative-binary-demo/v1' ||
     transportScenarioValue?.execution?.totalTimeoutSeconds !== 60 ||
+    JSON.stringify(transportScenarioValue?.renditions) !==
+      JSON.stringify(BUILDCHAIN_V3_NATIVE_RENDITIONS) ||
     JSON.stringify(transportScenarioValue?.product) !==
       JSON.stringify(scenarioValue?.product) ||
     JSON.stringify(transportScenarioValue?.artifact) !==
@@ -223,7 +243,7 @@ export function inspectAuditableDemoFastSentinel({
       JSON.stringify(scenarioValue?.authority)
   ) {
     issues.push(
-      'auditable-demo transport scenario no longer binds the exact bounded v3-compatible artifact smoke',
+      'auditable-demo transport scenario no longer binds the exact bounded v3-compatible artifact smoke and native rendition profiles',
     );
   }
   requirePattern(

--- a/scripts/alpha-promotion-preflight.test.mjs
+++ b/scripts/alpha-promotion-preflight.test.mjs
@@ -496,6 +496,23 @@ test('fast sentinels fail the representative recent invalid fixtures', () => {
   );
 });
 
+test('auditable-demo fast sentinel rejects Buildchain v3 rendition drift', () => {
+  const scenario = JSON.parse(
+    fs.readFileSync('.buildchain/auditable-demo.json', 'utf8'),
+  );
+  const transportScenario = JSON.parse(
+    fs.readFileSync('.buildchain/auditable-demo-transport-smoke.json', 'utf8'),
+  );
+  transportScenario.renditions[1].columns = 100;
+  const issues = inspectAuditableDemoFastSentinel({
+    workflow: fs.readFileSync('.github/workflows/build.yml', 'utf8'),
+    scenario,
+    transportScenario,
+    product: fs.readFileSync('product/scripts/dist.mjs', 'utf8'),
+  });
+  assert.match(issues.join('\n'), /native rendition profiles/u);
+});
+
 test('patrol, normal Alpha builds and sentinels keep one controller authority', () => {
   const patrol = fs.readFileSync(
     '.github/workflows/dev-alpha-candidate-patrol.yml',


### PR DESCRIPTION
<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Correct the existing Buildchain v3 transport rendition declaration and add fail-fast regression coverage without changing an architecture contract."
}
-->

## Summary

- align the auditable-demo 720p rendition with the Buildchain v3 native contract (150x28)
- fail fast in Alpha preflight when the rendition vocabulary drifts
- add a regression test for the obsolete 100-column profile

## Root cause

Exact-dev self-hosted build run 31382604081 stopped before platform jobs because `.buildchain/auditable-demo-transport-smoke.json` still declared 720p columns=100, while the pinned Buildchain v3 validator requires 150 columns for both native profiles. The existing workflow test asserted the stale value and the fast sentinel did not validate rendition profiles.

## Validation

- targeted JS tests: 28/28 passed
- auditable-demo fast sentinel: passed
- `./shifu check:source`: passed
- staged pre-commit source gate: passed

No release, tag, or Alpha publication is requested.