### PR TITLE
fix(packaging): enforce signed macOS CLI JIT runtime

### DIFF
--- a/.buildchain/buildchain.toml
+++ b/.buildchain/buildchain.toml
@@ -55,7 +55,7 @@ command = "node scripts/run-shifu-lifecycle.mjs cache-apply verify"
 
 [lifecycle.signing-finalization]
 # shifu-entry-contract: allow Buildchain's GitHub-hosted finalizer to rebind consumer qualification to imported signed bytes
-command = "node product/scripts/verify-cli-surface-qualification.mjs --qualification product/release/cli/kungfu-episodes-cli-darwin-arm64.qualification.json --archive product/release/cli/kungfu-episodes-cli-darwin-arm64.tar.gz --platform darwin-arm64 --signing-result .buildchain/artifacts/signing/macos-arm64/kungfu-cli-macos-arm64/result.json --signing-receipt .buildchain/artifacts/signing/macos-arm64/kungfu-cli-macos-arm64/receipt.json"
+command = "node product/scripts/verify-cli-surface-qualification.mjs --qualification product/release/cli/kungfu-episodes-cli-darwin-arm64.qualification.json --archive product/release/cli/kungfu-episodes-cli-darwin-arm64.tar.gz --platform darwin-arm64 --signing-result .buildchain/artifacts/signing/macos-arm64/kungfu-cli-macos-arm64/result.json --signing-receipt .buildchain/artifacts/signing/macos-arm64/kungfu-cli-macos-arm64/receipt.json --signing-provider-evidence .buildchain/artifacts/signing/macos-arm64/kungfu-cli-macos-arm64/provider-evidence.json"
 
 [lifecycle.publish]
 # shifu-entry-contract: allow Buildchain publish adapter bootstraps before repository lifecycle dispatch
@@ -88,6 +88,12 @@ profile = "auto"
 kind = "archive"
 platforms = ["macos-arm64"]
 required = true
+entitlements_profile = "jit-executable-v1"
+entitlements_paths = [
+  "kungfu-episodes-cli-darwin-arm64/runtime/kungfu",
+  "kungfu-episodes-cli-darwin-arm64/runtime/python/bin/python3",
+  "kungfu-episodes-cli-darwin-arm64/runtime/python/bin/python3.13",
+]
 
 [[signing.artifacts]]
 id = "kungfu-desktop-macos-arm64"

--- a/product/scripts/finalize-signed-cli-qualification.test.mjs
+++ b/product/scripts/finalize-signed-cli-qualification.test.mjs
@@ -2,6 +2,7 @@
 
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -10,12 +11,22 @@ import {
   cliQualificationNonClaims,
   cliQualificationRoot,
 } from './cli-surface-qualification.mjs';
-import { finalizeSignedCliQualification } from './verify-cli-surface-qualification.mjs';
+import {
+  bindSignedMacosRuntimeQualification,
+  finalizeSignedCliQualification,
+  signedMacosRuntimeReceiptRoot,
+  verifyCodesignEntitlements,
+} from './verify-cli-surface-qualification.mjs';
 
+const SCRIPT = fileURLToPath(
+  new URL('./verify-cli-surface-qualification.mjs', import.meta.url),
+);
 const ROOT = path.resolve(fileURLToPath(new URL('../..', import.meta.url)));
 const SOURCE = '1'.repeat(40);
 const BEFORE = `sha256:${'a'.repeat(64)}`;
 const AFTER = `sha256:${'b'.repeat(64)}`;
+const PROVIDER_EVIDENCE = `sha256:${'d'.repeat(64)}`;
+const EVIDENCE_DIGEST = `sha256:${'e'.repeat(64)}`;
 const JIT_EXECUTABLES = [
   'kungfu-episodes-cli-darwin-arm64/runtime/kungfu',
   'kungfu-episodes-cli-darwin-arm64/runtime/python/bin/python3',
@@ -67,13 +78,24 @@ function signing() {
       requestDigest,
       source: { sha: SOURCE },
       artifact: { digest: AFTER },
+      evidence: [
+        {
+          kind: 'apple-developer-id-verification',
+          path: 'provider-evidence.json',
+          digest: PROVIDER_EVIDENCE,
+        },
+      ],
+      evidenceDigest: EVIDENCE_DIGEST,
       verification: { status: 'passed' },
     },
     receipt: {
       contract: 'kungfu-buildchain-artifact-signing-receipt/v1',
       requestDigest,
       status: 'passed',
-      result: { artifactDigest: AFTER },
+      result: {
+        artifactDigest: AFTER,
+        evidenceDigest: EVIDENCE_DIGEST,
+      },
     },
     providerEvidence: {
       contract: 'kungfu-buildchain-apple-developer-id-evidence/v1',
@@ -97,9 +119,40 @@ function finalize(changes = {}) {
     signingResult: evidence.result,
     signingReceipt: evidence.receipt,
     signingProviderEvidence: evidence.providerEvidence,
+    signingProviderEvidenceDigest: PROVIDER_EVIDENCE,
     expectedSourceCommit: SOURCE,
     ...changes,
   });
+}
+
+function runtimeReceipt(changes = {}) {
+  const receipt = {
+    schema: 'kungfu.signed-macos-cli-runtime-verification/v1',
+    verified: true,
+    platform: 'darwin-arm64',
+    architecture: 'arm64',
+    sourceCommit: SOURCE,
+    archive: {
+      name: 'kungfu-episodes-cli-darwin-arm64.tar.gz',
+      sha256: AFTER,
+    },
+    checks: {
+      entitlements: JIT_EXECUTABLES.map((entry) => ({
+        path: entry,
+        allowJit: true,
+      })),
+      workProfile: { verdict: 'compatible' },
+      tuiAutoplay: { pty: 'node-pty', exitCode: 0 },
+      codexPlan: { fixtureOnly: true, credentialsRead: false },
+    },
+    isolation: {
+      realCodexRequired: false,
+      providerCredentialsRead: false,
+    },
+    ...changes,
+  };
+  receipt.receiptRoot = signedMacosRuntimeReceiptRoot(receipt);
+  return receipt;
 }
 
 test('signed CLI finalization rebinds the qualification to final archive bytes', () => {
@@ -108,6 +161,41 @@ test('signed CLI finalization rebinds the qualification to final archive bytes',
   assert.notEqual(report.qualificationRoot, qualification().qualificationRoot);
   const { qualificationRoot, ...subject } = report;
   assert.equal(qualificationRoot, cliQualificationRoot(subject));
+});
+
+test('signed CLI finalization binds the real post-sign runtime receipt', () => {
+  const report = bindSignedMacosRuntimeQualification({
+    report: finalize(),
+    signedRuntimeReceipt: runtimeReceipt(),
+    expectedPlatform: 'darwin-arm64',
+    archiveName: 'kungfu-episodes-cli-darwin-arm64.tar.gz',
+    archiveSha256: AFTER,
+    expectedSourceCommit: SOURCE,
+  });
+  assert.equal(report.checks.signedMacosRuntime.verified, true);
+  const { qualificationRoot, ...subject } = report;
+  assert.equal(qualificationRoot, cliQualificationRoot(subject));
+});
+
+test('signed CLI finalization rejects a runtime receipt for different archive bytes', () => {
+  const signedRuntimeReceipt = runtimeReceipt({
+    archive: {
+      name: 'kungfu-episodes-cli-darwin-arm64.tar.gz',
+      sha256: BEFORE,
+    },
+  });
+  assert.throws(
+    () =>
+      bindSignedMacosRuntimeQualification({
+        report: finalize(),
+        signedRuntimeReceipt,
+        expectedPlatform: 'darwin-arm64',
+        archiveName: 'kungfu-episodes-cli-darwin-arm64.tar.gz',
+        archiveSha256: AFTER,
+        expectedSourceCommit: SOURCE,
+      }),
+    /does not bind the qualified artifact/u,
+  );
 });
 
 test('signed CLI finalization rejects tampered pre-signing qualification', () => {
@@ -123,6 +211,25 @@ test('signed CLI finalization rejects archive bytes outside signing evidence', (
   assert.throws(
     () => finalize({ archiveSha256: `sha256:${'d'.repeat(64)}` }),
     /does not match the Buildchain signing result and receipt/u,
+  );
+});
+
+test('signed CLI finalization rejects a provider evidence file outside the signing result', () => {
+  assert.throws(
+    () =>
+      finalize({
+        signingProviderEvidenceDigest: `sha256:${'f'.repeat(64)}`,
+      }),
+    /does not bind the exact provider evidence file/u,
+  );
+});
+
+test('signed CLI finalization rejects divergent aggregate evidence digests', () => {
+  const evidence = signing();
+  evidence.receipt.result.evidenceDigest = `sha256:${'f'.repeat(64)}`;
+  assert.throws(
+    () => finalize({ signingReceipt: evidence.receipt }),
+    /result and receipt evidence digests differ/u,
   );
 });
 
@@ -149,9 +256,104 @@ test('signed CLI finalization rejects incomplete JIT executable coverage', () =>
   );
 });
 
+function fixtureRoot() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-entitlements-'));
+  for (const file of [
+    'runtime/kungfu',
+    'runtime/python/bin/python3',
+    'runtime/python/bin/python3.13',
+  ]) {
+    const target = path.join(root, ...file.split('/'));
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, 'fixture');
+  }
+  return root;
+}
+
+function codesignSpawn({ allowJit = true } = {}) {
+  return (command, args) => {
+    if (command === 'plutil') {
+      return {
+        status: 0,
+        stdout: JSON.stringify({
+          'com.apple.security.cs.allow-jit': allowJit,
+        }),
+        stderr: '',
+      };
+    }
+    assert.equal(command, 'codesign');
+    return {
+      status: 0,
+      stdout: args.includes('--display')
+        ? '<?xml version="1.0"?><plist><dict></dict></plist>'
+        : '',
+      stderr: '',
+    };
+  };
+}
+
+test('codesign readback requires allow-jit on every declared executable', (t) => {
+  const installRoot = fixtureRoot();
+  t.after(() => fs.rmSync(installRoot, { recursive: true, force: true }));
+  const result = verifyCodesignEntitlements(
+    { installRoot },
+    { spawn: codesignSpawn() },
+  );
+  assert.equal(result.length, 3);
+  assert.ok(result.every((entry) => entry.allowJit === true));
+});
+
+test('codesign readback fails closed when allow-jit is absent', (t) => {
+  const installRoot = fixtureRoot();
+  t.after(() => fs.rmSync(installRoot, { recursive: true, force: true }));
+  assert.throws(
+    () =>
+      verifyCodesignEntitlements(
+        { installRoot },
+        { spawn: codesignSpawn({ allowJit: false }) },
+      ),
+    /omitted com\.apple\.security\.cs\.allow-jit/u,
+  );
+});
+
+test('signed runtime receipt root changes with runtime evidence', () => {
+  const receipt = {
+    schema: 'kungfu.signed-macos-cli-runtime-verification/v1',
+    verified: true,
+    checks: { tuiAutoplay: { exitCode: 0 } },
+  };
+  const root = signedMacosRuntimeReceiptRoot(receipt);
+  assert.match(root, /^sha256:[0-9a-f]{64}$/u);
+  assert.notEqual(
+    root,
+    signedMacosRuntimeReceiptRoot({
+      ...receipt,
+      checks: { tuiAutoplay: { exitCode: 1 } },
+    }),
+  );
+});
+
+test('post-sign Codex planning is credential-free and selects only the fixture profile', () => {
+  const source = fs.readFileSync(SCRIPT, 'utf8');
+  assert.match(source, /!\['CODEX_HOME', 'OPENAI_API_KEY'\]\.includes\(key\)/u);
+  assert.match(source, /agent\.defaultRuntimeProfile/u);
+  assert.match(source, /'run',[\s\S]*?'codex',[\s\S]*?'--plan'/u);
+  assert.match(source, /realCodexRequired: false/u);
+  assert.match(source, /providerCredentialsRead: false/u);
+});
+
 test('Buildchain signing-finalization runs the consumer-owned qualification rebind', () => {
   const config = fs.readFileSync(
     path.join(ROOT, '.buildchain', 'buildchain.toml'),
+    'utf8',
+  );
+  const finalizer = fs.readFileSync(
+    path.join(
+      ROOT,
+      'product',
+      'scripts',
+      'verify-cli-surface-qualification.mjs',
+    ),
     'utf8',
   );
   assert.match(config, /\[lifecycle\.signing-finalization\]/u);
@@ -159,4 +361,9 @@ test('Buildchain signing-finalization runs the consumer-owned qualification rebi
     config,
     /verify-cli-surface-qualification\.mjs[\s\S]*--signing-result[\s\S]*--signing-receipt[\s\S]*--signing-provider-evidence/u,
   );
+  assert.match(
+    finalizer,
+    /options\.platform === 'darwin-arm64'[\s\S]*verifySignedMacosCliRuntime/u,
+  );
+  assert.match(finalizer, /bindSignedMacosRuntimeQualification/u);
 });

--- a/product/scripts/finalize-signed-cli-qualification.test.mjs
+++ b/product/scripts/finalize-signed-cli-qualification.test.mjs
@@ -16,6 +16,11 @@ const ROOT = path.resolve(fileURLToPath(new URL('../..', import.meta.url)));
 const SOURCE = '1'.repeat(40);
 const BEFORE = `sha256:${'a'.repeat(64)}`;
 const AFTER = `sha256:${'b'.repeat(64)}`;
+const JIT_EXECUTABLES = [
+  'kungfu-episodes-cli-darwin-arm64/runtime/kungfu',
+  'kungfu-episodes-cli-darwin-arm64/runtime/python/bin/python3',
+  'kungfu-episodes-cli-darwin-arm64/runtime/python/bin/python3.13',
+];
 
 function qualification() {
   const report = {
@@ -70,6 +75,15 @@ function signing() {
       status: 'passed',
       result: { artifactDigest: AFTER },
     },
+    providerEvidence: {
+      contract: 'kungfu-buildchain-apple-developer-id-evidence/v1',
+      status: 'passed',
+      compound: {
+        entitlementsProfile: 'jit-executable-v1',
+        entitledExecutableCount: JIT_EXECUTABLES.length,
+        entitledPaths: JIT_EXECUTABLES,
+      },
+    },
   };
 }
 
@@ -82,6 +96,7 @@ function finalize(changes = {}) {
     archiveSha256: AFTER,
     signingResult: evidence.result,
     signingReceipt: evidence.receipt,
+    signingProviderEvidence: evidence.providerEvidence,
     expectedSourceCommit: SOURCE,
     ...changes,
   });
@@ -111,6 +126,29 @@ test('signed CLI finalization rejects archive bytes outside signing evidence', (
   );
 });
 
+test('signed CLI finalization rejects provider evidence without JIT entitlements', () => {
+  const evidence = signing();
+  evidence.providerEvidence.compound = {
+    entitlementsProfile: 'none',
+    entitledExecutableCount: 0,
+    entitledPaths: [],
+  };
+  assert.throws(
+    () => finalize({ signingProviderEvidence: evidence.providerEvidence }),
+    /omitted the jit-executable-v1 entitlement profile/u,
+  );
+});
+
+test('signed CLI finalization rejects incomplete JIT executable coverage', () => {
+  const evidence = signing();
+  evidence.providerEvidence.compound.entitledExecutableCount = 1;
+  evidence.providerEvidence.compound.entitledPaths = [JIT_EXECUTABLES[0]];
+  assert.throws(
+    () => finalize({ signingProviderEvidence: evidence.providerEvidence }),
+    /must bind the JIT executables/u,
+  );
+});
+
 test('Buildchain signing-finalization runs the consumer-owned qualification rebind', () => {
   const config = fs.readFileSync(
     path.join(ROOT, '.buildchain', 'buildchain.toml'),
@@ -119,6 +157,6 @@ test('Buildchain signing-finalization runs the consumer-owned qualification rebi
   assert.match(config, /\[lifecycle\.signing-finalization\]/u);
   assert.match(
     config,
-    /verify-cli-surface-qualification\.mjs[\s\S]*--signing-result[\s\S]*--signing-receipt/u,
+    /verify-cli-surface-qualification\.mjs[\s\S]*--signing-result[\s\S]*--signing-receipt[\s\S]*--signing-provider-evidence/u,
   );
 });

--- a/product/scripts/verify-cli-surface-qualification.mjs
+++ b/product/scripts/verify-cli-surface-qualification.mjs
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { spawnSync } from 'node:child_process';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { extractTarGz } from './archive.mjs';
 import {
   cliQualificationNonClaims,
   cliQualificationRoot,
@@ -121,6 +124,7 @@ export function finalizeSignedCliQualification({
   signingResult,
   signingReceipt,
   signingProviderEvidence,
+  signingProviderEvidenceDigest,
   expectedSourceCommit,
 }) {
   assert(
@@ -159,6 +163,23 @@ export function finalizeSignedCliQualification({
     'Buildchain Apple Developer ID provider evidence did not pass',
   );
   assert(
+    ROOT_PATTERN.test(signingProviderEvidenceDigest || ''),
+    'Buildchain signing provider evidence omitted its file SHA256',
+  );
+  const providerEvidenceEntries = (signingResult.evidence || []).filter(
+    (entry) => entry?.path === 'provider-evidence.json',
+  );
+  assert(
+    providerEvidenceEntries.length === 1 &&
+      providerEvidenceEntries[0].digest === signingProviderEvidenceDigest,
+    'Buildchain signing result does not bind the exact provider evidence file',
+  );
+  assert(
+    ROOT_PATTERN.test(signingResult.evidenceDigest || '') &&
+      signingResult.evidenceDigest === signingReceipt.result?.evidenceDigest,
+    'Buildchain signing result and receipt evidence digests differ',
+  );
+  assert(
     signingProviderEvidence.compound?.entitlementsProfile ===
       'jit-executable-v1',
     'signed CLI provider evidence omitted the jit-executable-v1 entitlement profile',
@@ -188,6 +209,473 @@ export function finalizeSignedCliQualification({
 
   const rebound = structuredClone(report);
   rebound.identity.archiveSha256 = archiveSha256;
+  Reflect.deleteProperty(rebound, 'qualificationRoot');
+  rebound.qualificationRoot = cliQualificationRoot(rebound);
+  verifyCliSurfaceQualification({
+    report: rebound,
+    expectedPlatform,
+    archiveName,
+    archiveSha256,
+  });
+  return rebound;
+}
+
+const ARCHIVE_BASE = 'kungfu-episodes-cli-darwin-arm64';
+const JIT_EXECUTABLES = [
+  'runtime/kungfu',
+  'runtime/python/bin/python3',
+  'runtime/python/bin/python3.13',
+];
+function stable(value) {
+  if (Array.isArray(value)) return value.map(stable);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, stable(value[key])]),
+    );
+  }
+  return value;
+}
+
+function digestBytes(value) {
+  return `sha256:${crypto.createHash('sha256').update(value).digest('hex')}`;
+}
+
+export function signedMacosRuntimeReceiptRoot(receipt) {
+  const { receiptRoot: _receiptRoot, ...subject } = receipt;
+  return digestBytes(JSON.stringify(stable(subject)));
+}
+
+function sha256InstalledArchive(file) {
+  return digestBytes(fs.readFileSync(file));
+}
+
+function assertFile(file, label) {
+  assert(
+    fs.existsSync(file) && fs.statSync(file).isFile(),
+    `${label} not found: ${file}`,
+  );
+}
+
+function commandFailure(label, result) {
+  return [
+    `${label} failed (exit ${result.status ?? `signal ${result.signal}`})`,
+    result.error?.message ? `error: ${result.error.message}` : '',
+    result.stdout?.trim() ? `stdout:\n${result.stdout.trim()}` : '',
+    result.stderr?.trim() ? `stderr:\n${result.stderr.trim()}` : '',
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+function run(command, args, options = {}, spawn = spawnSync) {
+  const result = spawn(command, args, {
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    shell: false,
+    ...options,
+  });
+  if (result.status !== 0) {
+    throw new Error(commandFailure(`${command} ${args.join(' ')}`, result));
+  }
+  return result;
+}
+
+function parseJsonOutput(output, label) {
+  const text = String(output || '').trim();
+  try {
+    return JSON.parse(text);
+  } catch {
+    const start = text.indexOf('{');
+    const end = text.lastIndexOf('}');
+    if (start >= 0 && end > start) {
+      return JSON.parse(text.slice(start, end + 1));
+    }
+    throw new Error(`${label} did not produce JSON output`);
+  }
+}
+
+function plistXml(output, executable) {
+  const text = String(output || '');
+  const start = Math.max(text.indexOf('<?xml'), text.indexOf('<plist'));
+  const end = text.lastIndexOf('</plist>');
+  assert(
+    start >= 0 && end >= start,
+    `codesign entitlement readback omitted a plist: ${executable}`,
+  );
+  return text.slice(start, end + '</plist>'.length);
+}
+
+export function verifyCodesignEntitlements(
+  { installRoot },
+  { spawn = spawnSync } = {},
+) {
+  return JIT_EXECUTABLES.map((relativePath) => {
+    const executable = path.join(installRoot, ...relativePath.split('/'));
+    assertFile(executable, 'signed JIT executable');
+    run('codesign', ['--verify', '--strict', executable], {}, spawn);
+    const detail = run(
+      'codesign',
+      ['--display', '--entitlements', ':-', executable],
+      {},
+      spawn,
+    );
+    const converted = run(
+      'plutil',
+      ['-convert', 'json', '-o', '-', '--', '-'],
+      {
+        input: plistXml(
+          `${detail.stdout || ''}\n${detail.stderr || ''}`,
+          executable,
+        ),
+      },
+      spawn,
+    );
+    const entitlements = parseJsonOutput(
+      converted.stdout,
+      `codesign entitlements for ${relativePath}`,
+    );
+    assert(
+      entitlements['com.apple.security.cs.allow-jit'] === true,
+      `signed executable omitted com.apple.security.cs.allow-jit: ${relativePath}`,
+    );
+    return {
+      path: `${ARCHIVE_BASE}/${relativePath}`,
+      allowJit: true,
+    };
+  });
+}
+
+function installedEnvironment({ installRoot, temporaryRoot }) {
+  const home = path.join(temporaryRoot, 'home');
+  const runtimeHome = path.join(temporaryRoot, 'kungfu-home');
+  const configHome = path.join(temporaryRoot, 'kungfu-config');
+  const cacheHome = path.join(temporaryRoot, 'kungfu-cache');
+  for (const directory of [home, runtimeHome, configHome, cacheHome]) {
+    fs.mkdirSync(directory, { recursive: true });
+  }
+  const runtimeEntry = path.join(installRoot, 'runtime', 'kungfu');
+  const processEnvironment = Object.fromEntries(
+    Object.entries(process.env).filter(
+      ([key]) => !['CODEX_HOME', 'OPENAI_API_KEY'].includes(key),
+    ),
+  );
+  const environment = {
+    ...processEnvironment,
+    HOME: home,
+    USERPROFILE: home,
+    XDG_CONFIG_HOME: path.join(home, '.config'),
+    KF_HOME: runtimeHome,
+    KF_CONFIG_HOME: configHome,
+    KF_CACHE_HOME: cacheHome,
+    KUNGFU_CONTROLLER_ENTRYPOINT: runtimeEntry,
+    KUNGFU_AGENT_SESSION_EXECUTABLE: runtimeEntry,
+    PATH: '/usr/bin:/bin',
+    TERM: 'xterm-256color',
+  };
+  return environment;
+}
+
+function runKungfu(kungfu, args, { cwd, env, timeout = 60000 } = {}) {
+  return run(kungfu, args, { cwd, env, timeout });
+}
+
+function verifyEmbeddedWorkProfile({ installRoot, kungfu, env }) {
+  const profile = path.join(installRoot, 'extensions', 'work-control');
+  const result = runKungfu(kungfu, ['profile', 'validate', profile, '--json'], {
+    cwd: installRoot,
+    env,
+  });
+  const report = parseJsonOutput(
+    result.stdout,
+    'embedded Work Profile checker',
+  );
+  assert(
+    report.schema === 'kungfu.profile-validation/v1' &&
+      report.workConformance?.schema ===
+        'kungfu.work-profile-conformance-result/v1' &&
+      report.workConformance.verdict === 'compatible',
+    'embedded Work Profile checker did not return a compatible verdict',
+  );
+  return {
+    schema: report.workConformance.schema,
+    verdict: report.workConformance.verdict,
+    declarationRoot: report.workConformance.declarationRoot,
+  };
+}
+
+function writeFixtureCodex({ temporaryRoot }) {
+  const executable = path.join(temporaryRoot, 'codex-fixture');
+  fs.writeFileSync(
+    executable,
+    '#!/bin/sh\nif [ "${1:-}" = "--version" ]; then\n  printf "codex-fixture 0.0.0\\n"\n  exit 0\nfi\nexit 97\n',
+    { mode: 0o755 },
+  );
+  return executable;
+}
+
+function verifyCodexPlanWithoutCodex({
+  installRoot,
+  kungfu,
+  env,
+  temporaryRoot,
+}) {
+  const fixture = writeFixtureCodex({ temporaryRoot });
+  const profile = {
+    schema: 'kungfu.agent-runtime-profile/v1',
+    id: 'codex.post-sign-fixture',
+    label: 'Codex post-sign fixture',
+    provider: 'codex',
+    launch: {
+      executable: fixture,
+      argv: [],
+      interactiveArgv: [],
+      versionArgv: ['--version'],
+      shellMode: false,
+    },
+    cwdPolicy: 'workspace-root',
+    backendDefault: 'direct',
+    bootstrap: { adapter: 'codex', envelope: 'required' },
+    source: 'user',
+  };
+  runKungfu(
+    kungfu,
+    [
+      'config',
+      'set',
+      'agent.runtimeProfiles',
+      JSON.stringify([profile]),
+      '--json',
+    ],
+    { cwd: installRoot, env },
+  );
+  runKungfu(
+    kungfu,
+    [
+      'config',
+      'set',
+      'agent.defaultRuntimeProfile',
+      JSON.stringify(profile.id),
+      '--json',
+    ],
+    { cwd: installRoot, env },
+  );
+  const project = path.join(temporaryRoot, 'project');
+  const projectPlan = parseJsonOutput(
+    runKungfu(
+      kungfu,
+      ['agent-work-lab', 'starter-plan', '--destination', project, '--json'],
+      { cwd: temporaryRoot, env },
+    ).stdout,
+    'Agent Work Starter plan',
+  );
+  assert(projectPlan.planRoot, 'Agent Work Starter plan omitted planRoot');
+  runKungfu(
+    kungfu,
+    [
+      'agent-work-lab',
+      'starter-create',
+      '--destination',
+      project,
+      '--expected-plan-root',
+      projectPlan.planRoot,
+      '--actor',
+      'post-sign-smoke',
+      '--json',
+    ],
+    { cwd: temporaryRoot, env },
+  );
+  const plan = parseJsonOutput(
+    runKungfu(
+      kungfu,
+      ['run', 'codex', '--workspace', project, '--plan', '--json'],
+      { cwd: temporaryRoot, env },
+    ).stdout,
+    'kungfu run codex --plan',
+  );
+  assert(
+    /^sha256:[0-9a-f]{64}$/u.test(plan.planRoot || '') &&
+      plan.agent?.provider === 'codex',
+    'kungfu run codex --plan did not bind the fixture provider and exact plan',
+  );
+  return {
+    fixtureOnly: true,
+    provider: plan.agent.provider,
+    planRoot: plan.planRoot,
+    realProviderInstalled: false,
+    credentialsRead: false,
+  };
+}
+
+function ptyDriverSource() {
+  return [
+    'const nodePty = require(process.argv[1]);',
+    'const command = process.argv[2];',
+    'const args = JSON.parse(process.argv[3]);',
+    'const expected = process.argv[4];',
+    'const timeoutMs = Number(process.argv[5]);',
+    "let output = '';",
+    "const child = nodePty.spawn(command, args, {name: 'xterm-256color', cols: 120, rows: 40, cwd: process.cwd(), env: process.env});",
+    'child.onData((data) => { output += data; if (output.length > 64 * 1024 * 1024) { child.kill(); process.exit(93); } });',
+    'const timeout = setTimeout(() => { child.kill(); process.exit(94); }, timeoutMs);',
+    'child.onExit(({exitCode}) => { clearTimeout(timeout); if (exitCode !== 0) process.exit(95); if (!output.includes(expected)) process.exit(96); process.stdout.write(output); process.exit(0); });',
+  ].join('');
+}
+
+function verifyTuiAutoplayPty({ installRoot, kungfu, env, temporaryRoot }) {
+  const runtime = path.join(installRoot, 'runtime', 'kungfu');
+  const nodePty = path.join(
+    installRoot,
+    'tui',
+    'node_modules',
+    'node-pty',
+    'lib',
+    'index.js',
+  );
+  assertFile(nodePty, 'installed node-pty entry');
+  const result = run(
+    runtime,
+    [
+      '-e',
+      ptyDriverSource(),
+      nodePty,
+      kungfu,
+      JSON.stringify(['agent-work-lab', 'autoplay']),
+      'KUNGFU_TUI_DEMO_COMPLETE',
+      '180000',
+    ],
+    {
+      cwd: installRoot,
+      env: { ...env, KUNGFU_AS_VARIANT: 'node' },
+      timeout: 200000,
+    },
+  );
+  return {
+    pty: 'node-pty',
+    exitCode: 0,
+    completion: 'KUNGFU_TUI_DEMO_COMPLETE',
+    outputDigest: digestBytes(result.stdout || ''),
+    isolatedHome: path.relative(temporaryRoot, env.KF_HOME),
+  };
+}
+
+export async function verifySignedMacosCliRuntime({
+  archive,
+  expectedSourceCommit = process.env.BUILDCHAIN_SOURCE_SHA || '',
+} = {}) {
+  assert(
+    process.platform === 'darwin',
+    'signed macOS CLI runtime verification requires macOS',
+  );
+  assert(
+    process.arch === 'arm64',
+    'signed macOS CLI runtime verification requires arm64',
+  );
+  assertFile(archive, 'signed macOS CLI archive');
+  assert(
+    SOURCE_PATTERN.test(expectedSourceCommit),
+    'signed macOS CLI runtime verification requires an exact source commit',
+  );
+  const temporaryRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-signed-macos-cli-runtime-'),
+  );
+  try {
+    const extracted = path.join(temporaryRoot, 'extracted');
+    fs.mkdirSync(extracted, { recursive: true });
+    extractTarGz({ archiveFile: archive, targetDir: extracted });
+    const installRoot = path.join(extracted, ARCHIVE_BASE);
+    const product = JSON.parse(
+      fs.readFileSync(path.join(installRoot, 'product.json'), 'utf8'),
+    );
+    const upgrade = JSON.parse(
+      fs.readFileSync(
+        path.join(installRoot, 'upgrade', 'kungfu-release-manifest.json'),
+        'utf8',
+      ),
+    );
+    assert(
+      product.schema === 'kungfu.product.cli/v1' &&
+        product.platform === 'darwin-arm64',
+      'signed archive is not the standalone macOS arm64 CLI product',
+    );
+    assert(
+      upgrade.sourceCommit === expectedSourceCommit,
+      `signed archive source mismatch: expected ${expectedSourceCommit}, got ${upgrade.sourceCommit}`,
+    );
+    const kungfu = path.join(installRoot, product.entries.kungfu);
+    const env = installedEnvironment({ installRoot, temporaryRoot });
+    const receipt = {
+      schema: 'kungfu.signed-macos-cli-runtime-verification/v1',
+      verified: true,
+      platform: 'darwin-arm64',
+      architecture: 'arm64',
+      sourceCommit: expectedSourceCommit,
+      archive: {
+        name: path.basename(archive),
+        sha256: sha256InstalledArchive(archive),
+      },
+      checks: {
+        entitlements: verifyCodesignEntitlements({ installRoot }),
+        workProfile: verifyEmbeddedWorkProfile({ installRoot, kungfu, env }),
+        tuiAutoplay: verifyTuiAutoplayPty({
+          installRoot,
+          kungfu,
+          env,
+          temporaryRoot,
+        }),
+        codexPlan: verifyCodexPlanWithoutCodex({
+          installRoot,
+          kungfu,
+          env,
+          temporaryRoot,
+        }),
+      },
+      isolation: {
+        temporaryHome: true,
+        realCodexRequired: false,
+        providerCredentialsRead: false,
+      },
+      nonClaims: [
+        'The fixture Codex plan is not a real provider launch or authentication test.',
+        'Real Codex trust and model smoke remain clean-machine acceptance evidence.',
+      ],
+    };
+    receipt.receiptRoot = signedMacosRuntimeReceiptRoot(receipt);
+    return receipt;
+  } finally {
+    fs.rmSync(temporaryRoot, { recursive: true, force: true });
+  }
+}
+
+export function bindSignedMacosRuntimeQualification({
+  report,
+  signedRuntimeReceipt,
+  expectedPlatform,
+  archiveName,
+  archiveSha256,
+  expectedSourceCommit,
+}) {
+  assert(
+    signedRuntimeReceipt?.schema ===
+      'kungfu.signed-macos-cli-runtime-verification/v1' &&
+      signedRuntimeReceipt.verified === true,
+    'signed macOS CLI runtime verification did not pass',
+  );
+  assert(
+    signedRuntimeReceipt.receiptRoot ===
+      signedMacosRuntimeReceiptRoot(signedRuntimeReceipt),
+    'signed macOS CLI runtime receipt root mismatch',
+  );
+  assert(
+    signedRuntimeReceipt.platform === expectedPlatform &&
+      signedRuntimeReceipt.sourceCommit === expectedSourceCommit &&
+      signedRuntimeReceipt.archive?.name === archiveName &&
+      signedRuntimeReceipt.archive?.sha256 === archiveSha256,
+    'signed macOS CLI runtime receipt does not bind the qualified artifact',
+  );
+  const rebound = structuredClone(report);
+  rebound.checks.signedMacosRuntime = signedRuntimeReceipt;
   Reflect.deleteProperty(rebound, 'qualificationRoot');
   rebound.qualificationRoot = cliQualificationRoot(rebound);
   verifyCliSurfaceQualification({
@@ -269,7 +757,10 @@ async function main(argv) {
     }
     const sourceCommit =
       options['source-commit'] || process.env.BUILDCHAIN_SOURCE_SHA || '';
-    const report = finalizeSignedCliQualification({
+    const providerEvidencePath = path.resolve(
+      options['signing-provider-evidence'],
+    );
+    let report = finalizeSignedCliQualification({
       report: readJson(qualification),
       expectedPlatform: options.platform,
       archiveName: path.basename(archive),
@@ -283,11 +774,26 @@ async function main(argv) {
         'signing receipt',
       ),
       signingProviderEvidence: readJson(
-        path.resolve(options['signing-provider-evidence']),
+        providerEvidencePath,
         'signing provider evidence',
       ),
+      signingProviderEvidenceDigest: await sha256File(providerEvidencePath),
       expectedSourceCommit: sourceCommit,
     });
+    if (options.platform === 'darwin-arm64') {
+      const signedRuntimeReceipt = await verifySignedMacosCliRuntime({
+        archive,
+        expectedSourceCommit: sourceCommit,
+      });
+      report = bindSignedMacosRuntimeQualification({
+        report,
+        signedRuntimeReceipt,
+        expectedPlatform: options.platform,
+        archiveName: path.basename(archive),
+        archiveSha256,
+        expectedSourceCommit: sourceCommit,
+      });
+    }
     writeJsonAtomic(qualification, report);
     process.stdout.write(
       `${JSON.stringify({

--- a/product/scripts/verify-cli-surface-qualification.mjs
+++ b/product/scripts/verify-cli-surface-qualification.mjs
@@ -12,6 +12,11 @@ import {
 
 const ROOT_PATTERN = /^sha256:[0-9a-f]{64}$/u;
 const SOURCE_PATTERN = /^[0-9a-f]{40}$/u;
+const MACOS_CLI_JIT_EXECUTABLES = [
+  'kungfu-episodes-cli-darwin-arm64/runtime/kungfu',
+  'kungfu-episodes-cli-darwin-arm64/runtime/python/bin/python3',
+  'kungfu-episodes-cli-darwin-arm64/runtime/python/bin/python3.13',
+];
 
 function assert(condition, message) {
   if (!condition) throw new Error(message);
@@ -115,6 +120,7 @@ export function finalizeSignedCliQualification({
   archiveSha256,
   signingResult,
   signingReceipt,
+  signingProviderEvidence,
   expectedSourceCommit,
 }) {
   assert(
@@ -145,6 +151,26 @@ export function finalizeSignedCliQualification({
       'kungfu-buildchain-artifact-signing-receipt/v1' &&
       signingReceipt.status === 'passed',
     'Buildchain signing receipt did not pass',
+  );
+  assert(
+    signingProviderEvidence?.contract ===
+      'kungfu-buildchain-apple-developer-id-evidence/v1' &&
+      signingProviderEvidence.status === 'passed',
+    'Buildchain Apple Developer ID provider evidence did not pass',
+  );
+  assert(
+    signingProviderEvidence.compound?.entitlementsProfile ===
+      'jit-executable-v1',
+    'signed CLI provider evidence omitted the jit-executable-v1 entitlement profile',
+  );
+  const entitledPaths = signingProviderEvidence.compound?.entitledPaths;
+  assert(
+    Array.isArray(entitledPaths) &&
+      signingProviderEvidence.compound?.entitledExecutableCount ===
+        MACOS_CLI_JIT_EXECUTABLES.length &&
+      JSON.stringify([...entitledPaths].sort()) ===
+        JSON.stringify([...MACOS_CLI_JIT_EXECUTABLES].sort()),
+    `signed CLI provider evidence must bind the JIT executables: ${MACOS_CLI_JIT_EXECUTABLES.join(', ')}`,
   );
   assert(
     signingResult.requestDigest === signingReceipt.requestDigest,
@@ -181,6 +207,7 @@ function parseArgs(argv) {
     '--platform',
     '--signing-result',
     '--signing-receipt',
+    '--signing-provider-evidence',
     '--source-commit',
   ]);
   for (let index = 0; index < argv.length; index += 1) {
@@ -228,8 +255,16 @@ async function main(argv) {
   const qualification = path.resolve(options.qualification);
   const archive = path.resolve(options.archive);
   const archiveSha256 = await sha256File(archive);
-  if (options['signing-result'] || options['signing-receipt']) {
-    for (const required of ['signing-result', 'signing-receipt']) {
+  if (
+    options['signing-result'] ||
+    options['signing-receipt'] ||
+    options['signing-provider-evidence']
+  ) {
+    for (const required of [
+      'signing-result',
+      'signing-receipt',
+      'signing-provider-evidence',
+    ]) {
       if (!options[required]) throw new Error(`--${required} is required`);
     }
     const sourceCommit =
@@ -246,6 +281,10 @@ async function main(argv) {
       signingReceipt: readJson(
         path.resolve(options['signing-receipt']),
         'signing receipt',
+      ),
+      signingProviderEvidence: readJson(
+        path.resolve(options['signing-provider-evidence']),
+        'signing provider evidence',
       ),
       expectedSourceCommit: sourceCommit,
     });

--- a/scripts/alpha-macos-overflow.test.mjs
+++ b/scripts/alpha-macos-overflow.test.mjs
@@ -491,7 +491,10 @@ test('workflow contract keeps candidates exact-source, independent, and publish-
     signing,
     /id = "kungfu-cli-macos-arm64"[\s\S]*profile = "auto"[\s\S]*platforms = \["macos-arm64"\][\s\S]*required = true/u,
   );
-  assert.doesNotMatch(signing, /entitlements_(?:profile|paths)/u);
+  assert.match(
+    signing,
+    /id = "kungfu-cli-macos-arm64"[\s\S]*entitlements_profile = "jit-executable-v1"[\s\S]*entitlements_paths = \[[\s\S]*"kungfu-episodes-cli-darwin-arm64\/runtime\/kungfu"[\s\S]*"kungfu-episodes-cli-darwin-arm64\/runtime\/python\/bin\/python3"[\s\S]*"kungfu-episodes-cli-darwin-arm64\/runtime\/python\/bin\/python3\.13"[\s\S]*\]/u,
+  );
   assert.match(workflow, /checkout-history-mode: full/u);
   assert.match(
     workflow,


### PR DESCRIPTION
## Summary

- restore the standalone macOS CLI JIT entitlement profile for embedded Node and Python executables
- fail finalization unless provider evidence is digest-bound to the signing result and receipt
- verify the signed archive by entitlement readback, embedded Work Profile check, PTY autoplay, and credential-free `kungfu run codex --plan`
- use a local fixture provider in CI; GitHub is not assumed to have Codex, login state, or API credentials
- supersedes #2959 with a conflict-free linear branch on current canonical dev

## Validation

- `node --test product/scripts/finalize-signed-cli-qualification.test.mjs` (14/14)
- `./shifu test:cli-surface-qualification` (78/78)
- `./shifu check:source` (pass; 0 failures)
- exact Buildchain support merged at `dbad2f383a6ab93abd192c4edefb4689c9eebc78`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"Restores and verifies the existing standalone macOS CLI signing contract without changing architecture."}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk

No Alpha publication, release, tag, or stable-branch change. GitHub validation is credential-free and cannot launch a real Codex provider.
