### PR TITLE
fix(ci): grant macOS burst caller permissions

### DIFF
--- a/.github/workflows/aws-us-macos-burst-qualification.yml
+++ b/.github/workflows/aws-us-macos-burst-qualification.yml
@@ -34,6 +34,11 @@ concurrency:
 jobs:
   qualify:
     name: ${{ inputs.mode == 'smoke' && 'macOS JIT runner profile smoke' || 'Trusted exact-source full macOS qualification' }}
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      id-token: write
     if: >-
       ${{
         github.repository == 'kungfu-systems/kungfu' &&

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -217,8 +217,8 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:9957e8d71a92dc36c833b2153e3349ddcf1f418816a59bde4750a30c7454714d",
-          "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
+          "definitionDigest": "sha256:69653a7bab7660210dd9d0de27c6505099aea7372b8bd2ef0459b1e62b4f917a",
+          "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@b27e567473b4faee97b920bbbccf08e8412620b6"],
           "steps": []
         }

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -56,7 +56,7 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/alpha-promotion-preflight.yml` | `aggregate` | qualification | none | diagnostic | token:read | none | 4 |
 | `.github/workflows/alpha-promotion-preflight.yml` | `probe` | qualification | none | diagnostic | token:read | none | 10 |
 | `.github/workflows/aws-us-linux-burst-qualification.yml` | `qualify` | qualification | none | diagnostic | token:read | none | 0 |
-| `.github/workflows/aws-us-macos-burst-qualification.yml` | `qualify` | qualification | none | diagnostic | token:read | none | 0 |
+| `.github/workflows/aws-us-macos-burst-qualification.yml` | `qualify` | qualification | none | diagnostic | token:write, oidc | none | 0 |
 | `.github/workflows/aws-us-windows-burst-qualification.yml` | `cleanup-exercise` | qualification | none | diagnostic | token:read | none | 2 |
 | `.github/workflows/aws-us-windows-burst-qualification.yml` | `full` | qualification | none | diagnostic | token:write, oidc | none | 0 |
 | `.github/workflows/aws-us-windows-burst-qualification.yml` | `smoke` | qualification | none | diagnostic | token:write, oidc | none | 0 |

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -104,7 +104,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:378269823c1f08d4ff9545380adf6cc10ab2bd5273b9e3d46f57c10a8462833a"
+          "sourceRoot": "sha256:e04fa4c54afe0e218a4798deda227d8837e85dde8ceb2e658e5aa09bf8555918"
         },
         {
           "path": ".github/workflows/aws-us-windows-burst-qualification.yml",
@@ -860,5 +860,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:4c1f70542235b3869b05951697d490a7fe33e4c5a6625a4f7d7021e9dbbf2cd2"
+  "registryRoot": "sha256:3137558e2ae186d8a980f2b940894467782d2c13604ff878f66bc00aa3137a5b"
 }

--- a/scripts/buildchain-install.test.mjs
+++ b/scripts/buildchain-install.test.mjs
@@ -315,6 +315,15 @@ test('reactivated AWS burst workflows pin reviewed immutable Buildchain v3 sourc
         ).length,
         2,
       );
+    } else if (name === 'aws-us-macos-burst-qualification.yml') {
+      assert.equal(
+        (
+          workflow.match(
+            /permissions:\n {6}actions: read\n {6}contents: read\n {6}issues: write\n {6}id-token: write/g,
+          ) || []
+        ).length,
+        1,
+      );
     } else {
       assert.doesNotMatch(workflow, /id-token:\s*write/);
     }
@@ -414,6 +423,10 @@ test('AWS macOS burst workflow requires three sequential one-job JIT slots', () 
     /inputs\.runner-label == format\('aws-us-ec2-macos-jit-\{0\}', inputs\.qualification-id\)/,
   );
   assert.match(workflow, /group: aws-us-macos-burst/);
+  assert.match(
+    workflow,
+    /permissions:\n {6}actions: read\n {6}contents: read\n {6}issues: write\n {6}id-token: write/,
+  );
   assert.match(workflow, /aws-ec2-macos-runner-label:/);
   assert.doesNotMatch(workflow, /\n {2}trust:/);
 });


### PR DESCRIPTION
## Summary

Grant the manual AWS US macOS burst caller the job-level permissions required by its reviewed Buildchain reusable workflow. The missing caller permissions caused workflow_dispatch runs to fail at startup before any job or JIT runner could be created.

## Changes

- Grant the qualify job actions: read, contents: read, issues: write, and id-token: write.
- Assert the exact permission block in the Buildchain install regression tests.
- Refresh workflow-authority and release-publication source roots.

## Verification

- ./shifu check
- ./shifu check:source
- ./shifu gate:workflow-authority:refresh
- ./shifu release:publication:write-roots

No signing, notarization, publication, deployment, or release credentials were accessed. This PR allocates no AWS capacity; the caller remains workflow_dispatch-only and the live workflow remains disabled.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix restores the declared least-privilege caller contract without changing an architecture contract"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change restores only the reviewed GitHub OIDC and issue-reporting permission envelope. It performs no AWS or publication mutation.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation and generated authority projections updated