### PR TITLE
fix(release): forward-port signed CLI PAX support

### DIFF
--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.1",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.1",
-    "sourceSha": "1f08d5535488c490a49f85536817cdf865a104dd"
+    "sourceSha": "ae43bbf843c972a23abc8131fa98c25e29020818"
   },
   "claims": [
     {

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "1f08d5535488c490a49f85536817cdf865a104dd",
+    "sourceSha": "ae43bbf843c972a23abc8131fa98c25e29020818",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:5722db7858011aaaea6302535f795bb23015e4612eba472ce43c9722a5d950b6"
   },

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-        "sha256": "sha256:5ccc5f52e697a47f366a05c6cf1ba278fea2155f54ae7c1fc158a0aff73588d9"
+        "sha256": "sha256:21a4a15295148f3ef511918fda818af079944fac5a3614f04ad627f412ebddb0"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.1",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.1",
-    "sourceSha": "1f08d5535488c490a49f85536817cdf865a104dd"
+    "sourceSha": "ae43bbf843c972a23abc8131fa98c25e29020818"
   },
   "claims": [
     {

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:5ccc5f52e697a47f366a05c6cf1ba278fea2155f54ae7c1fc158a0aff73588d9"
+            "sha256": "sha256:21a4a15295148f3ef511918fda818af079944fac5a3614f04ad627f412ebddb0"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/product/scripts/archive.mjs
+++ b/product/scripts/archive.mjs
@@ -170,10 +170,51 @@ function chmodIfPossible(file, mode) {
   }
 }
 
+function readPaxRecords(body) {
+  const records = Object.create(null);
+  let offset = 0;
+  while (offset < body.length) {
+    const space = body.indexOf(0x20, offset);
+    if (space < 0) throw new Error('invalid PAX record length');
+    const lengthText = body.toString('ascii', offset, space);
+    if (!/^[1-9][0-9]*$/u.test(lengthText)) {
+      throw new Error('invalid PAX record length');
+    }
+    const length = Number(lengthText);
+    const end = offset + length;
+    if (
+      !Number.isSafeInteger(length) ||
+      end <= space + 1 ||
+      end > body.length ||
+      body[end - 1] !== 0x0a
+    ) {
+      throw new Error('malformed PAX record');
+    }
+    const record = body.toString('utf8', space + 1, end - 1);
+    const separator = record.indexOf('=');
+    if (separator <= 0) throw new Error('malformed PAX record');
+    records[record.slice(0, separator)] = record.slice(separator + 1);
+    offset = end;
+  }
+  return records;
+}
+
+function paxEntrySize(value, entryName) {
+  if (!/^(?:0|[1-9][0-9]*)$/u.test(value)) {
+    throw new Error(`invalid PAX entry size for ${entryName}`);
+  }
+  const size = Number(value);
+  if (!Number.isSafeInteger(size)) {
+    throw new Error(`invalid PAX entry size for ${entryName}`);
+  }
+  return size;
+}
+
 export function extractTarGz({ archiveFile, targetDir }) {
   const buffer = zlib.gunzipSync(fs.readFileSync(archiveFile));
   fs.mkdirSync(targetDir, { recursive: true });
   let offset = 0;
+  let pendingPax = null;
   while (offset + TAR_BLOCK <= buffer.length) {
     const header = buffer.subarray(offset, offset + TAR_BLOCK);
     offset += TAR_BLOCK;
@@ -181,20 +222,41 @@ export function extractTarGz({ archiveFile, targetDir }) {
 
     const name = readTarString(header, 0, 100);
     const prefix = readTarString(header, 345, 155);
-    const entryName = prefix ? `${prefix}/${name}` : name;
-    const size = readTarOctal(header, 124, 12);
     const mode = readTarOctal(header, 100, 8) || 0o644;
     const type = readTarString(header, 156, 1) || '0';
+    const headerSize = readTarOctal(header, 124, 12);
+    const headerName = prefix ? `${prefix}/${name}` : name;
+    if (!Number.isSafeInteger(headerSize) || headerSize < 0) {
+      throw new Error(`invalid tar entry size for ${headerName}`);
+    }
+    if (type === 'x' && pendingPax !== null) {
+      throw new Error('consecutive PAX local headers are unsupported');
+    }
+    const size =
+      type !== 'x' && pendingPax?.size !== undefined
+        ? paxEntrySize(pendingPax.size, headerName)
+        : headerSize;
+    if (offset + size > buffer.length) {
+      throw new Error(`truncated tar entry: ${headerName}`);
+    }
     const body = buffer.subarray(offset, offset + size);
     offset += size + (size % TAR_BLOCK ? TAR_BLOCK - (size % TAR_BLOCK) : 0);
 
+    if (type === 'x') {
+      pendingPax = readPaxRecords(body);
+      continue;
+    }
+
+    const pax = pendingPax;
+    pendingPax = null;
+    const entryName = pax?.path ?? headerName;
     const target = extractPath(targetDir, entryName);
     if (type === '5') {
       fs.mkdirSync(target, { recursive: true });
       continue;
     }
     if (type === '2') {
-      const link = readTarString(header, 157, 100);
+      const link = pax?.linkpath ?? readTarString(header, 157, 100);
       if (!link || path.isAbsolute(link) || /^[a-zA-Z]:/.test(link)) {
         throw new Error(`unsafe tar symlink for ${entryName}`);
       }

--- a/product/scripts/archive.test.mjs
+++ b/product/scripts/archive.test.mjs
@@ -5,6 +5,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { test } from 'node:test';
+import zlib from 'node:zlib';
 import { extractTarGz, extractZip, writeTarGz, writeZip } from './archive.mjs';
 
 function makeFixture(parent) {
@@ -59,6 +60,49 @@ function assertExtracted(targetDir) {
   );
 }
 
+function paxRecord(key, value) {
+  const content = `${key}=${value}\n`;
+  let length = Buffer.byteLength(content) + 2;
+  while (Buffer.byteLength(`${length} ${content}`) !== length) {
+    length = Buffer.byteLength(`${length} ${content}`);
+  }
+  return Buffer.from(`${length} ${content}`);
+}
+
+function malformedPaxRecord(content) {
+  const value = `${content}\n`;
+  let length = Buffer.byteLength(value) + 2;
+  while (Buffer.byteLength(`${length} ${value}`) !== length) {
+    length = Buffer.byteLength(`${length} ${value}`);
+  }
+  return Buffer.from(`${length} ${value}`);
+}
+
+function prependPaxHeader(archiveFile, bodySource) {
+  const archive = zlib.gunzipSync(fs.readFileSync(archiveFile));
+  const header = Buffer.from(archive.subarray(0, 512));
+  const name = header.toString('utf8', 0, 100).replace(/\0.*$/u, '');
+  const prefix = header.toString('utf8', 345, 500).replace(/\0.*$/u, '');
+  const entryPath = prefix ? `${prefix}/${name}` : name;
+  const body =
+    typeof bodySource === 'function' ? bodySource(entryPath) : bodySource;
+  header.fill(0, 0, 100);
+  header.write('././@PaxHeader', 0, 100, 'utf8');
+  header.write('x', 156, 1, 'ascii');
+  header.fill(0, 124, 136);
+  header.write(body.length.toString(8).padStart(11, '0'), 124, 11, 'ascii');
+  header.fill(0x20, 148, 156);
+  const checksum = [...header].reduce((sum, byte) => sum + byte, 0);
+  header.write(checksum.toString(8).padStart(6, '0'), 148, 6, 'ascii');
+  header[154] = 0;
+  header[155] = 0x20;
+  const padding = Buffer.alloc((512 - (body.length % 512)) % 512);
+  fs.writeFileSync(
+    archiveFile,
+    zlib.gzipSync(Buffer.concat([header, body, padding, archive])),
+  );
+}
+
 test('tar.gz archives round-trip the product layout', () => {
   const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-archive-test-'));
   try {
@@ -76,6 +120,72 @@ test('tar.gz archives round-trip the product layout', () => {
     }
   } finally {
     fs.rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test('tar.gz extraction accepts safe POSIX PAX local metadata', () => {
+  const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-archive-test-'));
+  try {
+    const { sourceDir } = makeFixture(parent);
+    const archiveFile = path.join(parent, 'product.tar.gz');
+    const targetDir = path.join(parent, 'tar-out');
+    writeTarGz({ sourceDir, outputFile: archiveFile });
+    prependPaxHeader(archiveFile, (entryPath) =>
+      Buffer.concat([
+        paxRecord('path', entryPath),
+        paxRecord('SCHILY.xattr.com.apple.provenance', 'opaque-test-value'),
+      ]),
+    );
+    extractTarGz({ archiveFile, targetDir });
+    assertExtracted(targetDir);
+  } finally {
+    fs.rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test('tar.gz extraction rejects traversal in a PAX path override', () => {
+  const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-archive-test-'));
+  try {
+    const { sourceDir } = makeFixture(parent);
+    const archiveFile = path.join(parent, 'product.tar.gz');
+    const targetDir = path.join(parent, 'tar-out');
+    writeTarGz({ sourceDir, outputFile: archiveFile });
+    prependPaxHeader(archiveFile, paxRecord('path', '../outside'));
+    assert.throws(
+      () => extractTarGz({ archiveFile, targetDir }),
+      /unsafe archive path: \.\.\/outside/u,
+    );
+    assert.equal(fs.existsSync(path.join(parent, 'outside')), false);
+  } finally {
+    fs.rmSync(parent, { recursive: true, force: true });
+  }
+});
+
+test('tar.gz extraction rejects malformed PAX records', () => {
+  for (const body of [
+    Buffer.from('not-a-length path=value\n'),
+    Buffer.from('99 path=value\n'),
+    malformedPaxRecord('pathvalue'),
+  ]) {
+    const parent = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'kungfu-archive-test-'),
+    );
+    try {
+      const { sourceDir } = makeFixture(parent);
+      const archiveFile = path.join(parent, 'product.tar.gz');
+      writeTarGz({ sourceDir, outputFile: archiveFile });
+      prependPaxHeader(archiveFile, body);
+      assert.throws(
+        () =>
+          extractTarGz({
+            archiveFile,
+            targetDir: path.join(parent, 'tar-out'),
+          }),
+        /(?:invalid PAX record length|malformed PAX record)/u,
+      );
+    } finally {
+      fs.rmSync(parent, { recursive: true, force: true });
+    }
   }
 });
 


### PR DESCRIPTION
## Summary

Forward-port the exact Alpha.2 r16 PAX transport repair to current `dev/v4/v4.0` as the mandatory publication gate.

- dev base: `67b6f6e992c7364e237682e788bc4b33b43d6ddd`
- dev exact head: `6a465dde40a11c20cdd13b60c91c3c5699187148`
- exact PAX repair commit on dev: `ae43bbf843c972a23abc8131fa98c25e29020818`
- r16 repair head: `4ecad99e6f491ebff27aa27aff949bfc3b3b9ec1`
- stable PAX patch-id on both lines: `4f42f50e39f1d3261413feb20b9951d0cfadfade`
- dev-only evidence alignment: `6a465dde40a11c20cdd13b60c91c3c5699187148`
- r16 protected delivery: #2993, independently approved and merged
- focused tests: 7/7 passed on dev; exact-head pre-commit gate passed

This PR does not recut Alpha.2, alter the frozen product source/tree, or provide any Alpha Build input. The native Assignment workspace remains the r16 Release Cut. Dev is a publication gate only.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This exact blocker-repair forward-port preserves the existing release transport architecture and changes no ADR record"
}
-->

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces

Signed-off-by: Keren Dong <keren.dong@kungfu.link>
