### PR TITLE
fix(source): bound cold read-only acceptance

### DIFF
--- a/scripts/readonly-agent-bootstrap.test.mjs
+++ b/scripts/readonly-agent-bootstrap.test.mjs
@@ -138,8 +138,6 @@ function sourceAuditRoot(rows) {
 }
 
 function boundedDiagnosticTail(...values) {
-  const [stderr] = values;
-  if (stderr) return stderr.slice(-24 * 1024);
   const output = values.filter(Boolean).join('\n');
   const lines = output.split(/\r?\n/u);
   const failingTestsIndex = lines.findLastIndex(
@@ -153,11 +151,21 @@ function boundedDiagnosticTail(...values) {
   const failureSummaryIndex = lines.findLastIndex((line) =>
     /^(?:ℹ fail [1-9]|# fail [1-9])/u.test(line.trimStart()),
   );
-  if (failureSummaryIndex >= 0)
+  if (failureSummaryIndex >= 0) {
+    const failedTestIndex = lines.findLastIndex(
+      (line, index) => index < failureSummaryIndex && /^not ok \d+/u.test(line),
+    );
     return lines
-      .slice(Math.max(0, failureSummaryIndex - 8), failureSummaryIndex + 40)
+      .slice(
+        Math.max(
+          0,
+          failedTestIndex >= 0 ? failedTestIndex : failureSummaryIndex - 80,
+        ),
+        failureSummaryIndex + 40,
+      )
       .join('\n')
       .slice(0, 24 * 1024);
+  }
   return output.slice(-24 * 1024);
 }
 
@@ -699,10 +707,17 @@ test('declared discovery routes are zero-write in a cold read-only fixture', (t)
     }
   }
   for (const relative of evidencePaths) copyFile(ROOT, fixture, relative);
+  for (const relative of [
+    'node_modules/@kungfu-tech/buildchain/package.json',
+    'node_modules/@kungfu-tech/buildchain/dist/site/buildchain-contract.json',
+    'node_modules/@kungfu-tech/buildchain/dist/site/publication-authority-registry.json',
+  ])
+    copyFile(ROOT, fixture, relative);
   fs.chmodSync(path.join(fixture, 'shifu'), 0o755);
 
   fs.symlinkSync(git, path.join(tools, 'git'));
   fs.symlinkSync(node, path.join(tools, 'node'));
+  fs.symlinkSync(executableOnPath('python3'), path.join(tools, 'python3'));
   for (const [name, relative] of [
     ['ruff', 'framework/core/.venv/bin/ruff'],
     ['mypy', 'framework/core/.venv/bin/mypy'],
@@ -755,6 +770,7 @@ test('declared discovery routes are zero-write in a cold read-only fixture', (t)
     XDG_CONFIG_HOME: path.join(home, 'config'),
     KUNGFU_READONLY_TOOL_LOG: toolLog,
     KUNGFU_READONLY_NESTED_SOURCE_ACCEPTANCE: '1',
+    PYTHONDONTWRITEBYTECODE: '1',
     KUNGFU_READONLY_PYTEST: pytest,
     KUNGFU_DEV_BRANCH: 'dev/v4/v4.0',
     KUNGFU_READONLY_TSX: requireFromGui.resolve('tsx/cli'),
@@ -765,6 +781,7 @@ test('declared discovery routes are zero-write in a cold read-only fixture', (t)
     KUNGFU_COMPLEXITY_PROTECTED_REF: protectedRef,
     PATH: `${tools}:/usr/bin:/bin`,
   };
+  env.NODE_TEST_CONTEXT = undefined;
   const cases = [
     [
       'architecture',
@@ -840,6 +857,8 @@ test('declared discovery routes are zero-write in a cold read-only fixture', (t)
       );
     }
   }
+  restoreWritable(fixture);
+  fs.chmodSync(path.join(fixture, 'shifu'), 0o755);
   const sourceAcceptance = spawnSync(
     path.join(fixture, 'shifu'),
     ['check:source'],

--- a/scripts/source-acceptance.mjs
+++ b/scripts/source-acceptance.mjs
@@ -515,10 +515,14 @@ export function sourceAcceptancePlan(files, evidenceBaseCommit = '') {
       'Shifu Documentation Protocol',
       'scripts/check-shifu-documentation-contract.mjs',
     ],
-    [
-      'documentation material lane',
-      'scripts/run-documentation-material-tests.mjs',
-    ],
+    ...(coldReadOnlySourceAcceptance
+      ? []
+      : [
+          [
+            'documentation material lane',
+            'scripts/run-documentation-material-tests.mjs',
+          ],
+        ]),
     [
       'read-only source and Agent route inventory',
       'scripts/check-readonly-source-routes.mjs',
@@ -940,21 +944,25 @@ export function sourceAcceptancePlan(files, evidenceBaseCommit = '') {
         'scripts.test_prepare_kungfu_phase_b_package',
       ],
     },
-    {
-      label: 'agent work state contract and CLI parity',
-      command: process.execPath,
-      args: ['scripts/run-agent-work-state-tests.mjs'],
-    },
-    {
-      label: 'runtime upgrade control-plane tests',
-      command: process.execPath,
-      args: ['scripts/run-runtime-upgrade-tests.mjs'],
-    },
-    {
-      label: 'desktop update adapter tests',
-      command: process.execPath,
-      args: ['scripts/run-desktop-update-tests.mjs'],
-    },
+    ...(coldReadOnlySourceAcceptance
+      ? []
+      : [
+          {
+            label: 'agent work state contract and CLI parity',
+            command: process.execPath,
+            args: ['scripts/run-agent-work-state-tests.mjs'],
+          },
+          {
+            label: 'runtime upgrade control-plane tests',
+            command: process.execPath,
+            args: ['scripts/run-runtime-upgrade-tests.mjs'],
+          },
+          {
+            label: 'desktop update adapter tests',
+            command: process.execPath,
+            args: ['scripts/run-desktop-update-tests.mjs'],
+          },
+        ]),
     ...(coldReadOnlySourceAcceptance
       ? []
       : [
@@ -969,6 +977,13 @@ export function sourceAcceptancePlan(files, evidenceBaseCommit = '') {
           },
         ]),
   ];
+
+  if (coldReadOnlySourceAcceptance) {
+    const nestedContractIndex = plan.findIndex(
+      (step) => step.label === 'source-acceptance contract tests',
+    );
+    if (nestedContractIndex >= 0) plan.splice(nestedContractIndex, 1);
+  }
 
   const web = files.filter(
     (file) =>

--- a/scripts/source-acceptance.test.mjs
+++ b/scripts/source-acceptance.test.mjs
@@ -1112,34 +1112,19 @@ test('cold read-only source acceptance skips dependency-backed checks', () => {
     const plan = sourceAcceptancePlan([
       'framework/gui/src/renderer/src/runtime.ts',
     ]);
-    assert.equal(
-      plan.some((step) => step.label === 'changed GUI TypeScript check'),
-      false,
-    );
-    assert.equal(
-      plan.some((step) => step.label === 'agent-first canonical policy'),
-      false,
-    );
-    assert.equal(
-      plan.some((step) => step.label === 'agent-first contract audit'),
-      false,
-    );
-    assert.equal(
-      plan.some((step) => step.label === 'Shifu Production Graph contract'),
-      false,
-    );
+    const labels = new Set(plan.map((step) => step.label));
     for (const label of [
+      'changed GUI TypeScript check',
+      'agent-first canonical policy',
+      'agent-first contract audit',
+      'Shifu Production Graph contract',
       'documentation material lane',
       'source-acceptance contract tests',
       'agent work state contract and CLI parity',
       'runtime upgrade control-plane tests',
       'desktop update adapter tests',
     ])
-      assert.equal(
-        plan.some((step) => step.label === label),
-        false,
-        `${label} requires the installed dependency graph`,
-      );
+      assert.equal(labels.has(label), false, `${label} needs installed deps`);
   } finally {
     if (previous === undefined) {
       Reflect.deleteProperty(

--- a/scripts/source-acceptance.test.mjs
+++ b/scripts/source-acceptance.test.mjs
@@ -1128,13 +1128,18 @@ test('cold read-only source acceptance skips dependency-backed checks', () => {
       plan.some((step) => step.label === 'Shifu Production Graph contract'),
       false,
     );
-    const contractTests = plan.find(
-      (step) => step.label === 'source-acceptance contract tests',
-    );
-    assert.equal(
-      contractTests?.args.includes('framework/production-graph/check.test.mjs'),
-      false,
-    );
+    for (const label of [
+      'documentation material lane',
+      'source-acceptance contract tests',
+      'agent work state contract and CLI parity',
+      'runtime upgrade control-plane tests',
+      'desktop update adapter tests',
+    ])
+      assert.equal(
+        plan.some((step) => step.label === label),
+        false,
+        `${label} requires the installed dependency graph`,
+      );
   } finally {
     if (previous === undefined) {
       Reflect.deleteProperty(


### PR DESCRIPTION
## Summary

- keep the cold read-only source fixture independent of the installed product dependency graph
- prevent inherited Node test context from suppressing nested contract execution
- retain exact zero-write auditing while routing temporary Python bytecode outside the checkout
- improve bounded failure diagnostics to include the actual failing test

## Related issue

Unblocks the protected source gate for the three-platform installer and first-run repair.

## Changes

- exclude documentation material qualification, the full source contract suite, and product runtime tests only when `KUNGFU_READONLY_NESTED_SOURCE_ACCEPTANCE=1`
- preserve every normal source-acceptance gate
- copy the exact installed Buildchain contract inputs required by the cold fixture
- assert the cold plan exclusions explicitly

## Verification

- `./shifu test:shifu-kfd-readonly` — 50 passed, zero-write roots unchanged
- `./shifu exec -- node --test scripts/source-acceptance.test.mjs` — 44 passed
- `./shifu exec -- node scripts/run-documentation-material-tests.mjs` — 12 passed on the normal path
- `./shifu exec -- biome check scripts/readonly-agent-bootstrap.test.mjs scripts/source-acceptance.mjs scripts/source-acceptance.test.mjs` — passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This patch fixes the dependency boundary of an existing cold read-only test fixture without changing product or architecture contracts"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable: test fixture boundary only)