### PR TITLE
fix(ci): pin repaired macOS allocation preflight

### DIFF
--- a/.github/workflows/aws-us-macos-burst-qualification.yml
+++ b/.github/workflows/aws-us-macos-burst-qualification.yml
@@ -43,9 +43,9 @@ jobs:
           (inputs.mode == 'full' && inputs.qualification-id == 'mac-full-01')
         )
       }}
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@56aee4f72e3b6beb9eead71c8d596640313f6e7d
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@b27e567473b4faee97b920bbbccf08e8412620b6
     with:
-      buildchain-ref: 56aee4f72e3b6beb9eead71c8d596640313f6e7d
+      buildchain-ref: b27e567473b4faee97b920bbbccf08e8412620b6
       runner-preset: aws-us-ec2-macos-jit
       aws-ec2-macos-runner-label: ${{ inputs.runner-label }}
       setup-rust: true

--- a/docs/qualification/gates/aws-burst-retirement.json
+++ b/docs/qualification/gates/aws-burst-retirement.json
@@ -25,6 +25,8 @@
     "windowsUsd80PhaseCapMergeCommit": "ae9bd5385cfb8060fb2574521121f1a798e83c6f",
     "macosBudgetGuardPullRequest": 2525,
     "macosBudgetGuardMergeCommit": "56aee4f72e3b6beb9eead71c8d596640313f6e7d",
+    "macosAllocateHostsPreflightPullRequest": 2526,
+    "macosAllocateHostsPreflightMergeCommit": "b27e567473b4faee97b920bbbccf08e8412620b6",
     "v3RequiredInputs": [
       "aws-codebuild-project",
       "aws-ec2-windows-runner-label",

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -217,9 +217,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:75e7904e09268c566e781f6089b9583a9ddb34f4f7df6575a288f19d4510418b",
+          "definitionDigest": "sha256:9957e8d71a92dc36c833b2153e3349ddcf1f418816a59bde4750a30c7454714d",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@56aee4f72e3b6beb9eead71c8d596640313f6e7d"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@b27e567473b4faee97b920bbbccf08e8412620b6"],
           "steps": []
         }
       ]

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -104,7 +104,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:dda8ea7be873ce25703a8e77d72acce1c591d8ae272b2a70573586ed7df138ea"
+          "sourceRoot": "sha256:378269823c1f08d4ff9545380adf6cc10ab2bd5273b9e3d46f57c10a8462833a"
         },
         {
           "path": ".github/workflows/aws-us-windows-burst-qualification.yml",
@@ -860,5 +860,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:87a49238e1ab3a5084b2d71e5ac8864e4b31a8aa8d72f657bb8f3b5b2f6f05ca"
+  "registryRoot": "sha256:847abae3c10df7bf28c3ea424581ca7c578b4da94fbc452e7b46b98cb0de80e8"
 }

--- a/scripts/buildchain-install.test.mjs
+++ b/scripts/buildchain-install.test.mjs
@@ -249,6 +249,16 @@ test('reactivated AWS burst workflows pin reviewed immutable Buildchain v3 sourc
     macosBudgetGuardSource,
     '56aee4f72e3b6beb9eead71c8d596640313f6e7d',
   );
+  assert.equal(
+    retirement.evidence.macosAllocateHostsPreflightPullRequest,
+    2526,
+  );
+  const macosAllocateHostsPreflightSource =
+    retirement.evidence.macosAllocateHostsPreflightMergeCommit;
+  assert.equal(
+    macosAllocateHostsPreflightSource,
+    'b27e567473b4faee97b920bbbccf08e8412620b6',
+  );
 
   for (const name of [
     'aws-us-linux-burst-qualification.yml',
@@ -263,7 +273,7 @@ test('reactivated AWS burst workflows pin reviewed immutable Buildchain v3 sourc
       name === 'aws-us-windows-burst-qualification.yml'
         ? windowsUsd80PhaseCapSource
         : name === 'aws-us-macos-burst-qualification.yml'
-          ? macosBudgetGuardSource
+          ? macosAllocateHostsPreflightSource
           : buildchainSource;
     assert.match(workflow, /workflow_dispatch:/);
     assert.doesNotMatch(workflow, /\n {2}pull_request:|\n {2}push:/);


### PR DESCRIPTION
## Summary

Pin the manual AWS US macOS burst caller to the reviewed Buildchain AllocateHosts preflight repair from PR #2526. The repaired controller uses IAM policy simulation for AllocateHosts authorization, retains the supported RunInstances DryRun, and still fails closed before paid capacity. The workflow remains manual-only.

## Related issue

- Continues the bounded AWS US elastic runner campaign.
- Consumes kungfu-systems/buildchain#2526.

## Changes

- Pin the macOS burst workflow to Buildchain `b27e567473b4faee97b920bbbccf08e8412620b6`.
- Record the AllocateHosts preflight PR and merge commit independently from the earlier budget-guard evidence.
- Refresh workflow-authority and publication-surface roots.
- Extend the immutable-pin regression test so the macOS caller requires the repaired source.

## Verification

- `./shifu check`
- `./shifu check:source`
- `./shifu gate:workflow-authority:refresh`
- `./shifu release:publication:write-roots`

No signing, notarization, publication, deployment, or release credentials were accessed. This PR allocates no AWS capacity; the caller remains `workflow_dispatch` only and `publish-channel: none`.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This fix advances an immutable diagnostic workflow dependency and its evidence without changing an architecture contract"
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change consumes the reviewed fail-closed AWS preflight repair and refreshes provenance projections only; it does not allocate compute or publish artifacts.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed