### PR TITLE
fix(ci): pin macOS burst to budget guard

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "1d2e061648fb3e60fa1696180d06b7059d3a1e0e",
+    "sourceSha": "08f4b03ce25f1813749408a1093925fecc99d0b8",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:504a67ce741c0f2ac63fa3c2cbc4ad93c76db68db2056567ba7a1055907fb838"
   },

--- a/.github/workflows/aws-us-macos-burst-qualification.yml
+++ b/.github/workflows/aws-us-macos-burst-qualification.yml
@@ -43,9 +43,9 @@ jobs:
           (inputs.mode == 'full' && inputs.qualification-id == 'mac-full-01')
         )
       }}
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@376fb92fa014102366111b9aaef4856486c1e499
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@56aee4f72e3b6beb9eead71c8d596640313f6e7d
     with:
-      buildchain-ref: 376fb92fa014102366111b9aaef4856486c1e499
+      buildchain-ref: 56aee4f72e3b6beb9eead71c8d596640313f6e7d
       runner-preset: aws-us-ec2-macos-jit
       aws-ec2-macos-runner-label: ${{ inputs.runner-label }}
       setup-rust: true

--- a/docs/qualification/gates/aws-burst-retirement.json
+++ b/docs/qualification/gates/aws-burst-retirement.json
@@ -23,6 +23,8 @@
     "windowsCampaignSourceBindingMergeCommit": "447936a3aa36415a39c75e92fc9b26b0774aeb75",
     "windowsUsd80PhaseCapPullRequest": 2229,
     "windowsUsd80PhaseCapMergeCommit": "ae9bd5385cfb8060fb2574521121f1a798e83c6f",
+    "macosBudgetGuardPullRequest": 2525,
+    "macosBudgetGuardMergeCommit": "56aee4f72e3b6beb9eead71c8d596640313f6e7d",
     "v3RequiredInputs": [
       "aws-codebuild-project",
       "aws-ec2-windows-runner-label",

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -217,9 +217,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:e7e9044c1cedb55ed79d43af5ae39800d4b9a7e40d79a68b44142ecb99fac53f",
+          "definitionDigest": "sha256:75e7904e09268c566e781f6089b9583a9ddb34f4f7df6575a288f19d4510418b",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@376fb92fa014102366111b9aaef4856486c1e499"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@56aee4f72e3b6beb9eead71c8d596640313f6e7d"],
           "steps": []
         }
       ]

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -104,7 +104,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:338f68ed79f6510402ca02e55f6a1352f7957ca714a117d50a4e2a06bc104a25"
+          "sourceRoot": "sha256:dda8ea7be873ce25703a8e77d72acce1c591d8ae272b2a70573586ed7df138ea"
         },
         {
           "path": ".github/workflows/aws-us-windows-burst-qualification.yml",
@@ -860,5 +860,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:31baceeae6c7f0e3c87edc1587a226f830381cc2312cb14d0953d50c793b0c36"
+  "registryRoot": "sha256:8179988827c998abc5cfe2f029b74bf40a5e22da657e997d74a0db6f3e7335b2"
 }

--- a/scripts/buildchain-install.test.mjs
+++ b/scripts/buildchain-install.test.mjs
@@ -242,6 +242,13 @@ test('reactivated AWS burst workflows pin reviewed immutable Buildchain v3 sourc
     windowsUsd80PhaseCapSource,
     'ae9bd5385cfb8060fb2574521121f1a798e83c6f',
   );
+  assert.equal(retirement.evidence.macosBudgetGuardPullRequest, 2525);
+  const macosBudgetGuardSource =
+    retirement.evidence.macosBudgetGuardMergeCommit;
+  assert.equal(
+    macosBudgetGuardSource,
+    '56aee4f72e3b6beb9eead71c8d596640313f6e7d',
+  );
 
   for (const name of [
     'aws-us-linux-burst-qualification.yml',
@@ -255,7 +262,9 @@ test('reactivated AWS burst workflows pin reviewed immutable Buildchain v3 sourc
     const expectedBuildchainSource =
       name === 'aws-us-windows-burst-qualification.yml'
         ? windowsUsd80PhaseCapSource
-        : buildchainSource;
+        : name === 'aws-us-macos-burst-qualification.yml'
+          ? macosBudgetGuardSource
+          : buildchainSource;
     assert.match(workflow, /workflow_dispatch:/);
     assert.doesNotMatch(workflow, /\n {2}pull_request:|\n {2}push:/);
     if (name === 'aws-us-windows-burst-qualification.yml') {


### PR DESCRIPTION
## Summary

Pin the manual AWS US macOS burst caller to the reviewed Buildchain budget-guard merge from PR #2525. The immutable reusable-workflow shell and runtime ref remain identical, publish-channel remains none, and the workflow remains manual-only.

## Related issue

- Continues the bounded AWS US elastic runner campaign.
- Consumes kungfu-systems/buildchain#2525.

## Changes

- Pin the macOS burst workflow to Buildchain `56aee4f72e3b6beb9eead71c8d596640313f6e7d`.
- Record the macOS budget-guard PR and merge commit independently from retained Linux and Windows history.
- Refresh the closed-world workflow-authority projection and KFD collaboration witness.
- Extend the immutable-pin regression test so each burst provider selects its reviewed source independently.

## Verification

- `./shifu check`
- `./shifu check:source`
- `./shifu gate:workflow-authority:refresh`
- `./shifu kfd:buildchain`

No signing, notarization, publication, deployment, or release credentials were accessed. The caller remains `workflow_dispatch` only and `publish-channel: none`.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This fix advances an immutable diagnostic workflow dependency and its evidence without changing an architecture contract"
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change consumes the reviewed AWS Budget fail-closed guard and refreshes provenance projections only; it does not allocate compute or publish artifacts.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed