### PR TITLE
fix(ci): grant auditable demo build permissions

### DIFF
--- a/.github/workflows/auditable-demo.yml
+++ b/.github/workflows/auditable-demo.yml
@@ -38,6 +38,8 @@ jobs:
     permissions:
       actions: read
       contents: read
+      issues: write
+      id-token: write
     uses: kungfu-systems/buildchain/.github/workflows/.build.yml@41d4dce2f38aa4821c794b49dcfb2bcf59d0984a
     with:
       buildchain-ref: 41d4dce2f38aa4821c794b49dcfb2bcf59d0984a

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -210,8 +210,8 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:6b7d4dc97af4cda47efe4b07f6c5209154bd172193230d6c8ddce4baecfe155c",
-          "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
+          "definitionDigest": "sha256:14d2078298182124e13cf02b26a3f2fc4d9b41992cc8c94e2b856d489fc6c829",
+          "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@41d4dce2f38aa4821c794b49dcfb2bcf59d0984a"],
           "steps": []
         },

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -56,7 +56,7 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/alpha-promotion-preflight.yml` | `aggregate` | qualification | none | diagnostic | token:read | none | 4 |
 | `.github/workflows/alpha-promotion-preflight.yml` | `probe` | qualification | none | diagnostic | token:read | none | 10 |
 | `.github/workflows/auditable-demo.yml` | `auditable-demo` | qualification | none | qualifying | token:write, repo-secret:KUNGFU_GITHUB_TOKEN | none | 0 |
-| `.github/workflows/auditable-demo.yml` | `build` | qualification | none | qualifying | token:read | none | 0 |
+| `.github/workflows/auditable-demo.yml` | `build` | qualification | none | qualifying | token:write, oidc | none | 0 |
 | `.github/workflows/auditable-demo.yml` | `resolve-binary` | qualification | none | diagnostic | token:read | none | 1 |
 | `.github/workflows/aws-us-linux-burst-qualification.yml` | `qualify` | qualification | none | diagnostic | token:read | none | 0 |
 | `.github/workflows/aws-us-macos-burst-qualification.yml` | `qualify` | qualification | none | diagnostic | token:write, oidc | none | 0 |

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -97,7 +97,7 @@
           "classification": "non-publication",
           "owner": "kungfu-docs",
           "surfaceIds": [],
-          "sourceRoot": "sha256:ec4237c0c3cd1ad639446d28f22acce071187fd2f364b1bb156f3460eac48c96"
+          "sourceRoot": "sha256:ef6eea6a5bf57325d6f1d8b9c2eaba911f9ab950cd720300f9fa286619283421"
         },
         {
           "path": ".github/workflows/aws-us-linux-burst-qualification.yml",
@@ -867,5 +867,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:611460a44d1029f0780845f63588215f51c95c1904f06586e33108218c00268c"
+  "registryRoot": "sha256:2f933e68b2ff7135a976d2c70bef2df1eedfc6ea3fe39a6016cd584188448cbe"
 }

--- a/scripts/auditable-demo-workflow.test.mjs
+++ b/scripts/auditable-demo-workflow.test.mjs
@@ -225,6 +225,12 @@ test('the build fails the real transported binary before either upload path', ()
     build.with['buildchain-ref'],
     '41d4dce2f38aa4821c794b49dcfb2bcf59d0984a',
   );
+  assert.deepEqual(build.permissions, {
+    actions: 'read',
+    contents: 'read',
+    issues: 'write',
+    'id-token': 'write',
+  });
   assert.equal(
     demo.uses,
     'kungfu-systems/buildchain/.github/workflows/.declarative-auditable-demo.yml@41d4dce2f38aa4821c794b49dcfb2bcf59d0984a',


### PR DESCRIPTION
## Outcome

Closes the exact caller/reusable-workflow permission contract that caused formal Auditable Demo run 31462267992 to fail before creating any job.

## Changes

- grant the pinned Buildchain build workflow its declared issues:write and id-token:write permissions
- freeze those grants in the auditable-demo workflow test
- refresh closed-world workflow authority credentials and definition digest

## Verification

- GitHub startup annotation: caller allowed issues:none/id-token:none while the pinned reusable workflow requested write
- actionlint passed
- auditable-demo workflow tests 10/10 passed
- workflow authority closed-world check passed
- gate catalog passed with 37 workflows
- full staged repository gate passed at a7d619eeddca59220e96f29f0f2a1983bf1a7f7c

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Closes the declared reusable-workflow permission contract without changing an architecture contract or ADR record"
}
-->