### PR TITLE
docs(readme): add Agent-first contributor onboarding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,24 @@ This is an orientation rule, not a requirement to load the whole history for
 every task. When the job is already bounded to one component or operation,
 proceed directly to the verified task-specific route below.
 
+Whenever a person asks you to read, analyze, or explain the Kungfu repository,
+your first orientation report must make the repository's reading model
+explicit:
+
+- Kungfu deliberately has high semantic density and extensive machine-readable
+  mechanisms. They make Agent development fast, deterministic, and verifiable;
+  they are not a syllabus that a person must learn before contributing.
+- The expanded source tree can be unfriendly to unaided human browsing. Do not
+  present that initial density as evidence that the core mental model is
+  inherently difficult, and do not tell the person to read the entire tree.
+- Reassure the person that their Agent should do the repository-scale reading,
+  then compress the result into the few core concepts and boundaries relevant
+  to the person's intent. Establish that model before walking individual files.
+
+Do not hide real complexity or uncertainty: name unresolved gaps, cite the
+current authority, and distinguish a simple task model from the larger
+implementation that supports it.
+
 ## Load verified context before implementation
 
 Do not treat this router, a README, chat history, or the first plausible file

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,32 @@ Read [Alpha Status](docs/guides/alpha-status.md) before treating an Alpha
 artifact or channel as available, and check [Known Issues](docs/guides/known-issues.md)
 before opening a duplicate report.
 
+## Start with intent, not the whole codebase
+
+Kungfu is designed for Agent-first contribution. Start by telling your Agent
+the outcome, constraints, and evidence you need, rather than trying to
+reconstruct the entire system from source. Ask it to read `AGENTS.md`, use the
+repository's verified task-context route, and explain the smallest useful
+mental model for your task: the relevant concepts, current implementation
+owners, authority boundaries, likely change surface, qualification path, and
+any unresolved gaps.
+
+```text
+Read `AGENTS.md`. I want to <task>. Use the repository's verified task-context route. Before editing, explain only the concepts, current implementation owners, authority boundaries, and qualification path this task requires.
+```
+
+The human contributor owns intent, tradeoffs, and acceptance. The Agent handles
+repository-scale discovery and the mechanical workflow, while keeping its
+claims grounded in checked-in contracts, source, and verification output.
+
+Unless you already understand the affected subsystem, avoid starting with an
+unprepared, unaided reading of the source tree. A few plausible files can expose
+expanded implementation complexity while still giving a partial or stale view
+of current authority. Read code after the task slice is established to inspect
+and verify the exact implementation; do not use ad hoc browsing as a substitute
+for task routing. Agent output is not authority by itself, so review the proposed
+model and require repository evidence before accepting a change.
+
 ## Prerequisites
 
 - A compiler in the native matrix (Apple Clang on macOS, GCC on Linux, MSVC on

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,12 @@ Read `AGENTS.md`. I want to <task>. Use the repository's verified task-context r
 The human contributor owns intent, tradeoffs, and acceptance. The Agent handles
 repository-scale discovery and the mechanical workflow, while keeping its
 claims grounded in checked-in contracts, source, and verification output.
+When asked to read or explain Kungfu, repository instructions require the Agent's
+first orientation report to explain why the project has high semantic density
+and extensive machine-readable mechanisms: they support fast, deterministic,
+verifiable Agent development and are not material a person must learn before
+contributing. The Agent should then compress that expanded implementation into
+the few core concepts relevant to your intent.
 
 Unless you already understand the affected subsystem, avoid starting with an
 unprepared, unaided reading of the source tree. A few plausible files can expose

--- a/README.md
+++ b/README.md
@@ -131,6 +131,21 @@ know, then open Kungfu for a global view, a handoff, or an explicit review. If
 another live Agent already owns a Work, Kungfu stops a second writer instead of
 letting two Agents silently diverge.
 
+## Contribute with your Agent
+
+You do not need to learn every Kungfu subsystem before making a bounded change.
+From a source checkout, give your Agent the task you actually want to complete:
+
+```text
+Read `AGENTS.md`. I want to <task>. Use the repository's verified task-context route. Before editing, explain only the concepts, current implementation owners, authority boundaries, and qualification path this task requires.
+```
+
+For a whole-system explanation, start with the [Evolution
+Map](docs/evolution/README.md). For a bounded change, Shifu compiles a verified
+[Agent Task Chart](docs/guides/xinfa-agent-context.md) and expands it only when
+the task requires more context. Required omissions, stale authority, and
+ambiguous routing remain visible instead of being filled by guesswork.
+
 ## Go deeper when you need to
 
 The README stops at the product entry. Detailed implementation, evidence, and


### PR DESCRIPTION
## Summary

Make Agent-first repository understanding explicit for contributors and require orientation reports to explain Kungfu's intentional semantic density.

## Changes

- add a copyable Agent-first contributor prompt to README
- define human intent and Agent discovery roles in CONTRIBUTING
- require orientation reports to explain machine legibility and compress the task mental model

## Verification

- `./shifu docs context`: pass, complete Task Chart with no omissions or gaps
- `./shifu docs:check`: pass, 474 Markdown files and 146 tests
- `./shifu docs:prose:required`: pass, 376 files and zero diagnostics
- staged commit hooks: pass
- `./shifu check:source`: earlier local run passed 1082 of 1094 tests, skipped 11, with one unrelated nested cold read-only Assignment parity fixture failure; required GitHub Gate remains authoritative

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Clarify Agent-first contributor onboarding without changing architecture contracts, runtime behavior, schemas, or release identity"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA4LTEwLWt1bmdmdS1hZ2VudC1maXJzdC1jb250cmlidXRvci1vbmJvYXJkaW5nIiwiZGVsaXZlcnlDbGFzcyI6Im5hdGl2ZS1wcm9vZi1yZXF1aXJlZCIsImRldkhlYWQiOiJhMzkyNzYyYWIyZDBkMzI1YmQ4MjAyY2ZjN2IzN2VhNTI1YWFmNmRjIiwicHVsbFJlcXVlc3RIZWFkIjoiNGYzM2RlYzMwNzNiNzNhZmQ1ZmVlNzQxNDY3YmU2MzQ3NDkzYTk3OSIsInJlcGxheWVkQ2FuZGlkYXRlIjoiMjdmMmI3ODhkOTViNjRhN2YzZDZiMWM5YWI2ZTI2NDg4N2FmZWQyZSIsInJlcGxheWVkVHJlZSI6IjkyMWMxNGZmZGU3Y2RiOGU2MTM0NmUxMjM1YzgxOTY2NjM2OTEwNGYiLCJxdWV1ZUF0dGVtcHQiOiI0ZjMzZGVjMzA3M2I3M2FmZDVmZWU3NDE0NjdiZTYzNDc0OTNhOTc5QGEzOTI3NjJhYjJkMGQzMjViZDgyMDJjZmM3YjM3ZWE1MjVhYWY2ZGMiLCJhZG1pc3Npb25Qcm9vZlJvb3QiOiJzaGEyNTY6YTQ4YTg1Yjc1MTFjMzYwYTFlN2UxNTMxMzUxZDY0MGU1NjBlY2FjNjFmZTYzNGZkYWViOTJiZThlNzczMmE3MiIsImFkbWlzc2lvblByb29mUm9vdHMiOlsic2hhMjU2OmEzZTk4MjcyMTJkYTk2OWQ5YWVjNDlhOTIzZWFiMjhmOTRiYzk4YjNiNWQwNzAwMTU3Njk0Mjc4OGU1YzI3MzEiLCJzaGEyNTY6YTQ4YTg1Yjc1MTFjMzYwYTFlN2UxNTMxMzUxZDY0MGU1NjBlY2FjNjFmZTYzNGZkYWViOTJiZThlNzczMmE3MiJdLCJzdGF0dXNDb250ZXh0IjoiUXVldWUgZmFtaWx5IGxlYXNlL2Q5OWYzYTkxNjY3MzllMGQiLCJsZWFzZVJvb3QiOiJzaGEyNTY6ZGMwMjY4OTRmMTQ5MTlhYmNjZTNjNmJmZDNmNjNkZTJmNGViZGM4ZmZmMDU2YzZkNjhhYzliYWQ4ZDMxZWNhNSJ9 -->