### PR TITLE
fix(release): align Alpha cut lock to r17

### DIFF
--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.1",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.1",
-    "sourceSha": "4ddab75987c618d69c4e19e5ce252cf4a014c21d"
+    "sourceSha": "8b22a3fc549a838d615d1d4ff38aaf48ba16f318"
   },
   "claims": [
     {

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "4ddab75987c618d69c4e19e5ce252cf4a014c21d",
+    "sourceSha": "8b22a3fc549a838d615d1d4ff38aaf48ba16f318",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:6ff53c35ea0c6a8e05aefbb75c5aa4dabb95e529b1367800333332d65a880b66"
   },

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:8510c8e704860893f22a0c85986480dbb65b604a703d9a6840f652a965f51867"
+            "sha256": "sha256:edcb0e76bcce4e2857c5060e227990d98100b73488d64dbe96c242049b7b016b"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,7 @@ jobs:
             --arg source "$RELEASE_CUT_SOURCE_SHA" \
             '.schema == "kungfu.alpha-release-cut-build-lock/v1" and
              .release == "v4.0.0-alpha.2" and
-             .cut == "r16" and
+             .cut == "r17" and
              .candidateSha == $source and
              .alphaBaseSha == "f9e6b0e34bcdd6407b2a18206ace7982d64de2c8" and
              .buildchainRef == "v3" and

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.1",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.1",
-    "sourceSha": "4ddab75987c618d69c4e19e5ce252cf4a014c21d"
+    "sourceSha": "8b22a3fc549a838d615d1d4ff38aaf48ba16f318"
   },
   "claims": [
     {

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:8510c8e704860893f22a0c85986480dbb65b604a703d9a6840f652a965f51867"
+            "sha256": "sha256:edcb0e76bcce4e2857c5060e227990d98100b73488d64dbe96c242049b7b016b"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -378,10 +378,10 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:a4e1203d12e44fd590e024ea8ce0d00cbe65d76737f3944f5de5173790926535",
+          "definitionDigest": "sha256:db77010b450883ede563b313901bc1145aaf9c038a8fbdd7fdd385b8c79c7fde",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
-          "steps": [{"index":1,"label":"name:Check out exact candidate source","definitionDigest":"sha256:90b7875c1b8263fc6ee031b6f446decfc1fe5eb289f08dbc3d506c4bce43f113"},{"index":2,"label":"name:Verify explicit Release Cut source lock","definitionDigest":"sha256:cd80a48941e576fa1b19a67a7c48b0c1fddaef301ca60da10245901820a09a16"},{"index":3,"label":"id:receipt","definitionDigest":"sha256:49dbd179361e6e926d6eab7b762bfa7bb7292e2f3c452a3b7ddd2d8bd626b623"}]
+          "steps": [{"index":1,"label":"name:Check out exact candidate source","definitionDigest":"sha256:90b7875c1b8263fc6ee031b6f446decfc1fe5eb289f08dbc3d506c4bce43f113"},{"index":2,"label":"name:Verify explicit Release Cut source lock","definitionDigest":"sha256:eaca9e1f6d333dacd278b06a19721fafb73906aba8d129db03b25b66f6a01778"},{"index":3,"label":"id:receipt","definitionDigest":"sha256:49dbd179361e6e926d6eab7b762bfa7bb7292e2f3c452a3b7ddd2d8bd626b623"}]
         },
         {
           "id": "windows-fast-sentinel",

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -129,7 +129,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:b19794f834d2c2aa8dc3f0c7eac1bf00efc619921fe576caa90149d298c92285"
+          "sourceRoot": "sha256:03b5888f87d83186d5553f414fee531e362550c7deff80bb242d8de6af67a1c8"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",
@@ -867,5 +867,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:2f933e68b2ff7135a976d2c70bef2df1eedfc6ea3fe39a6016cd584188448cbe"
+  "registryRoot": "sha256:f2ee3c6ebd031e37de406eb673a85ee0418e8699d629c4db5c5620fdf22281ad"
 }


### PR DESCRIPTION
## Summary

- align the Alpha source-lock assertion with the committed r17 cut
- refresh the generated workflow authority and KFD evidence closure required by the current dev head
- keep the repair limited to release-contract metadata; no product refactor

## Validation

- `./shifu node scripts/check-kungfu-gate-catalog.mjs`
- `./shifu node --test scripts/alpha-promotion-preflight.test.mjs`
- repository staged hook (full pass)

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Align the Alpha r17 source-lock assertion and refresh only its generated evidence closure"
}
-->