### PR TITLE
fix(release): bind r16 PR build to exact source lock

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,9 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'control' && 360 || 10 }}
     outputs:
+      release-cut-source-ref: ${{ steps.source-lock.outputs.source-ref }}
+      release-cut-source-sha: ${{ steps.source-lock.outputs.source-sha }}
+      release-cut-anchor-request-json: ${{ steps.source-lock.outputs.anchor-request-json }}
       receipt-root: ${{ steps.receipt.outputs.receipt-root }}
       source-tree: ${{ steps.receipt.outputs.source-tree }}
       dependency-lock-root: ${{ steps.receipt.outputs.dependency-lock-root }}
@@ -91,20 +94,44 @@ jobs:
           persist-credentials: false
 
       - name: Verify explicit Release Cut source lock
+        id: source-lock
         shell: bash
         env:
-          RELEASE_CUT_SOURCE_REF: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').releaseCutSourceRef || '' }}
-          RELEASE_CUT_SOURCE_SHA: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').sourceSha || '' }}
+          RELEASE_CUT_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'alpha/v4/v4.0' && github.event.pull_request.head.ref == 'fix/alpha2-lineage-repair-r16' && 'true' || 'false' }}
+          RELEASE_CUT_PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          RELEASE_CUT_SOURCE_REF: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').releaseCutSourceRef || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'alpha/v4/v4.0' && github.event.pull_request.head.ref == 'fix/alpha2-lineage-repair-r16' && 'publish-gate/anchor') || '' }}
+          RELEASE_CUT_SOURCE_SHA: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').sourceSha || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'alpha/v4/v4.0' && github.event.pull_request.head.ref == 'fix/alpha2-lineage-repair-r16' && github.event.pull_request.head.sha) || '' }}
           RELEASE_CUT_ANCHOR_REQUEST_JSON: ${{ toJSON(fromJSON(inputs.macos-overflow-request-json || '{}').releaseCutAnchorRequest) }}
         run: |
           set -euo pipefail
           if [[ -z "$RELEASE_CUT_SOURCE_REF" ]]; then
+            {
+              echo "source-ref="
+              echo "source-sha="
+              echo "anchor-request-json="
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
           test "$RELEASE_CUT_SOURCE_REF" = "publish-gate/anchor"
           [[ "$RELEASE_CUT_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
           test "$(git rev-parse HEAD)" = "$RELEASE_CUT_SOURCE_SHA"
           test "$(git ls-remote origin "refs/heads/$RELEASE_CUT_SOURCE_REF" | awk '{print $1}')" = "$RELEASE_CUT_SOURCE_SHA"
+          if [[ "$RELEASE_CUT_PR" = "true" ]]; then
+            test "$RELEASE_CUT_PR_BASE_SHA" = "f9e6b0e34bcdd6407b2a18206ace7982d64de2c8"
+            RELEASE_CUT_ANCHOR_REQUEST_JSON="$(
+              jq -cn \
+                --arg source "$RELEASE_CUT_SOURCE_SHA" \
+                '{
+                  schema: "kungfu.alpha-release-cut-build-lock/v1",
+                  release: "v4.0.0-alpha.2",
+                  cut: "r16",
+                  candidateSha: $source,
+                  alphaBaseSha: "f9e6b0e34bcdd6407b2a18206ace7982d64de2c8",
+                  buildchainRef: "v3",
+                  devMirrorIsBuildInput: false
+                }'
+            )"
+          fi
           jq -e \
             --arg source "$RELEASE_CUT_SOURCE_SHA" \
             '.schema == "kungfu.alpha-release-cut-build-lock/v1" and
@@ -115,6 +142,11 @@ jobs:
              .buildchainRef == "v3" and
              .devMirrorIsBuildInput == false' \
             <<<"$RELEASE_CUT_ANCHOR_REQUEST_JSON" >/dev/null
+          {
+            echo "source-ref=$RELEASE_CUT_SOURCE_REF"
+            echo "source-sha=$RELEASE_CUT_SOURCE_SHA"
+            echo "anchor-request-json=$RELEASE_CUT_ANCHOR_REQUEST_JSON"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Admit reusable source and platform probes
         id: receipt
@@ -198,8 +230,8 @@ jobs:
       # of authority. Buildchain admits train/exact-SHA overrides only for a
       # trusted manual actor and records the resolved immutable runtime.
       buildchain-ref: ${{ inputs.buildchain-ref || 'v3' }}
-      publish-source-ref: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').releaseCutSourceRef || '' }}
-      publish-anchor-request-json: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').releaseCutSourceRef && toJSON(fromJSON(inputs.macos-overflow-request-json || '{}').releaseCutAnchorRequest) || '' }}
+      publish-source-ref: ${{ needs.preflight.outputs.release-cut-source-ref }}
+      publish-anchor-request-json: ${{ needs.preflight.outputs.release-cut-anchor-request-json }}
       runner-preset: custom
       # Manual media publication consumes exactly one same-run Linux x64
       # product artifact. Protected Alpha and Release candidates retain the

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -301,7 +301,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:14eb1473954fc38740c64d96e24a30a87d875a833ee9d004af8caabaf79aba97",
+          "definitionDigest": "sha256:4a7e548d8a113036cd26b4c0e4589c1b6fc2decdc22a01446dca6b8bc9d9be0b",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN","KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@v3"],
           "steps": []
@@ -351,10 +351,10 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:a4e1203d12e44fd590e024ea8ce0d00cbe65d76737f3944f5de5173790926535",
+          "definitionDigest": "sha256:6248bddb8c20908f10575a1bf1c8b4b8742b09462c419271a554967a46e88093",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
-          "steps": [{"index":1,"label":"name:Check out exact candidate source","definitionDigest":"sha256:90b7875c1b8263fc6ee031b6f446decfc1fe5eb289f08dbc3d506c4bce43f113"},{"index":2,"label":"name:Verify explicit Release Cut source lock","definitionDigest":"sha256:cd80a48941e576fa1b19a67a7c48b0c1fddaef301ca60da10245901820a09a16"},{"index":3,"label":"id:receipt","definitionDigest":"sha256:49dbd179361e6e926d6eab7b762bfa7bb7292e2f3c452a3b7ddd2d8bd626b623"}]
+          "steps": [{"index":1,"label":"name:Check out exact candidate source","definitionDigest":"sha256:90b7875c1b8263fc6ee031b6f446decfc1fe5eb289f08dbc3d506c4bce43f113"},{"index":2,"label":"id:source-lock","definitionDigest":"sha256:68a4b7330370a3ebe3062068276c95f7deb0d402ea2df940c2ed774aee404eab"},{"index":3,"label":"id:receipt","definitionDigest":"sha256:49dbd179361e6e926d6eab7b762bfa7bb7292e2f3c452a3b7ddd2d8bd626b623"}]
         },
         {
           "id": "resolve-auditable-demo-source",

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -122,7 +122,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:6fef1730c12a1f76a17a529fbe00bb1346ed89bea11bb871f92f74ef0ff10da0"
+          "sourceRoot": "sha256:4ef5de32201d11813baf27a6368472e39d0a10a6c6b20d16a7634ea4c24d19e7"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",
@@ -860,5 +860,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:2c9e55a60ff51f99f1b5ad8383a60ac8134ca661321cc0340e3fe15b8892c29c"
+  "registryRoot": "sha256:c669d8a9a9106675dffbceb2432b9ec47157855451847bfa4bf169ccb28b8db4"
 }

--- a/scripts/alpha-promotion-preflight.test.mjs
+++ b/scripts/alpha-promotion-preflight.test.mjs
@@ -578,7 +578,7 @@ test('patrol, normal Alpha builds and sentinels keep one controller authority', 
   assert.match(build, /build:[\s\S]*!inputs\.fast-sentinels-only/u);
   assert.match(
     build,
-    /RELEASE_CUT_SOURCE_REF: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.releaseCutSourceRef \|\| '' \}\}[\s\S]*RELEASE_CUT_SOURCE_SHA: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.sourceSha \|\| '' \}\}/u,
+    /RELEASE_CUT_PR:[\s\S]*alpha\/v4\/v4\.0[\s\S]*fix\/alpha2-lineage-repair-r16[\s\S]*RELEASE_CUT_SOURCE_REF:[\s\S]*publish-gate\/anchor[\s\S]*RELEASE_CUT_SOURCE_SHA:[\s\S]*github\.event\.pull_request\.head\.sha/u,
   );
   assert.match(
     build,
@@ -586,7 +586,7 @@ test('patrol, normal Alpha builds and sentinels keep one controller authority', 
   );
   assert.match(
     build,
-    /buildchain-ref: \$\{\{ inputs\.buildchain-ref \|\| 'v3' \}\}[\s\S]*publish-source-ref: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.releaseCutSourceRef \|\| '' \}\}[\s\S]*publish-anchor-request-json: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.releaseCutSourceRef && toJSON/u,
+    /buildchain-ref: \$\{\{ inputs\.buildchain-ref \|\| 'v3' \}\}[\s\S]*publish-source-ref: \$\{\{ needs\.preflight\.outputs\.release-cut-source-ref \}\}[\s\S]*publish-anchor-request-json: \$\{\{ needs\.preflight\.outputs\.release-cut-anchor-request-json \}\}/u,
   );
   assert.doesNotMatch(
     build,

--- a/scripts/release-promotion-rehearsal.mjs
+++ b/scripts/release-promotion-rehearsal.mjs
@@ -844,6 +844,8 @@ function gitSnapshot(root) {
 function evaluateActualEvent(root, eventPath) {
   const payload = readJson(eventPath);
   if (!payload.pull_request) return null;
+  const baseRef = String(payload.pull_request.base?.ref || '');
+  if (!modeForBaseRef(baseRef)) return null;
   const directory = fs.mkdtempSync(
     path.join(os.tmpdir(), 'kungfu-promotion-event-'),
   );

--- a/scripts/release-promotion-rehearsal.mjs
+++ b/scripts/release-promotion-rehearsal.mjs
@@ -167,15 +167,21 @@ export function validateWorkflowSources(root, contract, overrides = {}) {
   );
   requirePattern(
     build,
-    /^\s+publish-source-ref: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.releaseCutSourceRef \|\| '' \}\}$/m,
+    /^\s+publish-source-ref: \$\{\{ needs\.preflight\.outputs\.release-cut-source-ref \}\}$/m,
     findings,
-    'manual Release Cut recovery must bind Buildchain to the source-lock ref carried by the trusted controller envelope',
+    'Release Cut builds must bind Buildchain to the preflight-verified source-lock ref',
+  );
+  requirePattern(
+    build,
+    /RELEASE_CUT_PR:[\s\S]*alpha\/v4\/v4\.0[\s\S]*fix\/alpha2-lineage-repair-r16[\s\S]*RELEASE_CUT_PR_BASE_SHA:[\s\S]*publish-gate\/anchor[\s\S]*test "\$RELEASE_CUT_PR_BASE_SHA" = "f9e6b0e34bcdd6407b2a18206ace7982d64de2c8"/u,
+    findings,
+    'the r16 PR build must bind the frozen Alpha base and exact Release Cut source lock',
   );
   forbidPattern(
     build,
     /^\s+publish-source-ref:\s+.*(?:github\.head_ref|github\.event\.pull_request)/m,
     findings,
-    'PR-stage release-candidate builds must leave publish-source locking to exact manual Release Cut recovery or post-merge promotion',
+    'Buildchain publish-source locking must consume only the preflight-verified Release Cut output',
   );
   requirePattern(
     build,

--- a/scripts/release-promotion-rehearsal.test.mjs
+++ b/scripts/release-promotion-rehearsal.test.mjs
@@ -429,7 +429,7 @@ test('candidate build rejects a committed exact Buildchain runtime pin', () => {
   );
 });
 
-test('PR-stage builds reject a premature publish-source lock', () => {
+test('PR-stage builds reject an unverified publish-source lock', () => {
   const buildPath = CONTRACT.workflows.build;
   const original = fs.readFileSync(path.join(ROOT, buildPath), 'utf8');
   const buildchainRef =
@@ -447,7 +447,7 @@ test('PR-stage builds reject a premature publish-source lock', () => {
   assert.ok(
     result.findings.some((entry) =>
       entry.message.includes(
-        'leave publish-source locking to exact manual Release Cut recovery',
+        'consume only the preflight-verified Release Cut output',
       ),
     ),
   );

--- a/scripts/release-promotion-rehearsal.test.mjs
+++ b/scripts/release-promotion-rehearsal.test.mjs
@@ -530,6 +530,27 @@ describe('Git-sensitive promotion rehearsals', { concurrency: false }, () => {
     }
   });
 
+  test('an intermediate Release Cut PR does not become ADR admission', () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-event-'));
+    const eventPath = path.join(directory, 'event.json');
+    fs.writeFileSync(
+      eventPath,
+      JSON.stringify({
+        pull_request: {
+          base: { ref: 'fix/alpha2-lineage-repair-r16' },
+          head: { ref: 'fix/alpha2-r16-recovery-identity' },
+        },
+      }),
+    );
+    try {
+      const result = runRehearsal({ root: ROOT, eventPath });
+      assert.equal(result.ok, true, JSON.stringify(result.findings, null, 2));
+      assert.equal(result.event, null);
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   test('an actual GitHub promotion event traverses the ADR gate CLI', () => {
     const head = execFileSync('git', ['rev-parse', 'HEAD'], {
       cwd: ROOT,


### PR DESCRIPTION
## Summary

- bind the frozen Alpha.2 r16 pull-request Build to `publish-gate/anchor` and the exact PR head SHA
- retain the fixed Alpha base `f9e6b0e34bcdd6407b2a18206ace7982d64de2c8` and floating Buildchain `v3` contract
- keep dev mirror out of Build inputs while making the PR-event candidate publishable by the existing Buildchain v3 sealed-candidate recovery contract

## Release Cut identity

- parent r16 control HEAD: `ccb24e346eae8ea8b656da888c0be833eaa0f1ed`
- repair exact HEAD: `c3a333a944423a93a7e7c59cb4e78e56cb39913e`
- repair tree: `77a00047e3b5ac92fd1afc378d4d35ad1f583a74`
- this is a direct descendant of r16; no dev recut

## Validation

- `./shifu check:source` (1097 tests: 1086 passed, 11 skipped, 0 failed)
- cold read-only source audit byte-unchanged
- repository commit hook passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded r16 release stabilization preserves existing architecture contracts and changes no ADR record"
}
-->

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces

Independent exact-head review is required before r16 or `publish-gate/anchor` moves.