### PR TITLE
fix(ci): continue Linux-only auditable demo generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -371,6 +371,7 @@ jobs:
   resolve-auditable-demo-source:
     name: Resolve exact auditable demo artifact
     needs: build
+    if: ${{ always() && needs.build.result == 'success' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
@@ -563,7 +564,7 @@ jobs:
   auditable-demo:
     name: Declarative multi-demo Gate and media
     needs: [build, resolve-auditable-demo-source]
-    if: ${{ needs.resolve-auditable-demo-source.outputs.applicable == 'true' }}
+    if: ${{ always() && needs.build.result == 'success' && needs.resolve-auditable-demo-source.result == 'success' && needs.resolve-auditable-demo-source.outputs.applicable == 'true' }}
     permissions:
       actions: read
       contents: write

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -281,7 +281,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:7b4cf57bda0843563c3499dfedce43b98719b2935569aac36ec6145d8aa9722c",
+          "definitionDigest": "sha256:b141275e8d819ee4a9d09ccb20056c4b33c26ccb1290ca5e0ceae5346c0143a3",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.declarative-auditable-demo.yml@41d4dce2f38aa4821c794b49dcfb2bcf59d0984a"],
           "steps": []
@@ -361,7 +361,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:6f21a7dfe16deedab6047bd80b8279e7aa67b5ff116daa08b123fbaae62c31dd",
+          "definitionDigest": "sha256:08cb80ffcd61ebc97a5ec74e24c0613f7bb9420316c33f403c94e3862a5b6002",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd","actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"],
           "steps": [{"index":1,"label":"id:resolve","definitionDigest":"sha256:c7fb80856c78364e30e47cf16634ef4d0f94abcefc8af3ecb58a32a526d3828b"},{"index":2,"label":"name:Retain machine-readable inapplicable reason","authority":"evidence-publication","definitionDigest":"sha256:a7a896172c158f321b28ee061bc1048c1d616464509938d0930aafcc361c6ba6"}]

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -122,7 +122,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:68a9f4c812f0f182be287c5bb8de5509f25cb65573307b5cd8fb923be89c73da"
+          "sourceRoot": "sha256:063a56ca1b58be953b1bb9c06fb48e113872d1f88f709b6aa0523ed27e03cc79"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",
@@ -860,5 +860,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:3137558e2ae186d8a980f2b940894467782d2c13604ff878f66bc00aa3137a5b"
+  "registryRoot": "sha256:133fada065488df7ec2e1a63563af0d99ce9f04f17b386cc7ea803431036ac75"
 }

--- a/scripts/auditable-demo-workflow.test.mjs
+++ b/scripts/auditable-demo-workflow.test.mjs
@@ -253,6 +253,7 @@ test('manual full refresh and promotion reuse the same materializer', () => {
 
 test('manual media publication runs only the Linux x64 product path', () => {
   const platformExpression = build.with['platforms-json'];
+  const resolver = workflow.jobs['resolve-auditable-demo-source'];
   assert.match(
     platformExpression,
     /github\.event_name == 'workflow_dispatch' && inputs\.render-auditable-demo/u,
@@ -268,6 +269,14 @@ test('manual media publication runs only the Linux x64 product path', () => {
   assert.match(
     build.if,
     /^\$\{\{ always\(\) &&[\s\S]*inputs\.render-auditable-demo && needs\.windows-fast-sentinel\.result == 'skipped'/u,
+  );
+  assert.equal(
+    resolver.if,
+    "${{ always() && needs.build.result == 'success' }}",
+  );
+  assert.equal(
+    demo.if,
+    "${{ always() && needs.build.result == 'success' && needs.resolve-auditable-demo-source.result == 'success' && needs.resolve-auditable-demo-source.outputs.applicable == 'true' }}",
   );
   assert.equal(
     build.with['compiler-cache-platforms-json'],


### PR DESCRIPTION
## Summary
- let the exact artifact resolver continue after intentional Windows sentinel skips
- keep the declarative demo job fail-closed on Linux build and resolver success
- pin workflow authority digests and add regression assertions

Supersedes #2915. This candidate is one linear commit directly on current dev so Project Cut queue admission can replay it.

## Validation
- ./shifu test:auditable-demo
- ./shifu test:alpha-macos-overflow
- ./shifu kfd:buildchain:check
- ./shifu check:source
- pre-commit staged gates

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix changes only CI continuation conditions and their generated authority digests; it does not alter an architecture contract."
}
-->