### PR TITLE
fix(release): bind r16 build to exact source lock

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,32 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Verify explicit Release Cut source lock
+        shell: bash
+        env:
+          RELEASE_CUT_SOURCE_REF: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').releaseCutSourceRef || '' }}
+          RELEASE_CUT_SOURCE_SHA: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').sourceSha || '' }}
+          RELEASE_CUT_ANCHOR_REQUEST_JSON: ${{ toJSON(fromJSON(inputs.macos-overflow-request-json || '{}').releaseCutAnchorRequest) }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$RELEASE_CUT_SOURCE_REF" ]]; then
+            exit 0
+          fi
+          test "$RELEASE_CUT_SOURCE_REF" = "publish-gate/anchor"
+          [[ "$RELEASE_CUT_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          test "$(git rev-parse HEAD)" = "$RELEASE_CUT_SOURCE_SHA"
+          test "$(git ls-remote origin "refs/heads/$RELEASE_CUT_SOURCE_REF" | awk '{print $1}')" = "$RELEASE_CUT_SOURCE_SHA"
+          jq -e \
+            --arg source "$RELEASE_CUT_SOURCE_SHA" \
+            '.schema == "kungfu.alpha-release-cut-build-lock/v1" and
+             .release == "v4.0.0-alpha.2" and
+             .cut == "r16" and
+             .candidateSha == $source and
+             .alphaBaseSha == "f9e6b0e34bcdd6407b2a18206ace7982d64de2c8" and
+             .buildchainRef == "v3" and
+             .devMirrorIsBuildInput == false' \
+            <<<"$RELEASE_CUT_ANCHOR_REQUEST_JSON" >/dev/null
+
       - name: Admit reusable source and platform probes
         id: receipt
         uses: ./.github/actions/require-alpha-preflight
@@ -172,6 +198,8 @@ jobs:
       # of authority. Buildchain admits train/exact-SHA overrides only for a
       # trusted manual actor and records the resolved immutable runtime.
       buildchain-ref: ${{ inputs.buildchain-ref || 'v3' }}
+      publish-source-ref: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').releaseCutSourceRef || '' }}
+      publish-anchor-request-json: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').releaseCutSourceRef && toJSON(fromJSON(inputs.macos-overflow-request-json || '{}').releaseCutAnchorRequest) || '' }}
       runner-preset: custom
       # Manual media publication consumes exactly one same-run Linux x64
       # product artifact. Protected Alpha and Release candidates retain the

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -301,7 +301,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:bc7ad59b29a30eb52730980b3221ce7bb543a082e74bb846b51f38a5c3b9d4f8",
+          "definitionDigest": "sha256:14eb1473954fc38740c64d96e24a30a87d875a833ee9d004af8caabaf79aba97",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN","KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@v3"],
           "steps": []
@@ -351,10 +351,10 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:9d72930d913021ac3d18731e4d5c4a72547dd307c2d361d1b77855180f2f33f5",
+          "definitionDigest": "sha256:a4e1203d12e44fd590e024ea8ce0d00cbe65d76737f3944f5de5173790926535",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
-          "steps": [{"index":1,"label":"name:Check out exact candidate source","definitionDigest":"sha256:90b7875c1b8263fc6ee031b6f446decfc1fe5eb289f08dbc3d506c4bce43f113"},{"index":2,"label":"id:receipt","definitionDigest":"sha256:49dbd179361e6e926d6eab7b762bfa7bb7292e2f3c452a3b7ddd2d8bd626b623"}]
+          "steps": [{"index":1,"label":"name:Check out exact candidate source","definitionDigest":"sha256:90b7875c1b8263fc6ee031b6f446decfc1fe5eb289f08dbc3d506c4bce43f113"},{"index":2,"label":"name:Verify explicit Release Cut source lock","definitionDigest":"sha256:cd80a48941e576fa1b19a67a7c48b0c1fddaef301ca60da10245901820a09a16"},{"index":3,"label":"id:receipt","definitionDigest":"sha256:49dbd179361e6e926d6eab7b762bfa7bb7292e2f3c452a3b7ddd2d8bd626b623"}]
         },
         {
           "id": "resolve-auditable-demo-source",

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -68,7 +68,7 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/build.yml` | `kungfu-phase-b` | qualification | none | qualifying | token:read | none | 0 |
 | `.github/workflows/build.yml` | `phase-b-package` | qualification | none | diagnostic | token:read | none | 5 |
 | `.github/workflows/build.yml` | `precompute-alpha-publication-tail` | qualification | none | diagnostic | token:read | none | 4 |
-| `.github/workflows/build.yml` | `preflight` | qualification | none | diagnostic | token:write, oidc, repo-secret:KUNGFU_GITHUB_TOKEN | none | 2 |
+| `.github/workflows/build.yml` | `preflight` | qualification | none | diagnostic | token:write, oidc, repo-secret:KUNGFU_GITHUB_TOKEN | none | 3 |
 | `.github/workflows/build.yml` | `resolve-auditable-demo-source` | qualification | none | diagnostic | token:read | none | 2 |
 | `.github/workflows/build.yml` | `windows-fast-sentinel` | qualification | none | diagnostic | token:read | none | 3 |
 | `.github/workflows/buildchain-validate.yml` | `promotion-rehearsal` | qualification | none | diagnostic | token:read | none | 2 |

--- a/scripts/alpha-promotion-preflight.test.mjs
+++ b/scripts/alpha-promotion-preflight.test.mjs
@@ -576,6 +576,22 @@ test('patrol, normal Alpha builds and sentinels keep one controller authority', 
     /windows-fast-sentinel:[\s\S]*always\(\)[\s\S]*inputs\.fast-sentinels-only[\s\S]*needs\.preflight\.result == 'skipped'/u,
   );
   assert.match(build, /build:[\s\S]*!inputs\.fast-sentinels-only/u);
+  assert.match(
+    build,
+    /RELEASE_CUT_SOURCE_REF: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.releaseCutSourceRef \|\| '' \}\}[\s\S]*RELEASE_CUT_SOURCE_SHA: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.sourceSha \|\| '' \}\}/u,
+  );
+  assert.match(
+    build,
+    /Verify explicit Release Cut source lock[\s\S]*publish-gate\/anchor[\s\S]*kungfu\.alpha-release-cut-build-lock\/v1[\s\S]*v4\.0\.0-alpha\.2[\s\S]*r16[\s\S]*f9e6b0e34bcdd6407b2a18206ace7982d64de2c8[\s\S]*buildchainRef == "v3"[\s\S]*devMirrorIsBuildInput == false/u,
+  );
+  assert.match(
+    build,
+    /buildchain-ref: \$\{\{ inputs\.buildchain-ref \|\| 'v3' \}\}[\s\S]*publish-source-ref: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.releaseCutSourceRef \|\| '' \}\}[\s\S]*publish-anchor-request-json: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.releaseCutSourceRef && toJSON/u,
+  );
+  assert.doesNotMatch(
+    build,
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@[0-9a-f]{40}/u,
+  );
   const preBuild = build.slice(0, build.indexOf('\n  build:'));
   assert.doesNotMatch(
     preBuild,

--- a/scripts/release-promotion-rehearsal.mjs
+++ b/scripts/release-promotion-rehearsal.mjs
@@ -165,11 +165,17 @@ export function validateWorkflowSources(root, contract, overrides = {}) {
     findings,
     'manual Buildchain runtime validation must remain an optional empty-default workflow_dispatch input',
   );
+  requirePattern(
+    build,
+    /^\s+publish-source-ref: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.releaseCutSourceRef \|\| '' \}\}$/m,
+    findings,
+    'manual Release Cut recovery must bind Buildchain to the source-lock ref carried by the trusted controller envelope',
+  );
   forbidPattern(
     build,
-    /^\s+publish-source-ref:/m,
+    /^\s+publish-source-ref:\s+.*(?:github\.head_ref|github\.event\.pull_request)/m,
     findings,
-    'PR-stage release-candidate builds must leave publish-source locking to post-merge promotion',
+    'PR-stage release-candidate builds must leave publish-source locking to exact manual Release Cut recovery or post-merge promotion',
   );
   requirePattern(
     build,

--- a/scripts/release-promotion-rehearsal.test.mjs
+++ b/scripts/release-promotion-rehearsal.test.mjs
@@ -446,7 +446,9 @@ test('PR-stage builds reject a premature publish-source lock', () => {
   assert.equal(result.ok, false);
   assert.ok(
     result.findings.some((entry) =>
-      entry.message.includes('leave publish-source locking to post-merge'),
+      entry.message.includes(
+        'leave publish-source locking to exact manual Release Cut recovery',
+      ),
     ),
   );
 });


### PR DESCRIPTION
## Summary

Add a release-blocker-only control-plane repair for Alpha.2 r16. Trusted manual Build dispatches can bind Buildchain v3 to `publish-gate/anchor`, verify the remote ref and exact Release Cut SHA `89781ff7236239aa310696e6bf40f8af3445c371`, and record `sourceLocked=true`. Ordinary Alpha PR builds remain forbidden from using PR-head source locks.

The product source, fixed Alpha base `f9e6b0e34bcdd6407b2a18206ace7982d64de2c8`, and floating Buildchain `v3` contract remain unchanged. Dev is not a Build input.

## Verification

- full staged repository gate passed
- `node --test scripts/release-promotion-rehearsal.test.mjs scripts/alpha-promotion-preflight.test.mjs` (41/41)
- workflow authority projection refreshed
- actionlint and diff check passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This narrows release source identity without changing architecture"
}
-->

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces

## Checklist

- [x] Commits are signed off (DCO)
- [x] No Buildchain exact-source pin introduced
- [x] Same patch root will be independently forward-ported to dev