### PR TITLE
fix(release): forward-port r16 promotion gate repair

### DIFF
--- a/scripts/release-promotion-rehearsal.mjs
+++ b/scripts/release-promotion-rehearsal.mjs
@@ -838,6 +838,8 @@ function gitSnapshot(root) {
 function evaluateActualEvent(root, eventPath) {
   const payload = readJson(eventPath);
   if (!payload.pull_request) return null;
+  const baseRef = String(payload.pull_request.base?.ref || '');
+  if (!modeForBaseRef(baseRef)) return null;
   const directory = fs.mkdtempSync(
     path.join(os.tmpdir(), 'kungfu-promotion-event-'),
   );

--- a/scripts/release-promotion-rehearsal.test.mjs
+++ b/scripts/release-promotion-rehearsal.test.mjs
@@ -530,6 +530,27 @@ describe('Git-sensitive promotion rehearsals', { concurrency: false }, () => {
     }
   });
 
+  test('an intermediate Release Cut PR does not become ADR admission', () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-event-'));
+    const eventPath = path.join(directory, 'event.json');
+    fs.writeFileSync(
+      eventPath,
+      JSON.stringify({
+        pull_request: {
+          base: { ref: 'fix/alpha2-lineage-repair-r16' },
+          head: { ref: 'fix/alpha2-r16-recovery-identity' },
+        },
+      }),
+    );
+    try {
+      const result = runRehearsal({ root: ROOT, eventPath });
+      assert.equal(result.ok, true, JSON.stringify(result.findings, null, 2));
+      assert.equal(result.event, null);
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   test('an actual GitHub promotion event traverses the ADR gate CLI', () => {
     const head = execFileSync('git', ['rev-parse', 'HEAD'], {
       cwd: ROOT,


### PR DESCRIPTION
## Summary

Forward-port the same minimum r16 blocker patch root onto the current protected dev head `0b6e1491e92c950c1a8c71b3bb9373526f7d1571`. The repair prevents an intermediate Release Cut PR from being treated as Alpha/Release ADR admission while preserving every promotion-event gate.

This is a dev publication gate only. Alpha Build run `31426765839` consumes frozen r16 and source lock `cad173d097d4f6b373baae2c9b564107004fda40`, fixed Alpha base `f9e6b0e34bcdd6407b2a18206ace7982d64de2c8`, and floating Buildchain `v3`; dev is not a Build input and cannot supersede or recut r16.

## Verification

- Exact targeted release tests: 52/52 pass
- `governance.promotion-rehearsal` passed on the r16 patch root
- r16 full `./shifu check:source`: 1097 tests, 1086 pass, 11 expected skips, 0 failures
- exact-source preflight `31426161891`: four platforms plus aggregate receipt passed
- dev full source gate is running under CI semantics; protected PR/merge-queue Gates remain authoritative

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded release stabilization preserves existing architecture contracts and changes no ADR record"
}
-->

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
