### PR TITLE
fix(release): align Alpha.2 r17 build lock

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,7 @@ jobs:
             --arg source "$RELEASE_CUT_SOURCE_SHA" \
             '.schema == "kungfu.alpha-release-cut-build-lock/v1" and
              .release == "v4.0.0-alpha.2" and
-             .cut == "r16" and
+             .cut == "r17" and
              .candidateSha == $source and
              .alphaBaseSha == "f9e6b0e34bcdd6407b2a18206ace7982d64de2c8" and
              .buildchainRef == "v3" and

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -378,10 +378,10 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:a4e1203d12e44fd590e024ea8ce0d00cbe65d76737f3944f5de5173790926535",
+          "definitionDigest": "sha256:db77010b450883ede563b313901bc1145aaf9c038a8fbdd7fdd385b8c79c7fde",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
-          "steps": [{"index":1,"label":"name:Check out exact candidate source","definitionDigest":"sha256:90b7875c1b8263fc6ee031b6f446decfc1fe5eb289f08dbc3d506c4bce43f113"},{"index":2,"label":"name:Verify explicit Release Cut source lock","definitionDigest":"sha256:cd80a48941e576fa1b19a67a7c48b0c1fddaef301ca60da10245901820a09a16"},{"index":3,"label":"id:receipt","definitionDigest":"sha256:49dbd179361e6e926d6eab7b762bfa7bb7292e2f3c452a3b7ddd2d8bd626b623"}]
+          "steps": [{"index":1,"label":"name:Check out exact candidate source","definitionDigest":"sha256:90b7875c1b8263fc6ee031b6f446decfc1fe5eb289f08dbc3d506c4bce43f113"},{"index":2,"label":"name:Verify explicit Release Cut source lock","definitionDigest":"sha256:eaca9e1f6d333dacd278b06a19721fafb73906aba8d129db03b25b66f6a01778"},{"index":3,"label":"id:receipt","definitionDigest":"sha256:49dbd179361e6e926d6eab7b762bfa7bb7292e2f3c452a3b7ddd2d8bd626b623"}]
         },
         {
           "id": "windows-fast-sentinel",

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -129,7 +129,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:b19794f834d2c2aa8dc3f0c7eac1bf00efc619921fe576caa90149d298c92285"
+          "sourceRoot": "sha256:03b5888f87d83186d5553f414fee531e362550c7deff80bb242d8de6af67a1c8"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",
@@ -867,5 +867,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:2f933e68b2ff7135a976d2c70bef2df1eedfc6ea3fe39a6016cd584188448cbe"
+  "registryRoot": "sha256:f2ee3c6ebd031e37de406eb673a85ee0418e8699d629c4db5c5620fdf22281ad"
 }


### PR DESCRIPTION
Postmerge validation of the macOS CLI JIT repair found one fail-closed source-lock drift: the Alpha preflight contract requires r17 while build.yml still declared r16. This PR aligns the exact Release Cut lock, refreshes generated workflow authority digests, and refreshes the publication-control-plane workflow root.

Validation: alpha-promotion-preflight 18/18; full staged gate and full source acceptance passed.

No release, tag, or Alpha publication is performed.

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"Repair Release Cut source-lock and derived authority digest drift without changing an ADR contract."}
-->