### PR TITLE
test(ci): align preflight with pinned build shell

### DIFF
--- a/scripts/alpha-promotion-preflight.test.mjs
+++ b/scripts/alpha-promotion-preflight.test.mjs
@@ -588,9 +588,9 @@ test('patrol, normal Alpha builds and sentinels keep one controller authority', 
     build,
     /buildchain-ref: \$\{\{ inputs\.buildchain-ref \|\| 'v3' \}\}[\s\S]*publish-source-ref: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.releaseCutSourceRef \|\| '' \}\}[\s\S]*publish-anchor-request-json: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.releaseCutSourceRef && toJSON/u,
   );
-  assert.doesNotMatch(
+  assert.match(
     build,
-    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@[0-9a-f]{40}/u,
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@dbad2f383a6ab93abd192c4edefb4689c9eebc78/u,
   );
   const preBuild = build.slice(0, build.indexOf('\n  build:'));
   assert.doesNotMatch(


### PR DESCRIPTION
Align the Alpha preflight contract with the reviewed Buildchain workflow shell pinned by the signed macOS runtime finalization repair. The runtime buildchain-ref input remains on the v3 contract boundary.

Validation: alpha-promotion-preflight 18/18; related release contracts 52/52; full staged source gate passed.

No release, tag, or Alpha publication is performed.

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"Align the preflight test with the reviewed exact Buildchain workflow shell without changing an ADR contract."}
-->