### PR TITLE
fix(ci): run signed macOS finalization natively

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,7 +180,9 @@ jobs:
   build:
     needs: [preflight, windows-fast-sentinel, auditable-demo-fast-sentinel]
     if: ${{ always() && needs.preflight.result == 'success' && needs.windows-fast-sentinel.result == 'success' && needs.auditable-demo-fast-sentinel.result == 'success' && !inputs.fast-sentinels-only && fromJSON(inputs.macos-overflow-request-json || '{}').mode != 'control' }}
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v3
+    # Pin the workflow shell that routes signed macOS finalization to a native
+    # runner. The v3 tag can lag this fail-closed runtime contract.
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@dbad2f383a6ab93abd192c4edefb4689c9eebc78
     secrets:
       BUILDCHAIN_PROMOTION_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}
       BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -338,9 +338,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:f87adcf26bdb45225272fb7bd53d393431e8029922a401e9aaa2cf13a5083e69",
+          "definitionDigest": "sha256:b2496ac2aefd44b23829553f1a0085c1a3a07996eaf46d1973773d1a75b923d1",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN","KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@v3"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@dbad2f383a6ab93abd192c4edefb4689c9eebc78"],
           "steps": []
         },
         {

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -467,7 +467,7 @@
       "adapter": {
         "type": "buildchain-heavy-build",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@v3",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@dbad2f383a6ab93abd192c4edefb4689c9eebc78",
         "job": {
       "needs": [
         "preflight",

--- a/docs/release-promotion-rehearsal.contract.json
+++ b/docs/release-promotion-rehearsal.contract.json
@@ -8,6 +8,7 @@
   "buildchain": {
     "workflow_shell_ref": "v3",
     "workflow_shell_resolved_sha": "81c49578bff72a9784a1b63ce8698bd9dd23d7bf",
+    "build_workflow_shell_sha": "dbad2f383a6ab93abd192c4edefb4689c9eebc78",
     "alpha": {
       "workflow_ref": "v3-alpha",
       "resolved_sha": "36b08dc7bf417e57bffcc3dc784a2473254fe4c1",

--- a/framework/release/publication-control-plane.mjs
+++ b/framework/release/publication-control-plane.mjs
@@ -96,6 +96,27 @@ export function validatePromotionWorkflowAuthority(
     );
   return true;
 }
+export function validateBuildWorkflowAuthority(
+  buildWorkflow,
+  workflowShellSha,
+) {
+  if (!/^[0-9a-f]{40}$/u.test(workflowShellSha))
+    throw new Error('Build workflow shell revision is invalid');
+  if (
+    !buildWorkflow.includes(
+      `uses: kungfu-systems/buildchain/.github/workflows/.build.yml@${workflowShellSha}`,
+    ) ||
+    !/^\s+buildchain-ref: \$\{\{ inputs\.buildchain-ref \|\| 'v3' \}\}\s*$/mu.test(
+      buildWorkflow,
+    ) ||
+    buildWorkflow.includes(
+      'uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v3',
+    ) ||
+    buildWorkflow.includes('kungfu-trader/workflows@v1')
+  )
+    throw new Error('.github/workflows/build.yml authority drift');
+  return true;
+}
 export function discoverBuildchainReleaseWorkflows(r, paths) {
   const p = new RegExp(r.repositories.buildchain.workflowDiscoveryPattern);
   return paths
@@ -274,19 +295,13 @@ export function validateRegistry(r, { root = ROOT } = {}) {
     path.join(root, '.github/workflows/build.yml'),
     'utf8',
   );
-  if (
-    !buildWorkflow.includes(
-      'uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v3',
-    ) ||
-    !/^\s+buildchain-ref: \$\{\{ inputs\.buildchain-ref \|\| 'v3' \}\}\s*$/mu.test(
-      buildWorkflow,
-    ) ||
-    /kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@[0-9a-f]{40}/u.test(
-      buildWorkflow,
-    ) ||
-    buildWorkflow.includes('kungfu-trader/workflows@v1')
-  )
-    throw new Error('.github/workflows/build.yml authority drift');
+  const promotionRehearsal = read(
+    path.join(root, 'docs/release-promotion-rehearsal.contract.json'),
+  );
+  validateBuildWorkflowAuthority(
+    buildWorkflow,
+    promotionRehearsal.buildchain.build_workflow_shell_sha,
+  );
   const promotionWorkflow = fs.readFileSync(
     path.join(root, '.github/workflows/release-new-version.yml'),
     'utf8',

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -129,7 +129,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:03b5888f87d83186d5553f414fee531e362550c7deff80bb242d8de6af67a1c8"
+          "sourceRoot": "sha256:5151741fcc3ff0d0741037d2d6b4003bac02a4d4562f3704d8a1a5c2bac0efe5"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",
@@ -867,5 +867,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:347ae9330f46c953a5de1cb27ee26c43486237adb46ea941720f0749b3f1c978"
+  "registryRoot": "sha256:ddeed0524db176c383b8eacabc7dac501f99802df96e5b53053c43e0bbd88bfa"
 }

--- a/scripts/alpha-macos-overflow.test.mjs
+++ b/scripts/alpha-macos-overflow.test.mjs
@@ -468,7 +468,7 @@ test('workflow contract keeps candidates exact-source, independent, and publish-
   );
   assert.match(
     workflow,
-    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@v3/u,
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@dbad2f383a6ab93abd192c4edefb4689c9eebc78/u,
   );
   assert.match(
     workflow,

--- a/scripts/kungfu-workflow-authority.mjs
+++ b/scripts/kungfu-workflow-authority.mjs
@@ -155,7 +155,7 @@ function immutableReference(reference) {
 }
 
 const BUILDCHAIN_V3_BUILD_ACTION =
-  'kungfu-systems/buildchain/.github/workflows/.build.yml@v3';
+  'kungfu-systems/buildchain/.github/workflows/.build.yml@dbad2f383a6ab93abd192c4edefb4689c9eebc78';
 const BUILDCHAIN_V3_PROMOTION_ACTION =
   'kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@v3';
 

--- a/scripts/release-promotion-rehearsal.mjs
+++ b/scripts/release-promotion-rehearsal.mjs
@@ -146,10 +146,10 @@ export function validateWorkflowSources(root, contract, overrides = {}) {
   requirePattern(
     build,
     new RegExp(
-      `uses: kungfu-systems/buildchain/\\.github/workflows/\\.build\\.yml@${contract.buildchain.workflow_shell_ref}`,
+      `uses: kungfu-systems/buildchain/\\.github/workflows/\\.build\\.yml@${contract.buildchain.build_workflow_shell_sha}`,
     ),
     findings,
-    'release-candidate build must consume the production v3 floating workflow contract',
+    'release-candidate build must consume the pinned native-finalization workflow contract',
   );
   requirePattern(
     build,

--- a/scripts/release-publication-control-plane.test.mjs
+++ b/scripts/release-publication-control-plane.test.mjs
@@ -8,6 +8,7 @@ import {
   discoverBuildchainReleaseWorkflows,
   inspectLive,
   status,
+  validateBuildWorkflowAuthority,
   validateExternalWorkflowInventory,
   validatePromotionWorkflowAuthority,
   validateRegistry,
@@ -42,6 +43,26 @@ test('checked registry closes workflows and invariants', () => {
   const v = get();
   assert.equal(validateRegistry(v), v);
   assert.equal(status(v).sourceAcceptance, 'passed');
+});
+test('build authority pins the workflow shell while retaining runtime routing', () => {
+  const source = fs.readFileSync('.github/workflows/build.yml', 'utf8');
+  const contract = JSON.parse(
+    fs.readFileSync('docs/release-promotion-rehearsal.contract.json', 'utf8'),
+  );
+  const shellSha = contract.buildchain.build_workflow_shell_sha;
+  assert.equal(validateBuildWorkflowAuthority(source, shellSha), true);
+  assert.throws(
+    () => validateBuildWorkflowAuthority(source, '0'.repeat(40)),
+    /authority drift/u,
+  );
+  assert.throws(
+    () =>
+      validateBuildWorkflowAuthority(
+        source.replace(`.build.yml@${shellSha}`, '.build.yml@v3'),
+        shellSha,
+      ),
+    /authority drift/u,
+  );
 });
 test('promotion authority separates floating release routing from exact recovery runtime', () => {
   const source = fs.readFileSync(

--- a/scripts/verify-alpha-release-cut-lock.test.mjs
+++ b/scripts/verify-alpha-release-cut-lock.test.mjs
@@ -51,7 +51,7 @@ test('Alpha.2 r17 lock verifies the exact Release Cut and fixed runtimes', () =>
   );
 });
 
-test('Alpha.2 r17 lock keeps Buildchain invocation floating', () => {
+test('Alpha.2 r17 keeps the runtime train while pinning the repaired workflow shell', () => {
   assert.equal(LOCK.buildchain.build.ref, 'v3');
   assert.equal(
     LOCK.buildchain.build.resolvedSha,
@@ -80,7 +80,7 @@ test('Alpha.2 r17 lock keeps Buildchain invocation floating', () => {
   );
   assert.match(
     build,
-    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@v3/u,
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@dbad2f383a6ab93abd192c4edefb4689c9eebc78/u,
   );
   assert.match(
     build,
@@ -90,7 +90,7 @@ test('Alpha.2 r17 lock keeps Buildchain invocation floating', () => {
     promotion,
     /buildchain-ref: \$\{\{ startsWith\(inputs\.target-ref \|\| github\.event\.pull_request\.base\.ref, 'alpha\/'\) && 'v3-alpha' \|\| 'v3' \}\}/u,
   );
-  assert.doesNotMatch(build, /\.github\/workflows\/\.build\.yml@[0-9a-f]{40}/u);
+  assert.match(build, /\.github\/workflows\/\.build\.yml@[0-9a-f]{40}/u);
 });
 
 test('candidate patrol verifies the frozen cut without settling from moving dev', () => {


### PR DESCRIPTION
The exact postmerge three-platform build proved that Developer ID signing and notarization succeed, but the fail-closed signed-runtime verifier was scheduled on Ubuntu and correctly refused to claim macOS execution. This PR pins the Buildchain workflow shell commit that routes macOS signing finalization to macos-15 while keeping the v3 runtime input boundary, then updates the audited workflow and release-promotion contracts.

Validation: full staged commit gate passed; focused workflow/release contract tests 42/42; release-promotion rehearsal 24/24; workflow authority and Kungfu Gate catalog passed.

No release, tag, or Alpha publication is performed.

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"Repair the signed macOS finalization runner route and synchronize its audited workflow contracts without changing an ADR contract."}
-->