### PR TITLE
fix(release): refresh auditable demo KFD gates

### DIFF
--- a/.buildchain/buildchain.toml
+++ b/.buildchain/buildchain.toml
@@ -84,12 +84,6 @@ profile = "auto"
 kind = "archive"
 platforms = ["macos-arm64"]
 required = true
-entitlements_profile = "jit-executable-v1"
-entitlements_paths = [
-  "kungfu-episodes-cli-darwin-arm64/runtime/kungfu",
-  "kungfu-episodes-cli-darwin-arm64/runtime/python/bin/python3",
-  "kungfu-episodes-cli-darwin-arm64/runtime/python/bin/python3.13",
-]
 
 [[signing.artifacts]]
 id = "kungfu-desktop-macos-arm64"

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "202e266d0dea9473a5948b062887dc47f66b485c",
+    "sourceSha": "03c54ae642d28d219d739504c30a14f2889d3c08",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:504a67ce741c0f2ac63fa3c2cbc4ad93c76db68db2056567ba7a1055907fb838"
   },

--- a/scripts/alpha-macos-overflow.test.mjs
+++ b/scripts/alpha-macos-overflow.test.mjs
@@ -489,16 +489,9 @@ test('workflow contract keeps candidates exact-source, independent, and publish-
   const signing = fs.readFileSync('.buildchain/buildchain.toml', 'utf8');
   assert.match(
     signing,
-    /id = "kungfu-cli-macos-arm64"[\s\S]*entitlements_profile = "jit-executable-v1"/u,
+    /id = "kungfu-cli-macos-arm64"[\s\S]*profile = "auto"[\s\S]*platforms = \["macos-arm64"\][\s\S]*required = true/u,
   );
-  for (const executable of [
-    'kungfu-episodes-cli-darwin-arm64/runtime/kungfu',
-    'kungfu-episodes-cli-darwin-arm64/runtime/python/bin/python3',
-    'kungfu-episodes-cli-darwin-arm64/runtime/python/bin/python3.13',
-  ]) {
-    assert.match(signing, new RegExp(`"${executable}"`, 'u'));
-  }
-  assert.doesNotMatch(signing, /entitlements_paths = \[[^\]]*libnode/su);
+  assert.doesNotMatch(signing, /entitlements_(?:profile|paths)/u);
   assert.match(workflow, /checkout-history-mode: full/u);
   assert.match(
     workflow,


### PR DESCRIPTION
## Summary

- remove unsupported executable-level entitlements hints from the Buildchain signing declaration
- retain the declarative macOS archive signing profile and fail closed if executable hints return
- regenerate the source-bound KFD prebuild witness from the latest development base so release qualification can enter auditable-demo rendering

## Verification

- `./shifu kfd2:claims:check`
- `./shifu kfd:buildchain:check`
- `./shifu test:alpha-macos-overflow` (14 passed)
- `./shifu check:source` (1097 tests, 1086 passed, 11 skipped, 0 failed; zero-write root unchanged)
- repository staged gate passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Aligns checked-in signing inputs and generated KFD evidence with the existing Buildchain-owned signing and source-binding contracts; no architecture decision changes."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces

No credentials or publication authority are changed. The patch narrows the product declaration and refreshes generated evidence through the existing repository-owned generator.
