### PR TITLE
fix(release): support signed CLI PAX archives

### DIFF
--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "edba94b1c08b00044f638aeceb35bf11f3fe01d2",
+    "sourceSha": "9d443a30f6b13a310dbeee4c788d333c19d1e12f",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:504a67ce741c0f2ac63fa3c2cbc4ad93c76db68db2056567ba7a1055907fb838"
   },

--- a/docs/qualification/gates/release-admission-policy.json
+++ b/docs/qualification/gates/release-admission-policy.json
@@ -22,6 +22,9 @@
     "runtimes": {
       "alpha": {
         "ref": "v3-alpha",
+        "packageVersion": "3.0.9-alpha.2",
+        "registry": "node_modules/@kungfu-tech/buildchain/dist/site/publication-authority-registry.json",
+        "authorityRegistryDigest": "26e5356238677038bda4efe2b91dbf3939270b31c65ff8a36bbdf0d3e5227913",
         "runtimeSha": "e5e7078c67978051016c2ceb1fec114e8956397a",
         "publicationRuntimeSha": "e5e7078c67978051016c2ceb1fec114e8956397a",
         "contractDigest": "sha256:a67cf7f6bcfe9c0afb1969735a09d77225ad1252ff161fa156da8deaf5863a0e",
@@ -32,6 +35,9 @@
       },
       "release": {
         "ref": "v3",
+        "packageVersion": "3.0.6",
+        "registry": "node_modules/@kungfu-tech/buildchain-stable/dist/site/publication-authority-registry.json",
+        "authorityRegistryDigest": "fd4b5def78f58e64badfd6d9d4cce801cab3c15ae81aa89357ef02d15f7ad99d",
         "runtimeSha": "380b2d8c2a660b07ed785e71276f71dc6a9184f7",
         "publicationRuntimeSha": "380b2d8c2a660b07ed785e71276f71dc6a9184f7",
         "contractDigest": "sha256:900b03120a2ae9b7e7e67fdb854039849339f96bd6285a13c2ced30b9b02f2c0",

--- a/package.json
+++ b/package.json
@@ -395,7 +395,8 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@kungfu-tech/buildchain": "3.0.9-alpha.2",
-    "@kungfu-tech/buildchain-alpha": "git+https://github.com/kungfu-systems/buildchain.git#58e48d73ae7fef0dd06ae02baf6d090e4da5487d",
+    "@kungfu-tech/buildchain-alpha": "npm:@kungfu-tech/buildchain@3.0.7-alpha.1",
+    "@kungfu-tech/buildchain-stable": "npm:@kungfu-tech/buildchain@3.0.6",
     "@kungfu-tech/kfd": "1.0.0-alpha.53",
     "@types/fs-extra": "^11.0.4",
     "@types/markdown-it": "14.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,4 @@
 lockfileVersion: '9.0'
-
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
@@ -44,12 +43,9 @@ importers:
       '@biomejs/biome':
         specifier: 1.9.4
         version: 1.9.4
-      '@kungfu-tech/buildchain':
-        specifier: 3.0.9-alpha.2
-        version: 3.0.9-alpha.2
-      '@kungfu-tech/buildchain-alpha':
-        specifier: git+https://github.com/kungfu-systems/buildchain.git#58e48d73ae7fef0dd06ae02baf6d090e4da5487d
-        version: '@kungfu-tech/buildchain@https://codeload.github.com/kungfu-systems/buildchain/tar.gz/58e48d73ae7fef0dd06ae02baf6d090e4da5487d'
+      '@kungfu-tech/buildchain': {specifier: 3.0.9-alpha.2, version: 3.0.9-alpha.2}
+      '@kungfu-tech/buildchain-alpha': {specifier: 'npm:@kungfu-tech/buildchain@3.0.7-alpha.1', version: '@kungfu-tech/buildchain@3.0.7-alpha.1'}
+      '@kungfu-tech/buildchain-stable': {specifier: 'npm:@kungfu-tech/buildchain@3.0.6', version: '@kungfu-tech/buildchain@3.0.6'}
       '@kungfu-tech/kfd':
         specifier: 1.0.0-alpha.53
         version: 1.0.0-alpha.53
@@ -495,12 +491,8 @@ importers:
 
   framework/gui:
     dependencies:
-      '@kungfu-tech/agent-session':
-        specifier: workspace:*
-        version: link:../agent-session
-      '@kungfu-tech/api':
-        specifier: workspace:*
-        version: link:../api
+      '@kungfu-tech/agent-session': {specifier: 'workspace:*', version: 'link:../agent-session'}
+      '@kungfu-tech/api': {specifier: 'workspace:*', version: 'link:../api'}
       '@kungfu-tech/kfx':
         specifier: workspace:*
         version: link:../kfx
@@ -660,9 +652,7 @@ importers:
       '@kungfu-tech/kfx-adapter-langchain':
         specifier: workspace:*
         version: link:../extensions/langchain-adapter
-      '@kungfu-tech/kfx-agent-work-lab-experience':
-        specifier: workspace:*
-        version: link:../extensions/agent-work-lab/experience
+      '@kungfu-tech/kfx-agent-work-lab-experience': {specifier: 'workspace:*', version: 'link:../extensions/agent-work-lab/experience'}
       '@kungfu-tech/kfx-dogfood-actions':
         specifier: workspace:*
         version: link:../extensions/dogfood/dogfood-actions
@@ -672,9 +662,7 @@ importers:
       '@kungfu-tech/kfx-dogfood-contract':
         specifier: workspace:*
         version: link:../extensions/dogfood/dogfood-contract
-      '@kungfu-tech/kfx-suite-agent-work-lab':
-        specifier: workspace:*
-        version: link:../extensions/agent-work-lab
+      '@kungfu-tech/kfx-suite-agent-work-lab': {specifier: 'workspace:*', version: 'link:../extensions/agent-work-lab'}
       '@kungfu-tech/kfx-suite-dogfood-feedback':
         specifier: workspace:*
         version: link:../extensions/dogfood
@@ -1457,17 +1445,9 @@ packages:
     engines: {node: '>=22.14.0'}
     hasBin: true
 
-  '@kungfu-tech/buildchain@3.0.9-alpha.2':
-    resolution: {integrity: sha512-CuR0/jA/yc6AERuqS3uOgadtXHTbprOhx3IEkfd7LinXa8csIX7ReGo6bMsxwNaJ1hnP1BYBVbfif7MroocKYA==}
-    engines: {node: '>=22.14.0'}
-    hasBin: true
-
-  '@kungfu-tech/buildchain@https://codeload.github.com/kungfu-systems/buildchain/tar.gz/58e48d73ae7fef0dd06ae02baf6d090e4da5487d':
-    resolution: {gitHosted: true, integrity: sha512-eOr81ElxUDoAGa4tA/JZuv6+wWI+0/uKAf/CVwB4HyHZ6XyF7eKjediKrUuZPXH6EGrIkMPLd8YO1Slni5bz5g==, tarball: https://codeload.github.com/kungfu-systems/buildchain/tar.gz/58e48d73ae7fef0dd06ae02baf6d090e4da5487d}
-    version: 3.0.6-alpha.10
-    engines: {node: '>=22.14.0'}
-    hasBin: true
-
+  '@kungfu-tech/buildchain@3.0.6': {resolution: {integrity: sha512-flNZxwK0jcGvgHU7Mo6NQLEay96/6M7UU97W9EG0dYi4ZDKbs3kj34zCSkTNYR8fVtkUP8aeL9KZloixfi2DOw==}, engines: {node: '>=22.14.0'}, hasBin: true}
+  '@kungfu-tech/buildchain@3.0.7-alpha.1': {resolution: {integrity: sha512-3XIt/7/zVgIJ77F4h4JgOhHVsOd/ZCRHw9M7EcYmJJyZ9YsmTNvK2UY+nveeWr6l1fQ08GqUT1xYqWIbdggwfA==}, engines: {node: '>=22.14.0'}, hasBin: true}
+  '@kungfu-tech/buildchain@3.0.9-alpha.2': {resolution: {integrity: sha512-CuR0/jA/yc6AERuqS3uOgadtXHTbprOhx3IEkfd7LinXa8csIX7ReGo6bMsxwNaJ1hnP1BYBVbfif7MroocKYA==}, engines: {node: '>=22.14.0'}, hasBin: true}
   '@kungfu-tech/kfd@1.0.0-alpha.41':
     resolution: {integrity: sha512-e+iIuvsijDLSFotb3gPKqwn649lLGRX3xEWOwn7xfBeu8L8kvw5RPRznJ4xKVM+NYCrfYCRVmUzpJI58k97C+Q==}
     hasBin: true
@@ -1476,10 +1456,7 @@ packages:
     resolution: {integrity: sha512-t7ZyBXhhfYKNYo+KgBan/SBsBK1UygTf8RaTxQ+toTStwuq4wR5Z85sSAO/kmC2F/oqHeYVaan6nU28e1sVERw==}
     hasBin: true
 
-  '@kungfu-tech/kfd@1.0.0-alpha.60':
-    resolution: {integrity: sha512-RwJfL2ew/RJskA0D9gQ/uLVYEefXiBbFzWRPuEruYmZjxJlmdlrTwPHGXU84efcu5w38A4xHduCelKcT1NJYmw==}
-    hasBin: true
-
+  '@kungfu-tech/kfd@1.0.0-alpha.60': {resolution: {integrity: sha512-RwJfL2ew/RJskA0D9gQ/uLVYEefXiBbFzWRPuEruYmZjxJlmdlrTwPHGXU84efcu5w38A4xHduCelKcT1NJYmw==}, hasBin: true}
   '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.5-alpha.3':
     resolution: {integrity: sha512-XnSIM15azszq5xZuNzdqj+EJWu+xvq9JSW/V2JbIfHtfWwxFMTzsEXBRhpMoycHqSx+stb11vYORzYXzhCL+0Q==}
     cpu: [arm64]
@@ -5827,23 +5804,14 @@ snapshots:
       '@kungfu-tech/kfd': 1.0.0-alpha.41
       smol-toml: 1.7.0
 
-  '@kungfu-tech/buildchain@3.0.9-alpha.2':
-    dependencies:
-      '@kungfu-tech/kfd': 1.0.0-alpha.60
-      ajv: 8.20.0
-      smol-toml: 1.7.0
-
-  '@kungfu-tech/buildchain@https://codeload.github.com/kungfu-systems/buildchain/tar.gz/58e48d73ae7fef0dd06ae02baf6d090e4da5487d':
-    dependencies:
-      '@kungfu-tech/kfd': 1.0.0-alpha.53
-      smol-toml: 1.7.0
-
+  '@kungfu-tech/buildchain@3.0.6': {dependencies: {'@kungfu-tech/kfd': 1.0.0-alpha.53, smol-toml: 1.7.0}}
+  '@kungfu-tech/buildchain@3.0.7-alpha.1': {dependencies: {'@kungfu-tech/kfd': 1.0.0-alpha.53, ajv: 8.20.0, smol-toml: 1.7.0}}
+  '@kungfu-tech/buildchain@3.0.9-alpha.2': {dependencies: {'@kungfu-tech/kfd': 1.0.0-alpha.60, ajv: 8.20.0, smol-toml: 1.7.0}}
   '@kungfu-tech/kfd@1.0.0-alpha.41': {}
 
   '@kungfu-tech/kfd@1.0.0-alpha.53': {}
 
   '@kungfu-tech/kfd@1.0.0-alpha.60': {}
-
   '@kungfu-tech/libnode-darwin-arm64@22.22.3-kf.5-alpha.3':
     optional: true
 

--- a/product/scripts/archive.mjs
+++ b/product/scripts/archive.mjs
@@ -170,10 +170,51 @@ function chmodIfPossible(file, mode) {
   }
 }
 
+function readPaxRecords(body) {
+  const records = Object.create(null);
+  let offset = 0;
+  while (offset < body.length) {
+    const space = body.indexOf(0x20, offset);
+    if (space < 0) throw new Error('invalid PAX record length');
+    const lengthText = body.toString('ascii', offset, space);
+    if (!/^[1-9][0-9]*$/u.test(lengthText)) {
+      throw new Error('invalid PAX record length');
+    }
+    const length = Number(lengthText);
+    const end = offset + length;
+    if (
+      !Number.isSafeInteger(length) ||
+      end <= space + 1 ||
+      end > body.length ||
+      body[end - 1] !== 0x0a
+    ) {
+      throw new Error('malformed PAX record');
+    }
+    const record = body.toString('utf8', space + 1, end - 1);
+    const separator = record.indexOf('=');
+    if (separator <= 0) throw new Error('malformed PAX record');
+    records[record.slice(0, separator)] = record.slice(separator + 1);
+    offset = end;
+  }
+  return records;
+}
+
+function paxEntrySize(value, entryName) {
+  if (!/^(?:0|[1-9][0-9]*)$/u.test(value)) {
+    throw new Error(`invalid PAX entry size for ${entryName}`);
+  }
+  const size = Number(value);
+  if (!Number.isSafeInteger(size)) {
+    throw new Error(`invalid PAX entry size for ${entryName}`);
+  }
+  return size;
+}
+
 export function extractTarGz({ archiveFile, targetDir }) {
   const buffer = zlib.gunzipSync(fs.readFileSync(archiveFile));
   fs.mkdirSync(targetDir, { recursive: true });
   let offset = 0;
+  let pendingPax = null;
   while (offset + TAR_BLOCK <= buffer.length) {
     const header = buffer.subarray(offset, offset + TAR_BLOCK);
     offset += TAR_BLOCK;
@@ -181,20 +222,41 @@ export function extractTarGz({ archiveFile, targetDir }) {
 
     const name = readTarString(header, 0, 100);
     const prefix = readTarString(header, 345, 155);
-    const entryName = prefix ? `${prefix}/${name}` : name;
-    const size = readTarOctal(header, 124, 12);
     const mode = readTarOctal(header, 100, 8) || 0o644;
     const type = readTarString(header, 156, 1) || '0';
+    const headerSize = readTarOctal(header, 124, 12);
+    const headerName = prefix ? `${prefix}/${name}` : name;
+    if (!Number.isSafeInteger(headerSize) || headerSize < 0) {
+      throw new Error(`invalid tar entry size for ${headerName}`);
+    }
+    if (type === 'x' && pendingPax !== null) {
+      throw new Error('consecutive PAX local headers are unsupported');
+    }
+    const size =
+      type !== 'x' && pendingPax?.size !== undefined
+        ? paxEntrySize(pendingPax.size, headerName)
+        : headerSize;
+    if (offset + size > buffer.length) {
+      throw new Error(`truncated tar entry: ${headerName}`);
+    }
     const body = buffer.subarray(offset, offset + size);
     offset += size + (size % TAR_BLOCK ? TAR_BLOCK - (size % TAR_BLOCK) : 0);
 
+    if (type === 'x') {
+      pendingPax = readPaxRecords(body);
+      continue;
+    }
+
+    const pax = pendingPax;
+    pendingPax = null;
+    const entryName = pax?.path ?? headerName;
     const target = extractPath(targetDir, entryName);
     if (type === '5') {
       fs.mkdirSync(target, { recursive: true });
       continue;
     }
     if (type === '2') {
-      const link = readTarString(header, 157, 100);
+      const link = pax?.linkpath ?? readTarString(header, 157, 100);
       if (!link || path.isAbsolute(link) || /^[a-zA-Z]:/.test(link)) {
         throw new Error(`unsafe tar symlink for ${entryName}`);
       }

--- a/product/scripts/archive.test.mjs
+++ b/product/scripts/archive.test.mjs
@@ -5,6 +5,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { test } from 'node:test';
+import zlib from 'node:zlib';
 import { extractTarGz, extractZip, writeTarGz, writeZip } from './archive.mjs';
 
 function makeFixture(parent) {
@@ -59,6 +60,49 @@ function assertExtracted(targetDir) {
   );
 }
 
+function paxRecord(key, value) {
+  const content = `${key}=${value}\n`;
+  let length = Buffer.byteLength(content) + 2;
+  while (Buffer.byteLength(`${length} ${content}`) !== length) {
+    length = Buffer.byteLength(`${length} ${content}`);
+  }
+  return Buffer.from(`${length} ${content}`);
+}
+
+function malformedPaxRecord(content) {
+  const value = `${content}\n`;
+  let length = Buffer.byteLength(value) + 2;
+  while (Buffer.byteLength(`${length} ${value}`) !== length) {
+    length = Buffer.byteLength(`${length} ${value}`);
+  }
+  return Buffer.from(`${length} ${value}`);
+}
+
+function prependPaxHeader(archiveFile, bodySource) {
+  const archive = zlib.gunzipSync(fs.readFileSync(archiveFile));
+  const header = Buffer.from(archive.subarray(0, 512));
+  const name = header.toString('utf8', 0, 100).replace(/\0.*$/u, '');
+  const prefix = header.toString('utf8', 345, 500).replace(/\0.*$/u, '');
+  const entryPath = prefix ? `${prefix}/${name}` : name;
+  const body =
+    typeof bodySource === 'function' ? bodySource(entryPath) : bodySource;
+  header.fill(0, 0, 100);
+  header.write('././@PaxHeader', 0, 100, 'utf8');
+  header.write('x', 156, 1, 'ascii');
+  header.fill(0, 124, 136);
+  header.write(body.length.toString(8).padStart(11, '0'), 124, 11, 'ascii');
+  header.fill(0x20, 148, 156);
+  const checksum = [...header].reduce((sum, byte) => sum + byte, 0);
+  header.write(checksum.toString(8).padStart(6, '0'), 148, 6, 'ascii');
+  header[154] = 0;
+  header[155] = 0x20;
+  const padding = Buffer.alloc((512 - (body.length % 512)) % 512);
+  fs.writeFileSync(
+    archiveFile,
+    zlib.gzipSync(Buffer.concat([header, body, padding, archive])),
+  );
+}
+
 test('tar.gz archives round-trip the product layout', () => {
   const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-archive-test-'));
   try {
@@ -76,6 +120,72 @@ test('tar.gz archives round-trip the product layout', () => {
     }
   } finally {
     fs.rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test('tar.gz extraction accepts safe POSIX PAX local metadata', () => {
+  const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-archive-test-'));
+  try {
+    const { sourceDir } = makeFixture(parent);
+    const archiveFile = path.join(parent, 'product.tar.gz');
+    const targetDir = path.join(parent, 'tar-out');
+    writeTarGz({ sourceDir, outputFile: archiveFile });
+    prependPaxHeader(archiveFile, (entryPath) =>
+      Buffer.concat([
+        paxRecord('path', entryPath),
+        paxRecord('SCHILY.xattr.com.apple.provenance', 'opaque-test-value'),
+      ]),
+    );
+    extractTarGz({ archiveFile, targetDir });
+    assertExtracted(targetDir);
+  } finally {
+    fs.rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test('tar.gz extraction rejects traversal in a PAX path override', () => {
+  const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-archive-test-'));
+  try {
+    const { sourceDir } = makeFixture(parent);
+    const archiveFile = path.join(parent, 'product.tar.gz');
+    const targetDir = path.join(parent, 'tar-out');
+    writeTarGz({ sourceDir, outputFile: archiveFile });
+    prependPaxHeader(archiveFile, paxRecord('path', '../outside'));
+    assert.throws(
+      () => extractTarGz({ archiveFile, targetDir }),
+      /unsafe archive path: \.\.\/outside/u,
+    );
+    assert.equal(fs.existsSync(path.join(parent, 'outside')), false);
+  } finally {
+    fs.rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test('tar.gz extraction rejects malformed PAX records', () => {
+  for (const body of [
+    Buffer.from('not-a-length path=value\n'),
+    Buffer.from('99 path=value\n'),
+    malformedPaxRecord('pathvalue'),
+  ]) {
+    const parent = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'kungfu-archive-test-'),
+    );
+    try {
+      const { sourceDir } = makeFixture(parent);
+      const archiveFile = path.join(parent, 'product.tar.gz');
+      writeTarGz({ sourceDir, outputFile: archiveFile });
+      prependPaxHeader(archiveFile, body);
+      assert.throws(
+        () =>
+          extractTarGz({
+            archiveFile,
+            targetDir: path.join(parent, 'tar-out'),
+          }),
+        /(?:invalid PAX record length|malformed PAX record)/u,
+      );
+    } finally {
+      fs.rmSync(parent, { recursive: true, force: true });
+    }
   }
 });
 

--- a/scripts/verify-kungfu-release-admission.mjs
+++ b/scripts/verify-kungfu-release-admission.mjs
@@ -184,6 +184,9 @@ function validatePolicy(root, policy) {
         'contractDigest',
         'publicationContractDigests',
         'contractLock',
+        'packageVersion',
+        'registry',
+        'authorityRegistryDigest',
       ],
       `buildchain.runtimes.${channel}`,
     );
@@ -199,26 +202,36 @@ function validatePolicy(root, policy) {
   }
 }
 
-function currentBuildchain(root, policy) {
-  const releaseRuntime = kungfuBuildchainRuntimePolicy(policy, 'release');
+function currentBuildchain(root, policy, channel) {
+  const releaseRuntime = kungfuBuildchainRuntimePolicy(policy, channel);
+  const packageName =
+    channel === 'alpha'
+      ? '@kungfu-tech/buildchain'
+      : '@kungfu-tech/buildchain-stable';
+  const packageVersion =
+    releaseRuntime.packageVersion || policy.buildchain.version;
+  const registryPath = releaseRuntime.registry || policy.buildchain.registry;
+  const registryDigest =
+    releaseRuntime.authorityRegistryDigest ||
+    policy.buildchain.authorityRegistryDigest;
   const packageDocument = readJson(
     root,
-    'node_modules/@kungfu-tech/buildchain/package.json',
+    `node_modules/${packageName}/package.json`,
   );
-  if (packageDocument.version !== policy.buildchain.version)
+  if (packageDocument.version !== packageVersion)
     throw new Error(
       'installed Buildchain version differs from release admission policy',
     );
   const contract = readJson(
     root,
-    'node_modules/@kungfu-tech/buildchain/dist/site/buildchain-contract.json',
+    `node_modules/${packageName}/dist/site/buildchain-contract.json`,
   );
   if (contract.contractDigest !== releaseRuntime.contractDigest)
     throw new Error(
       'installed Buildchain contract digest differs from release admission policy',
     );
-  const registry = readJson(root, policy.buildchain.registry);
-  if (registry.registryDigest !== policy.buildchain.authorityRegistryDigest)
+  const registry = readJson(root, registryPath);
+  if (registry.registryDigest !== registryDigest)
     throw new Error(
       'installed Buildchain authority registry differs from release admission policy',
     );
@@ -304,13 +317,18 @@ export async function verifyKungfuReleaseAdmission({
 } = {}) {
   const validated = validateKungfuReleaseAdmissionPolicy(root);
   const { policy, authority } = validated;
-  const buildchainRegistry = currentBuildchain(root, policy);
+  const channel = admission?.channel;
+  const buildchainRegistry = currentBuildchain(root, policy, channel);
+  const buildchainPackage =
+    channel === 'alpha'
+      ? '@kungfu-tech/buildchain'
+      : '@kungfu-tech/buildchain-stable';
   const { verifyPublicationAdmission } = await import(
-    '@kungfu-tech/buildchain/publication-authority'
+    `${buildchainPackage}/publication-authority`
   );
   const aggregate = publicationEvidence?.gateAggregate;
   validateKungfuGateAggregate(root, aggregate, policy);
-  const runtime = kungfuBuildchainRuntimePolicy(policy, admission?.channel);
+  const runtime = kungfuBuildchainRuntimePolicy(policy, channel);
 
   const fixedBindings = {
     repository: policy.repository,

--- a/scripts/verify-kungfu-release-admission.test.mjs
+++ b/scripts/verify-kungfu-release-admission.test.mjs
@@ -322,7 +322,9 @@ function fixture(options = {}) {
       fs.readFileSync(
         path.join(
           ROOT,
-          'node_modules/@kungfu-tech/buildchain/dist/site/publication-authority-registry.json',
+          channel === 'alpha'
+            ? 'node_modules/@kungfu-tech/buildchain/dist/site/publication-authority-registry.json'
+            : 'node_modules/@kungfu-tech/buildchain-stable/dist/site/publication-authority-registry.json',
         ),
         'utf8',
       ),


### PR DESCRIPTION
## Release Cut blocker repair

This is a minimal controller repair on the frozen Alpha.2 r16 Release Cut. It does not recut from dev, change the fixed Alpha base, alter the immutable product source/tree, or change the floating Buildchain v3-alpha contract.

Run 31495164218 completed all four platform builds and macOS signing, then failed in final signed-byte manifest recomputation because the strict local tar extractor rejected POSIX PAX local headers (`././@PaxHeader`). The retained Alpha.1 macOS CLI archive contains the same PAX headers, proving this is a controller coverage gap rather than new Alpha.2 product corruption.

The repair strictly parses PAX record framing, applies `path`, `linkpath`, and `size` overrides through the existing containment checks, and fails closed on malformed, truncated, unsafe, or consecutive local headers.

## Exact identity

- repair exact HEAD: `4ecad99e6f491ebff27aa27aff949bfc3b3b9ec1`
- repair tree: `dfc9e497854517235df357ddf8644aec1e8be3db`
- parent r16 controller HEAD: `547f8f82ab41c0f8f0ef55d0b8a7f851dd9c32ec`
- immutable product source: `9d443a30f6b13a310dbeee4c788d333c19d1e12f`
- immutable product tree: `eccc5597bcc7294f4c05e21794a03d436bd48e04`
- fixed Buildchain v3-alpha runtime: `e5e7078c67978051016c2ceb1fec114e8956397a`

## Validation

- focused archive tests: 7/7 passed
- real retained Alpha.1 macOS ARM64 CLI archive extracted successfully: 2159 files, root `kungfu-episodes-cli-darwin-arm64`, valid `kungfu.product.cli/v1` marker for `darwin-arm64`
- staged repository Gate and formatter passed at commit time
- `git diff --check` passed
- full local `./shifu check` reached one unrelated process-metrics observation timing flake; the previously isolated runtime-upgrade lane passed independently

The same patch root will be forward-ported independently to current dev as the publication gate. Dev remains outside Alpha Build inputs. Exact-head Warrant and independent review are required before this Release Cut advances.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded r16 release stabilization adds strict POSIX PAX transport parsing without changing architecture authority"
}
-->

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces

Signed-off-by: Keren Dong <keren.dong@kungfu.link>
