### PR TITLE
fix(release): freeze Alpha.2 r17 source lock

### DIFF
--- a/.buildchain/alpha-release-cut-lock.json
+++ b/.buildchain/alpha-release-cut-lock.json
@@ -1,16 +1,16 @@
 {
   "schema": "kungfu.alpha-release-cut-lock/v1",
   "release": "v4.0.0-alpha.2",
-  "cut": "r16",
+  "cut": "r17",
   "state": "frozen",
   "candidate": {
-    "ref": "refs/heads/fix/alpha2-lineage-repair-r16",
-    "sha": "89781ff7236239aa310696e6bf40f8af3445c371",
-    "tree": "095f2ea60cce5bb96c22314ae02dfad48d904052"
+    "ref": "refs/heads/fix/alpha2-lineage-repair-r17",
+    "sha": "77a66f7141143e524484a548dbba76a1ae1ecc38",
+    "tree": "6f3a82c10712ec344ecefbf30d11a580aeb4f22b"
   },
   "devCut": {
-    "sha": "a392762ab2d0d325bd8202cfc7b37ea525aaf6dc",
-    "tree": "095f2ea60cce5bb96c22314ae02dfad48d904052"
+    "sha": "c3938d8fc5e71578c960cc8137a853a8817b09ca",
+    "tree": "6f3a82c10712ec344ecefbf30d11a580aeb4f22b"
   },
   "alphaBase": {
     "ref": "refs/heads/alpha/v4/v4.0",
@@ -19,7 +19,7 @@
   },
   "lineage": {
     "parentOrder": [
-      "a392762ab2d0d325bd8202cfc7b37ea525aaf6dc",
+      "c3938d8fc5e71578c960cc8137a853a8817b09ca",
       "f9e6b0e34bcdd6407b2a18206ace7982d64de2c8"
     ],
     "candidateTreeEqualsDevCut": true
@@ -28,8 +28,8 @@
     "sourcePinPolicy": "floating-contract-with-recorded-resolution",
     "build": {
       "ref": "v3",
-      "resolvedSha": "81c49578bff72a9784a1b63ce8698bd9dd23d7bf",
-      "contractDigest": "sha256:8e9a161653c40611ffd76aa878ae348fc215506c1caa88347111fb122cfe7c12"
+      "resolvedSha": "f4ca5182f53fddf76bdf4246be0993afa5a592bc",
+      "contractDigest": "sha256:52cdb871cb0559534f78548f2487d8f3ceb64bb92e8a587f440a2946f78e7386"
     },
     "promotion": {
       "ref": "v3-alpha",

--- a/.github/workflows/dev-alpha-candidate-patrol.yml
+++ b/.github/workflows/dev-alpha-candidate-patrol.yml
@@ -101,19 +101,19 @@ jobs:
           lock=.buildchain/alpha-release-cut-lock.json
           test "$(jq -er '.schema' "$lock")" = "kungfu.alpha-release-cut-lock/v1"
           test "$(jq -er '.release' "$lock")" = "v4.0.0-alpha.2"
-          test "$(jq -er '.cut' "$lock")" = "r16"
+          test "$(jq -er '.cut' "$lock")" = "r17"
           test "$(jq -er '.state' "$lock")" = "frozen"
           jq -e '
-            .candidate.ref == "refs/heads/fix/alpha2-lineage-repair-r16" and
-            .candidate.sha == "89781ff7236239aa310696e6bf40f8af3445c371" and
-            .candidate.tree == "095f2ea60cce5bb96c22314ae02dfad48d904052" and
-            .devCut.sha == "a392762ab2d0d325bd8202cfc7b37ea525aaf6dc" and
-            .devCut.tree == "095f2ea60cce5bb96c22314ae02dfad48d904052" and
+            .candidate.ref == "refs/heads/fix/alpha2-lineage-repair-r17" and
+            .candidate.sha == "77a66f7141143e524484a548dbba76a1ae1ecc38" and
+            .candidate.tree == "6f3a82c10712ec344ecefbf30d11a580aeb4f22b" and
+            .devCut.sha == "c3938d8fc5e71578c960cc8137a853a8817b09ca" and
+            .devCut.tree == "6f3a82c10712ec344ecefbf30d11a580aeb4f22b" and
             .alphaBase.ref == "refs/heads/alpha/v4/v4.0" and
             .alphaBase.sha == "f9e6b0e34bcdd6407b2a18206ace7982d64de2c8" and
             .alphaBase.tree == "67a93b5831596555e7c29104421de3a0b97eb865" and
-            .buildchain.build.resolvedSha == "81c49578bff72a9784a1b63ce8698bd9dd23d7bf" and
-            .buildchain.build.contractDigest == "sha256:8e9a161653c40611ffd76aa878ae348fc215506c1caa88347111fb122cfe7c12" and
+            .buildchain.build.resolvedSha == "f4ca5182f53fddf76bdf4246be0993afa5a592bc" and
+            .buildchain.build.contractDigest == "sha256:52cdb871cb0559534f78548f2487d8f3ceb64bb92e8a587f440a2946f78e7386" and
             .buildchain.promotion.resolvedSha == "36b08dc7bf417e57bffcc3dc784a2473254fe4c1" and
             .buildchain.promotion.contractDigest == "sha256:8e565f9ac5146d5dceafc3da6b267147fb412937db979bf35a0429966da82197"
           ' "$lock" >/dev/null

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -496,10 +496,10 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:31eb10938d77f7604b3b1285f08b297a7cc97d93005762ecaba9aa5410c31611",
+          "definitionDigest": "sha256:b33778ba4b57a95e37dc344c5874e8b78eefa250b98f8edac34914fe7c14284c",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
-          "steps": [{"index":1,"label":"name:Check out the dev mirror verifier","definitionDigest":"sha256:8d92682cf7803f194bf70107c82b9ee6d73e0de0b37f91a3ed75850183e688e3"},{"index":2,"label":"name:Fetch exact frozen Release Cut objects","definitionDigest":"sha256:74cc2b6e4607b8069f49ae903e6992163f007c8fa940342ba28a2efa110d41ce"},{"index":3,"label":"id:lock","definitionDigest":"sha256:24c3ad75cc83436b2862e8179a571bf6025d8ae22d71e144d0057c9e1283cf8c"}]
+          "steps": [{"index":1,"label":"name:Check out the dev mirror verifier","definitionDigest":"sha256:8d92682cf7803f194bf70107c82b9ee6d73e0de0b37f91a3ed75850183e688e3"},{"index":2,"label":"name:Fetch exact frozen Release Cut objects","definitionDigest":"sha256:74cc2b6e4607b8069f49ae903e6992163f007c8fa940342ba28a2efa110d41ce"},{"index":3,"label":"id:lock","definitionDigest":"sha256:8552126f1e8c9f119ef7060e2b4221bc0c8f6dc861981bdcc88df70ebf223e67"}]
         },
         {
           "id": "resolve-channels",

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -170,7 +170,7 @@
             "product-alpha",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:521eb00649e376aea3ed84b6574302dea24312ce6effd735766a56445f086050"
+          "sourceRoot": "sha256:d563654f01552dbf52dcb1294f0d87fe627be10457deadb4259f47152ea1a355"
         },
         {
           "path": ".github/workflows/dev-delivery-warrant-terminal.yml",
@@ -860,5 +860,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:133fada065488df7ec2e1a63563af0d99ce9f04f17b386cc7ea803431036ac75"
+  "registryRoot": "sha256:a30cf64591ec56bcd99c308dd72a9ac0c0e82f3bb172a36bbd5c92c427c7ae3b"
 }

--- a/scripts/alpha-promotion-preflight.test.mjs
+++ b/scripts/alpha-promotion-preflight.test.mjs
@@ -582,7 +582,7 @@ test('patrol, normal Alpha builds and sentinels keep one controller authority', 
   );
   assert.match(
     build,
-    /Verify explicit Release Cut source lock[\s\S]*publish-gate\/anchor[\s\S]*kungfu\.alpha-release-cut-build-lock\/v1[\s\S]*v4\.0\.0-alpha\.2[\s\S]*r16[\s\S]*f9e6b0e34bcdd6407b2a18206ace7982d64de2c8[\s\S]*buildchainRef == "v3"[\s\S]*devMirrorIsBuildInput == false/u,
+    /Verify explicit Release Cut source lock[\s\S]*publish-gate\/anchor[\s\S]*kungfu\.alpha-release-cut-build-lock\/v1[\s\S]*v4\.0\.0-alpha\.2[\s\S]*r17[\s\S]*f9e6b0e34bcdd6407b2a18206ace7982d64de2c8[\s\S]*buildchainRef == "v3"[\s\S]*devMirrorIsBuildInput == false/u,
   );
   assert.match(
     build,

--- a/scripts/verify-alpha-release-cut-lock.test.mjs
+++ b/scripts/verify-alpha-release-cut-lock.test.mjs
@@ -18,12 +18,12 @@ function git(...args) {
   return execFileSync('git', args, { cwd: ROOT, encoding: 'utf8' }).trim();
 }
 
-test('Alpha.2 r16 lock verifies the exact Release Cut and fixed runtimes', () => {
+test('Alpha.2 r17 lock verifies the exact Release Cut and fixed runtimes', () => {
   assert.equal(LOCK.schema, 'kungfu.alpha-release-cut-lock/v1');
   assert.equal(LOCK.release, 'v4.0.0-alpha.2');
-  assert.equal(LOCK.cut, 'r16');
+  assert.equal(LOCK.cut, 'r17');
   assert.equal(LOCK.state, 'frozen');
-  assert.equal(LOCK.candidate.sha, '89781ff7236239aa310696e6bf40f8af3445c371');
+  assert.equal(LOCK.candidate.sha, '77a66f7141143e524484a548dbba76a1ae1ecc38');
   assert.equal(LOCK.alphaBase.sha, 'f9e6b0e34bcdd6407b2a18206ace7982d64de2c8');
   assert.equal(
     git('show', '-s', '--format=%P', LOCK.candidate.sha),
@@ -51,15 +51,15 @@ test('Alpha.2 r16 lock verifies the exact Release Cut and fixed runtimes', () =>
   );
 });
 
-test('Alpha.2 r16 lock keeps Buildchain invocation floating', () => {
+test('Alpha.2 r17 lock keeps Buildchain invocation floating', () => {
   assert.equal(LOCK.buildchain.build.ref, 'v3');
   assert.equal(
     LOCK.buildchain.build.resolvedSha,
-    '81c49578bff72a9784a1b63ce8698bd9dd23d7bf',
+    'f4ca5182f53fddf76bdf4246be0993afa5a592bc',
   );
   assert.equal(
     LOCK.buildchain.build.contractDigest,
-    'sha256:8e9a161653c40611ffd76aa878ae348fc215506c1caa88347111fb122cfe7c12',
+    'sha256:52cdb871cb0559534f78548f2487d8f3ceb64bb92e8a587f440a2946f78e7386',
   );
   assert.equal(LOCK.buildchain.promotion.ref, 'v3-alpha');
   assert.equal(


### PR DESCRIPTION
## Summary

Freeze Alpha.2 r17 from the current protected dev cut and bind its exact lineage to the production Buildchain v3 contract. Dev to Alpha Candidate Patrol verifies the immutable r17 candidate and cannot settle, supersede, or rebuild it from moving dev.

## Changes

- record candidate `77a66f7141143e524484a548dbba76a1ae1ecc38` with the exact protected dev and Alpha parents
- advance the fixed dev cut to `c3938d8fc5e71578c960cc8137a853a8817b09ca`
- record production Buildchain `v3` resolution `f4ca5182f53fddf76bdf4246be0993afa5a592bc` and contract digest `sha256:52cdb871cb0559534f78548f2487d8f3ceb64bb92e8a587f440a2946f78e7386`
- refresh workflow authority and release publication source roots generated from the patrol definition

## Verification

- `./shifu check` passed
- `./shifu check:source` passed with zero-write source roots
- commit hooks passed
- candidate parents are exactly `c3938d8fc5e71578c960cc8137a853a8817b09ca` and `f9e6b0e34bcdd6407b2a18206ace7982d64de2c8`
- candidate tree `6f3a82c10712ec344ecefbf30d11a580aeb4f22b` equals the protected dev cut tree
- both exact heads passed managed push admission

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This release-control repair advances the frozen source cut and recorded production runtime without changing an architecture decision"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces

The dev mirror remains a publication gate only. Alpha Build is bound to the immutable r17 Release Cut candidate and the production floating Buildchain contracts.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation projections updated
