### PR TITLE
fix(qualification): forward-port r16 NSIS race repair

### DIFF
--- a/tests/qualification/layers/surfaces/installer.mjs
+++ b/tests/qualification/layers/surfaces/installer.mjs
@@ -159,23 +159,35 @@ export function pathRemovalDiagnostics(
   return diagnostics;
 }
 
-export function removeEmptyDirectoryShells(target) {
-  if (!fs.existsSync(target)) return true;
-  const stat = fs.lstatSync(target);
+export function removeEmptyDirectoryShells(target, filesystem = fs) {
+  let stat;
+  try {
+    stat = filesystem.lstatSync(target);
+  } catch (error) {
+    if (error?.code === 'ENOENT') return true;
+    throw error;
+  }
   if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
 
-  for (const entry of fs.readdirSync(target, { withFileTypes: true })) {
+  let entries;
+  try {
+    entries = filesystem.readdirSync(target, { withFileTypes: true });
+  } catch (error) {
+    if (error?.code === 'ENOENT') return true;
+    throw error;
+  }
+  for (const entry of entries) {
     const child = path.join(target, entry.name);
     if (
       entry.isSymbolicLink() ||
       !entry.isDirectory() ||
-      !removeEmptyDirectoryShells(child)
+      !removeEmptyDirectoryShells(child, filesystem)
     )
       return false;
   }
 
   try {
-    fs.rmdirSync(target);
+    filesystem.rmdirSync(target);
   } catch (error) {
     if (error?.code === 'ENOENT') return true;
     if (
@@ -186,7 +198,7 @@ export function removeEmptyDirectoryShells(target) {
       return false;
     throw error;
   }
-  return !fs.existsSync(target);
+  return !filesystem.existsSync(target);
 }
 
 export async function waitForPathRemoval(

--- a/tests/qualification/layers/surfaces/installer.test.mjs
+++ b/tests/qualification/layers/surfaces/installer.test.mjs
@@ -89,6 +89,40 @@ test('removes only empty directory shells left by NSIS', async () => {
   assert.equal(fs.existsSync(root), false);
 });
 
+test('tolerates NSIS removing a child during empty-shell traversal', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-uninstall-race-'));
+  const vanishing = path.join(
+    root,
+    'resources',
+    'app',
+    'node_modules',
+    'node-pty',
+  );
+  const retained = path.join(root, 'retained.exe');
+  fs.mkdirSync(vanishing, { recursive: true });
+  fs.writeFileSync(retained, 'fixture');
+  let raced = false;
+  const filesystem = {
+    existsSync: fs.existsSync,
+    lstatSync(target) {
+      if (!raced && target === vanishing) {
+        raced = true;
+        fs.rmSync(vanishing, { recursive: true, force: true });
+      }
+      return fs.lstatSync(target);
+    },
+    readdirSync: fs.readdirSync,
+    rmdirSync: fs.rmdirSync,
+  };
+  try {
+    assert.equal(removeEmptyDirectoryShells(root, filesystem), false);
+    assert.equal(raced, true);
+    assert.equal(fs.existsSync(retained), true);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('does not remove a file or link while cleaning empty directory shells', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-uninstall-file-'));
   const resource = path.join(root, 'resources', 'app');


### PR DESCRIPTION
## Summary

Forward-port the exact minimal Alpha.2 r16 blocker patch root independently onto current protected dev base a65e46fc7ea0d4fb18d0f8d640bb6322e68bb6a7. Stable patch-id: 1fa4bb6a06c8038ea624c53883b4dfedacfabd88.

The repair tolerates a child disappearing while the detached NSIS uninstaller removes the installed tree, while preserving fail-closed behavior for retained files, symlinks, locked directories, and other errors.

This is a dev publication gate only. Formal Alpha Build 31435864136 consumes frozen r16/source lock 0e959b5d3c50ec8598c2a6c207b1b369d42eeba8, fixed Alpha base f9e6b0e34bcdd6407b2a18206ace7982d64de2c8, and floating Buildchain v3. Dev is not a Build input and cannot supersede or recut r16.

## Verification

- patch-id exactly matches r16 blocker repair
- installer/run targeted tests: 18/18 passed
- Biome passed
- full staged commit gates passed
- r16 full ./shifu check:source passed: 1097 total, 1086 passed, 11 skipped, 0 failed
- exact-source r16 preflight 31435127632 passed four platforms plus aggregate receipt

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded qualification race repair preserves existing architecture contracts and changes no ADR record"
}
-->

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
