### PR TITLE
fix(release): align Alpha r17 source lock

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
             --arg source "$RELEASE_CUT_SOURCE_SHA" \
             '.schema == "kungfu.alpha-release-cut-build-lock/v1" and
              .release == "v4.0.0-alpha.2" and
-             .cut == "r16" and
+             .cut == "r17" and
              .candidateSha == $source and
              .alphaBaseSha == "f9e6b0e34bcdd6407b2a18206ace7982d64de2c8" and
              .buildchainRef == "v3" and

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -351,10 +351,10 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:a4e1203d12e44fd590e024ea8ce0d00cbe65d76737f3944f5de5173790926535",
+          "definitionDigest": "sha256:db77010b450883ede563b313901bc1145aaf9c038a8fbdd7fdd385b8c79c7fde",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
-          "steps": [{"index":1,"label":"name:Check out exact candidate source","definitionDigest":"sha256:90b7875c1b8263fc6ee031b6f446decfc1fe5eb289f08dbc3d506c4bce43f113"},{"index":2,"label":"name:Verify explicit Release Cut source lock","definitionDigest":"sha256:cd80a48941e576fa1b19a67a7c48b0c1fddaef301ca60da10245901820a09a16"},{"index":3,"label":"id:receipt","definitionDigest":"sha256:49dbd179361e6e926d6eab7b762bfa7bb7292e2f3c452a3b7ddd2d8bd626b623"}]
+          "steps": [{"index":1,"label":"name:Check out exact candidate source","definitionDigest":"sha256:90b7875c1b8263fc6ee031b6f446decfc1fe5eb289f08dbc3d506c4bce43f113"},{"index":2,"label":"name:Verify explicit Release Cut source lock","definitionDigest":"sha256:eaca9e1f6d333dacd278b06a19721fafb73906aba8d129db03b25b66f6a01778"},{"index":3,"label":"id:receipt","definitionDigest":"sha256:49dbd179361e6e926d6eab7b762bfa7bb7292e2f3c452a3b7ddd2d8bd626b623"}]
         },
         {
           "id": "resolve-auditable-demo-source",

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -122,7 +122,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:063a56ca1b58be953b1bb9c06fb48e113872d1f88f709b6aa0523ed27e03cc79"
+          "sourceRoot": "sha256:16ea97268409389c063005c636da48658e7dffb336e405493ca6b1d3ce08efd7"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",
@@ -860,5 +860,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:a30cf64591ec56bcd99c308dd72a9ac0c0e82f3bb172a36bbd5c92c427c7ae3b"
+  "registryRoot": "sha256:51a811e16c59bc77174f0b3c87a47a010dd465efd47064ba3071338029c62673"
 }


### PR DESCRIPTION
<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Align the Alpha r17 source-lock assertion and refresh only its generated evidence closure"
}
-->

## Summary

- align the explicit Alpha.2 Release Cut lock from r16 to r17
- regenerate the closed-world workflow authority digests
- refresh the publication control-plane source and registry roots

## Validation

- `./shifu node framework/release/publication-control-plane.mjs check`
- `./shifu check:gate-catalog`
- `./shifu node --test scripts/verify-alpha-release-cut-lock.test.mjs`
- `./shifu node --test scripts/alpha-promotion-preflight.test.mjs` (18/18)
- `./shifu check:source`