### PR TITLE
fix(release): forward-port Alpha.2 r16 blocker repair

### DIFF
--- a/scripts/upgrade-publication-admission.mjs
+++ b/scripts/upgrade-publication-admission.mjs
@@ -177,23 +177,26 @@ function safeRelative(root, filePath, label) {
 }
 
 function candidateBundleIdentity(directory) {
+  const hasProductPayload = fs.existsSync(path.join(directory, 'product'));
   const platformManifestPath = path.join(
     directory,
     CANDIDATE_PLATFORM_MANIFEST_FILE,
   );
-  const credentialEvidence = filesNamed(directory, CREDENTIAL_EVIDENCE_FILE);
-  if (credentialEvidence.length > 0) {
-    if (!fs.existsSync(platformManifestPath)) {
-      throw new Error('credential-island bundle has no platform manifest');
-    }
+  if (fs.existsSync(platformManifestPath)) {
     const manifest = readJson(
       platformManifestPath,
-      'credential-island platform manifest',
+      'candidate platform manifest',
     );
-    return {
-      role: 'credential-island',
-      platformId: String(manifest.platform?.id || ''),
-    };
+    if (
+      (manifest.lifecycle?.stage === 'credential-island' ||
+        manifest.platform?.id === 'macos-arm64-credential') &&
+      filesNamed(directory, CREDENTIAL_EVIDENCE_FILE).length > 0
+    ) {
+      return {
+        role: 'credential-island',
+        platformId: String(manifest.platform?.id || ''),
+      };
+    }
   }
   const upgradeManifests = upgradeManifestFiles(directory);
   if (upgradeManifests.length > 0) {
@@ -207,17 +210,22 @@ function candidateBundleIdentity(directory) {
         `product-upgrade bundle has multiple platform roles: ${[...platformIds].join(', ')}`,
       );
     }
-    return { role: 'product-upgrade', platformId: [...platformIds][0] };
+    const platformId = [...platformIds][0];
+    if (
+      hasProductPayload &&
+      EXPECTED_CANDIDATE_PLATFORM_ROLES['product-support'].includes(platformId)
+    ) {
+      return { role: 'product-support', platformId };
+    }
+    return { role: 'product-upgrade', platformId };
   }
-  if (fs.existsSync(platformManifestPath)) {
+  if (hasProductPayload && fs.existsSync(platformManifestPath)) {
     const manifest = readJson(
       platformManifestPath,
       'product-support platform manifest',
     );
-    return {
-      role: 'product-support',
-      platformId: String(manifest.platform?.id || ''),
-    };
+    const platformId = String(manifest.platform?.id || '');
+    return { role: 'product-support', platformId };
   }
   return null;
 }
@@ -1063,6 +1071,13 @@ function verifyBundle({
     throw new Error(
       `upgrade manifest source ${manifest.sourceCommit || '<empty>'} is not bound by the release-candidate passport`,
     );
+  }
+  if (
+    EXPECTED_CANDIDATE_PLATFORM_ROLES['product-support'].includes(
+      platformIdentity(manifest),
+    )
+  ) {
+    return null;
   }
 
   let evidence = null;

--- a/scripts/upgrade-publication-admission.test.mjs
+++ b/scripts/upgrade-publication-admission.test.mjs
@@ -899,6 +899,144 @@ test('candidate finalization seals one rooted product admission receipt into its
   });
 });
 
+test('candidate finalization ignores root-manifest-only artifact projections', () => {
+  withFixture((value) => {
+    for (const [name, manifestPath] of [
+      ['kungfu-credential-manifest-macos', value.credential.manifestPath],
+      [
+        'kungfu-manifest-linux-arm64',
+        path.join(value.support.bundleRoot, 'manifest.json'),
+      ],
+      [
+        'kungfu-manifest-linux-x64',
+        path.join(value.platforms.linux.bundleRoot, 'manifest.json'),
+      ],
+    ]) {
+      const projectionRoot = path.join(value.payloadRoot, name);
+      fs.mkdirSync(projectionRoot, { recursive: true });
+      fs.copyFileSync(manifestPath, path.join(projectionRoot, 'manifest.json'));
+    }
+    const outputRoot = path.join(
+      value.payloadRoot,
+      `kungfu-product-admission-${SOURCE}`,
+    );
+    const written = writeUpgradePublicationAdmission({
+      payloadRoot: value.payloadRoot,
+      releaseCandidatePassportPath: value.passportPath,
+      expectedVersion: VERSION,
+      outputPath: path.join(
+        outputRoot,
+        PRODUCT_UPGRADE_PUBLICATION_ADMISSION_FILE,
+      ),
+      capsulePath: path.join(
+        outputRoot,
+        PRODUCT_UPGRADE_PUBLICATION_CAPSULE_FILE,
+      ),
+    });
+    assert.equal(written.receipt.candidate.bundleCount, 5);
+    assert.deepEqual(
+      written.receipt.candidate.bundles.map(({ name }) => name).sort(),
+      [
+        path.basename(value.credential.bundleRoot),
+        path.basename(value.platforms.darwin.bundleRoot),
+        path.basename(value.platforms.linux.bundleRoot),
+        path.basename(value.platforms.win32.bundleRoot),
+        path.basename(value.support.bundleRoot),
+      ].sort(),
+    );
+  });
+});
+
+test('candidate finalization retains Linux ARM64 as product support when it carries an upgrade manifest', () => {
+  withFixture((value) => {
+    const supportManifestPath = path.join(
+      value.support.bundleRoot,
+      'product',
+      'release',
+      'cli',
+      `kungfu-upgrade-${VERSION}-linux-arm64.json`,
+    );
+    const supportManifest = JSON.parse(
+      fs.readFileSync(value.platforms.linux.cliManifestPath, 'utf8'),
+    );
+    supportManifest.platform = 'linux';
+    supportManifest.architecture = 'arm64';
+    writeJson(supportManifestPath, supportManifest);
+    const outputRoot = path.join(
+      value.payloadRoot,
+      `kungfu-product-admission-${SOURCE}`,
+    );
+    const written = writeUpgradePublicationAdmission({
+      payloadRoot: value.payloadRoot,
+      releaseCandidatePassportPath: value.passportPath,
+      expectedVersion: VERSION,
+      outputPath: path.join(
+        outputRoot,
+        PRODUCT_UPGRADE_PUBLICATION_ADMISSION_FILE,
+      ),
+      capsulePath: path.join(
+        outputRoot,
+        PRODUCT_UPGRADE_PUBLICATION_CAPSULE_FILE,
+      ),
+    });
+    assert.equal(written.receipt.candidate.bundleCount, 5);
+    assert.deepEqual(
+      written.receipt.candidate.bundles
+        .filter(({ platformId }) => platformId === 'linux-arm64')
+        .map(({ role }) => role),
+      ['product-support'],
+    );
+    assert.deepEqual(written.receipt.admission.platforms, [
+      'darwin-arm64',
+      'linux-x64',
+      'win32-x64',
+    ]);
+  });
+});
+
+test('candidate finalization treats a real Linux ARM64 upgrade manifest without a root projection as support-only', () => {
+  withFixture((value) => {
+    fs.rmSync(path.join(value.support.bundleRoot, 'manifest.json'));
+    const supportManifestPath = path.join(
+      value.support.bundleRoot,
+      'product',
+      'release',
+      'cli',
+      `kungfu-upgrade-${VERSION}-linux-arm64.json`,
+    );
+    const supportManifest = JSON.parse(
+      fs.readFileSync(value.platforms.linux.cliManifestPath, 'utf8'),
+    );
+    supportManifest.platform = 'linux';
+    supportManifest.architecture = 'arm64';
+    writeJson(supportManifestPath, supportManifest);
+    const outputRoot = path.join(
+      value.payloadRoot,
+      `kungfu-product-admission-${SOURCE}`,
+    );
+    const written = writeUpgradePublicationAdmission({
+      payloadRoot: value.payloadRoot,
+      releaseCandidatePassportPath: value.passportPath,
+      expectedVersion: VERSION,
+      outputPath: path.join(
+        outputRoot,
+        PRODUCT_UPGRADE_PUBLICATION_ADMISSION_FILE,
+      ),
+      capsulePath: path.join(
+        outputRoot,
+        PRODUCT_UPGRADE_PUBLICATION_CAPSULE_FILE,
+      ),
+    });
+    assert.equal(written.receipt.candidate.bundleCount, 5);
+    assert.equal(
+      written.receipt.candidate.bundles.find(
+        ({ role }) => role === 'product-support',
+      ).platformId,
+      'linux-arm64',
+    );
+  });
+});
+
 test('candidate finalization rejects a candidate without the exact five bundle roles', () => {
   withFixture((value) => {
     fs.rmSync(value.support.bundleRoot, { recursive: true });


### PR DESCRIPTION
## Summary

- forward-port the final Alpha.2 r16 blocker patch root onto the latest dev/v4/v4.0
- ignore manifest-only artifact projections while retaining real Linux ARM64 product support payloads
- keep support-only Linux ARM64 outside the three-platform upgrade-admission claim
- preserve frozen r16 as the sole Alpha Build input; this dev mirror is publication-gate evidence only

## Validation

- repository pre-commit gate passed
- node --test scripts/upgrade-publication-admission.test.mjs passed 27/27
- exact forward-port commit: 5ec7e2a839ce72e767a54caf0a8236830d990c62
- frozen Release Cut remains: 1111c25b5be5e24be21be5ce9a22bfe6cf68b8ab

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"Forward-ports an already validated Alpha.2 release-blocker repair without changing architecture or the frozen Release Cut."}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk

This PR does not recut, supersede, or rebuild Alpha.2. It only satisfies the required same-patch-root dev publication gate.

Signed-off-by: Keren Dong <keren.dong@kungfu.link>