### PR TITLE
fix(qualification): tolerate concurrent NSIS removal

### DIFF
--- a/tests/qualification/layers/surfaces/installer.mjs
+++ b/tests/qualification/layers/surfaces/installer.mjs
@@ -159,23 +159,35 @@ export function pathRemovalDiagnostics(
   return diagnostics;
 }
 
-export function removeEmptyDirectoryShells(target) {
-  if (!fs.existsSync(target)) return true;
-  const stat = fs.lstatSync(target);
+export function removeEmptyDirectoryShells(target, filesystem = fs) {
+  let stat;
+  try {
+    stat = filesystem.lstatSync(target);
+  } catch (error) {
+    if (error?.code === 'ENOENT') return true;
+    throw error;
+  }
   if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
 
-  for (const entry of fs.readdirSync(target, { withFileTypes: true })) {
+  let entries;
+  try {
+    entries = filesystem.readdirSync(target, { withFileTypes: true });
+  } catch (error) {
+    if (error?.code === 'ENOENT') return true;
+    throw error;
+  }
+  for (const entry of entries) {
     const child = path.join(target, entry.name);
     if (
       entry.isSymbolicLink() ||
       !entry.isDirectory() ||
-      !removeEmptyDirectoryShells(child)
+      !removeEmptyDirectoryShells(child, filesystem)
     )
       return false;
   }
 
   try {
-    fs.rmdirSync(target);
+    filesystem.rmdirSync(target);
   } catch (error) {
     if (error?.code === 'ENOENT') return true;
     if (
@@ -186,7 +198,7 @@ export function removeEmptyDirectoryShells(target) {
       return false;
     throw error;
   }
-  return !fs.existsSync(target);
+  return !filesystem.existsSync(target);
 }
 
 export async function waitForPathRemoval(

--- a/tests/qualification/layers/surfaces/installer.test.mjs
+++ b/tests/qualification/layers/surfaces/installer.test.mjs
@@ -89,6 +89,40 @@ test('removes only empty directory shells left by NSIS', async () => {
   assert.equal(fs.existsSync(root), false);
 });
 
+test('tolerates NSIS removing a child during empty-shell traversal', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-uninstall-race-'));
+  const vanishing = path.join(
+    root,
+    'resources',
+    'app',
+    'node_modules',
+    'node-pty',
+  );
+  const retained = path.join(root, 'retained.exe');
+  fs.mkdirSync(vanishing, { recursive: true });
+  fs.writeFileSync(retained, 'fixture');
+  let raced = false;
+  const filesystem = {
+    existsSync: fs.existsSync,
+    lstatSync(target) {
+      if (!raced && target === vanishing) {
+        raced = true;
+        fs.rmSync(vanishing, { recursive: true, force: true });
+      }
+      return fs.lstatSync(target);
+    },
+    readdirSync: fs.readdirSync,
+    rmdirSync: fs.rmdirSync,
+  };
+  try {
+    assert.equal(removeEmptyDirectoryShells(root, filesystem), false);
+    assert.equal(raced, true);
+    assert.equal(fs.existsSync(retained), true);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('does not remove a file or link while cleaning empty directory shells', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-uninstall-file-'));
   const resource = path.join(root, 'resources', 'app');


### PR DESCRIPTION
## Release Cut blocker repair

This is a minimal repair on the frozen Alpha.2 r16 Release Cut. It does not recut from dev and does not change the fixed Alpha base or the Buildchain v3 floating runtime contract.

Formal Build run 31426765839 reached all four platform build lifecycles, then Windows verification failed before 4/4 completion in job 93581306288. The NSIS uninstaller was concurrently deleting installed node_modules while removeEmptyDirectoryShells traversed it; node-pty disappeared between readdir and lstat and produced a false ENOENT.

The repair treats an ENOENT child as already removed while remaining fail-closed for retained files, symlinks, locked directories, or other filesystem errors. A deterministic regression reproduces the disappearing node-pty child and proves a retained sibling remains visible.

Exact repair HEAD: 0e959b5d3c50ec8598c2a6c207b1b369d42eeba8
Repair tree: e7b9a80097014eb40d91b98373f298f4e386f57a
Fixed Alpha base: f9e6b0e34bcdd6407b2a18206ace7982d64de2c8

Validation:
- installer/run targeted node tests: 18/18 passed
- Biome check passed
- full ./shifu check:source passed
- Node tests: 1097 total, 1086 passed, 11 skipped, 0 failed
- trackedTreeRoot: sha256:4d3681084820da8a21d89cc2ca5b0ae816c10b9a3042ef68f41e891612808ad3
- untracked inventory: empty

After this Release Cut repair is reviewed and warranted, the same patch root will be forward-ported independently to current dev as a publication gate. Dev is not an Alpha Build input.