### PR TITLE
fix(ci): bind macOS burst validation train

### DIFF
--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.1",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.1",
-    "sourceSha": "05fd476ebc68a812399d9f5c2e595b1dab92d4fc"
+    "sourceSha": "734a311f345d0bd19a5e1aa14154b6f9350b99fa"
   },
   "claims": [
     {

--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.1",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.1",
-    "sourceSha": "734a311f345d0bd19a5e1aa14154b6f9350b99fa"
+    "sourceSha": "7f97ecb625e1c5e374ff392473da881dd40eac3b"
   },
   "claims": [
     {

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "05fd476ebc68a812399d9f5c2e595b1dab92d4fc",
+    "sourceSha": "734a311f345d0bd19a5e1aa14154b6f9350b99fa",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:5722db7858011aaaea6302535f795bb23015e4612eba472ce43c9722a5d950b6"
   },

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "734a311f345d0bd19a5e1aa14154b6f9350b99fa",
+    "sourceSha": "7f97ecb625e1c5e374ff392473da881dd40eac3b",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:5722db7858011aaaea6302535f795bb23015e4612eba472ce43c9722a5d950b6"
   },

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:90355f9d0434c113e1073bfac763253076f59faca0effa65e55c3e8a0c5cbc61"
+            "sha256": "sha256:c86dad04662437d4abb059c43735b4661cb9c9720f5bacf1405577c95220b5e0"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:c86dad04662437d4abb059c43735b4661cb9c9720f5bacf1405577c95220b5e0"
+            "sha256": "sha256:903e216aeb35813c21fa69b5ed1b45e3060d077685bd27510ccfd3394a40fb2b"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/.github/workflows/aws-us-macos-burst-qualification.yml
+++ b/.github/workflows/aws-us-macos-burst-qualification.yml
@@ -48,9 +48,9 @@ jobs:
           (inputs.mode == 'full' && inputs.qualification-id == 'mac-full-01')
         )
       }}
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@028383e592a8e942396c1792761ec66a4b0d6020
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v3
     with:
-      buildchain-ref: 028383e592a8e942396c1792761ec66a4b0d6020
+      buildchain-ref: train/v3/v3.0/aws-macos-burst-20260811
       runner-preset: aws-us-ec2-macos-jit
       aws-ec2-macos-runner-label: ${{ inputs.runner-label }}
       setup-rust: true

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.1",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.1",
-    "sourceSha": "05fd476ebc68a812399d9f5c2e595b1dab92d4fc"
+    "sourceSha": "734a311f345d0bd19a5e1aa14154b6f9350b99fa"
   },
   "claims": [
     {

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.1",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.1",
-    "sourceSha": "734a311f345d0bd19a5e1aa14154b6f9350b99fa"
+    "sourceSha": "7f97ecb625e1c5e374ff392473da881dd40eac3b"
   },
   "claims": [
     {

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:90355f9d0434c113e1073bfac763253076f59faca0effa65e55c3e8a0c5cbc61"
+            "sha256": "sha256:c86dad04662437d4abb059c43735b4661cb9c9720f5bacf1405577c95220b5e0"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:c86dad04662437d4abb059c43735b4661cb9c9720f5bacf1405577c95220b5e0"
+            "sha256": "sha256:903e216aeb35813c21fa69b5ed1b45e3060d077685bd27510ccfd3394a40fb2b"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/docs/qualification/gates/aws-burst-retirement.json
+++ b/docs/qualification/gates/aws-burst-retirement.json
@@ -4,7 +4,7 @@
   "owner": "kungfu-ci",
   "retiredAt": "2026-07-30",
   "reactivatedAt": "2026-07-30",
-  "reason": "The v2 callers were retired until the bounded Linux, Windows, and macOS providers landed in reviewed Buildchain v3 authority. Each active caller fixes both the reusable workflow shell and buildchain-ref to its immutable reviewed provider commit; the Windows caller additionally requires the persistent one-shot campaign ledger, exact campaign/source binding, and the USD 80 phase cap with a frozen spend baseline.",
+  "reason": "The v2 callers were retired until the bounded Linux, Windows, and macOS providers landed in reviewed Buildchain v3 authority. Linux and Windows fix the reusable workflow shell and buildchain-ref to immutable reviewed provider commits. The bounded macOS campaign uses the protected v3 shell with one named validation train whose exact head is retained below; the Windows caller additionally requires the persistent one-shot campaign ledger, exact campaign/source binding, and the USD 80 phase cap with a frozen spend baseline.",
   "runtimeSafety": {
     "workflowShellReferencesV2": false,
     "buildchainRefInputsV2": false,
@@ -29,6 +29,11 @@
     "macosAllocateHostsPreflightMergeCommit": "b27e567473b4faee97b920bbbccf08e8412620b6",
     "macosFailedSourceRebindPullRequest": 2587,
     "macosFailedSourceRebindMergeCommit": "028383e592a8e942396c1792761ec66a4b0d6020",
+    "macosHistoricalRebindPullRequest": 2599,
+    "macosHistoricalRebindMergeCommit": "1724840a37b2b80c9cd0c5d91a42b43ff8d270e4",
+    "macosValidationWorkflowShell": "v3",
+    "macosValidationTrain": "train/v3/v3.0/aws-macos-burst-20260811",
+    "macosValidationTrainHead": "6b39d6f72224a8b2fa93c1bb997ed72cbed6cdf4",
     "v3RequiredInputs": [
       "aws-codebuild-project",
       "aws-ec2-windows-runner-label",
@@ -64,7 +69,7 @@
   "historyPolicy": {
     "v2TrainRef": "retained-immutable-history",
     "priorRuns": "retained-immutable-history",
-    "currentWorkflowAuthority": "reviewed-v3-exact-sha"
+    "currentWorkflowAuthority": "reviewed-v3-exact-sha-except-bounded-macos-validation-train"
   },
   "reactivation": {
     "automatic": false,
@@ -74,7 +79,8 @@
     "requirementsSatisfied": [
       "Protected Assignment remains owned by kungfu-ci and Buildchain maintainers.",
       "Required runner presets and controller inputs landed in reviewed Buildchain v3.",
-      "Each reusable workflow shell and buildchain-ref pair is pinned to the same immutable reviewed v3 commit.",
+      "Linux and Windows reusable workflow shell and buildchain-ref pairs remain pinned to the same immutable reviewed v3 commit.",
+      "The macOS qualification caller alone uses the protected v3 shell with the named validation train and retained exact train head.",
       "Windows admission is one-shot, source-bound, permanently killable, and atomically capped before launch.",
       "Windows run title and runner label both bind campaign and qualification identity before launch.",
       "Bounded trust, label, non-publication, timeout, cancellation, and cleanup assertions are restored with targeted tests.",

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -264,9 +264,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:489f356bc337b9158a647edb774c4bcf29f197952ead58c7d470155712f2b9ff",
+          "definitionDigest": "sha256:b63e99818b70697a66f0569dfe74c8a2a733dd6aff3c2963b4ffcc970607d677",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@028383e592a8e942396c1792761ec66a4b0d6020"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@v3"],
           "steps": []
         }
       ]

--- a/framework/core/src/python/kungfu/cli/commands/run.py
+++ b/framework/core/src/python/kungfu/cli/commands/run.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-import os
 import re
 import sys
 from pathlib import Path
@@ -545,8 +544,8 @@ def _run_provider(
     from kungfu.cli.commands import assignment as work_commands
 
     try:
-        target = resolve_workspace_target(
-            "read-only", workspace_root or None, cwd=os.getcwd()
+        target, _launch_root, _resolution = native_launch.resolve_native_launch_target(
+            ctx, workspace_root
         )
     except WorkspaceTargetRequired as error:
         raise click.ClickException(

--- a/framework/core/tests/python/test_run_product_path.py
+++ b/framework/core/tests/python/test_run_product_path.py
@@ -13,7 +13,11 @@ from kungfu.agent import managed_run
 from kungfu.agent import native_launch
 from kungfu.agent import run_agent
 from kungfu.cli.commands import assignment, kfc, run
-from kungfu.workspace import resolve_workspace_target
+from kungfu.workspace import (
+    inspect_workspace,
+    resolve_workspace_target,
+    select_workspace,
+)
 
 
 @pytest.mark.parametrize("command", ["claim", "status", "gate"])
@@ -508,7 +512,9 @@ def test_successful_managed_work_start_completes_agent_onboarding(
         )
     )
     monkeypatch.setattr(
-        run, "resolve_workspace_target", lambda *_args, **_kwargs: target
+        native_launch,
+        "resolve_native_launch_target",
+        lambda *_args, **_kwargs: (target, str(project), "explicit-project"),
     )
     monkeypatch.setattr(
         run,
@@ -573,6 +579,80 @@ def test_successful_managed_work_start_completes_agent_onboarding(
             "runtime_home": str(tmp_path / "home"),
         }
     ]
+
+
+def test_managed_provider_plan_uses_selected_current_project_outside_it(
+    tmp_path, monkeypatch
+):
+    source = tmp_path / "outside"
+    project = tmp_path / "selected"
+    source.mkdir()
+    project.mkdir()
+    request = project / "request.json"
+    request.write_text("{}\n", encoding="utf-8")
+    config_home = tmp_path / "config"
+    runtime_home = tmp_path / "home"
+    environment = {
+        "HOME": str(tmp_path / "user"),
+        "KF_CONFIG_HOME": str(config_home),
+        "KF_HOME": str(runtime_home),
+    }
+    identity = inspect_workspace(str(project), env=environment)
+    assert identity is not None
+    select_workspace(identity, config_home=str(config_home), env=environment)
+    monkeypatch.chdir(source)
+    for name, value in environment.items():
+        monkeypatch.setenv(name, value)
+    for name in ("KF_WORKSPACE_ROOT", "KF_RUNTIME_DIR", "KUNGFU_WORKSPACE_ROOT"):
+        monkeypatch.delenv(name, raising=False)
+
+    selected_roots = []
+    monkeypatch.setattr(
+        run,
+        "_choose_work",
+        lambda root, **_kwargs: (
+            selected_roots.append(root)
+            or {
+                "requestPath": str(request),
+                "initiativeId": "project-work",
+                "assignmentId": "first",
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        run,
+        "_provider_profile",
+        lambda *_args, **_kwargs: {"id": "codex.test", "provider": "codex"},
+    )
+    monkeypatch.setattr(
+        assignment,
+        "_work_start_plan",
+        lambda **_kwargs: {
+            "planRoot": "sha256:" + "1" * 64,
+            "workspace": {"root": str(project)},
+            "work": {"assignmentId": "first", "title": "First Work"},
+            "agent": {
+                "label": "Codex",
+                "verification": {"version": "1.0.0"},
+            },
+            "effects": [],
+        },
+    )
+
+    run._run_provider(
+        SimpleNamespace(config_home=str(config_home), home=str(runtime_home)),
+        "codex",
+        None,
+        None,
+        None,
+        True,
+        True,
+        False,
+        None,
+        False,
+    )
+
+    assert selected_roots == [str(project)]
 
 
 def test_only_bare_provider_invocation_selects_native_interactive_mode():

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -111,7 +111,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:a1f8bc4b37b47b3fe9aefd397d8663b0f8ca5367a371a0b0d53449ec98c4ebfc"
+          "sourceRoot": "sha256:78c1e0f925b6284a784df8112abccea1aea9c3573b54245c9e483d9c76f30732"
         },
         {
           "path": ".github/workflows/aws-us-windows-burst-qualification.yml",
@@ -867,5 +867,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:e2eec6e2845c3246f09bc339e5ac8dd71dc4d9c0f48e6155608c90ad3e37feb9"
+  "registryRoot": "sha256:9c320d3c70a3a5c22c20a82ee2d3b5fbae0e60b7c56c029b329ed7f03f392707"
 }

--- a/scripts/buildchain-install.test.mjs
+++ b/scripts/buildchain-install.test.mjs
@@ -196,7 +196,7 @@ test('AWS CodeBuild qualification rejects static and release credentials', () =>
   }
 });
 
-test('reactivated AWS burst workflows pin reviewed immutable Buildchain v3 sources', () => {
+test('reactivated AWS burst workflows use reviewed bounded Buildchain v3 sources', () => {
   const retirement = JSON.parse(
     fs.readFileSync(
       path.join(
@@ -266,6 +266,20 @@ test('reactivated AWS burst workflows pin reviewed immutable Buildchain v3 sourc
     macosFailedSourceRebindSource,
     '028383e592a8e942396c1792761ec66a4b0d6020',
   );
+  assert.equal(retirement.evidence.macosHistoricalRebindPullRequest, 2599);
+  assert.equal(
+    retirement.evidence.macosHistoricalRebindMergeCommit,
+    '1724840a37b2b80c9cd0c5d91a42b43ff8d270e4',
+  );
+  assert.equal(retirement.evidence.macosValidationWorkflowShell, 'v3');
+  assert.equal(
+    retirement.evidence.macosValidationTrain,
+    'train/v3/v3.0/aws-macos-burst-20260811',
+  );
+  assert.equal(
+    retirement.evidence.macosValidationTrainHead,
+    '6b39d6f72224a8b2fa93c1bb997ed72cbed6cdf4',
+  );
 
   for (const name of [
     'aws-us-linux-burst-qualification.yml',
@@ -276,12 +290,16 @@ test('reactivated AWS burst workflows pin reviewed immutable Buildchain v3 sourc
       path.join(repositoryRoot, '.github/workflows', name),
       'utf8',
     );
-    const expectedBuildchainSource =
+    const expectedWorkflowShell =
       name === 'aws-us-windows-burst-qualification.yml'
         ? windowsUsd80PhaseCapSource
         : name === 'aws-us-macos-burst-qualification.yml'
-          ? macosFailedSourceRebindSource
+          ? retirement.evidence.macosValidationWorkflowShell
           : buildchainSource;
+    const expectedBuildchainSource =
+      name === 'aws-us-macos-burst-qualification.yml'
+        ? retirement.evidence.macosValidationTrain
+        : expectedWorkflowShell;
     assert.match(workflow, /workflow_dispatch:/);
     assert.doesNotMatch(workflow, /\n {2}pull_request:|\n {2}push:/);
     if (name === 'aws-us-windows-burst-qualification.yml') {
@@ -294,7 +312,7 @@ test('reactivated AWS burst workflows pin reviewed immutable Buildchain v3 sourc
     const shellPins =
       workflow.match(
         new RegExp(
-          `uses: kungfu-systems/buildchain/\\.github/workflows/\\.build\\.yml@${expectedBuildchainSource}`,
+          `uses: kungfu-systems/buildchain/\\.github/workflows/\\.build\\.yml@${expectedWorkflowShell}`,
           'g',
         ),
       ) || [];
@@ -305,6 +323,8 @@ test('reactivated AWS burst workflows pin reviewed immutable Buildchain v3 sourc
     assert.ok(shellPins.length >= 1);
     assert.equal(runtimePins.length, shellPins.length);
     assert.doesNotMatch(workflow, /train\/v2|buildchain-ref:\s*[\r\n]/);
+    if (name !== 'aws-us-macos-burst-qualification.yml')
+      assert.doesNotMatch(workflow, /train\/v3/);
     assert.doesNotMatch(
       workflow,
       /secrets:\s*inherit|notar|signing|npm-publish|release-new-version|deploy/,

--- a/scripts/kungfu-workflow-authority.mjs
+++ b/scripts/kungfu-workflow-authority.mjs
@@ -158,6 +158,8 @@ const BUILDCHAIN_V3_BUILD_ACTION =
   'kungfu-systems/buildchain/.github/workflows/.build.yml@dbad2f383a6ab93abd192c4edefb4689c9eebc78';
 const BUILDCHAIN_V3_PROMOTION_ACTION =
   'kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@v3';
+const BUILDCHAIN_V3_MACOS_BURST_ACTION =
+  'kungfu-systems/buildchain/.github/workflows/.build.yml@v3';
 
 function authorityReferenceAllowed(workflowPath, jobId, reference) {
   return (
@@ -167,7 +169,10 @@ function authorityReferenceAllowed(workflowPath, jobId, reference) {
       reference === BUILDCHAIN_V3_BUILD_ACTION) ||
     (workflowPath.endsWith('/release-new-version.yml') &&
       ['promote', 'recover'].includes(jobId) &&
-      reference === BUILDCHAIN_V3_PROMOTION_ACTION)
+      reference === BUILDCHAIN_V3_PROMOTION_ACTION) ||
+    (workflowPath.endsWith('/aws-us-macos-burst-qualification.yml') &&
+      jobId === 'qualify' &&
+      reference === BUILDCHAIN_V3_MACOS_BURST_ACTION)
   );
 }
 


### PR DESCRIPTION
## Summary

Bind the bounded macOS one-shot qualification caller to the protected Buildchain v3 workflow shell and the named validation train that contains the protected historical-rebind fixes. The workflow remains manual-only and disabled outside exact dispatch windows.

## Related issue

- Assignment: `2026-07-28-kungfu-aws-us-elastic-runner-burst-plane`

## Changes

- use the protected Buildchain `@v3` reusable-workflow shell for the macOS burst caller
- bind runtime execution to `train/v3/v3.0/aws-macos-burst-20260811` at retained head `6b39d6f72224a8b2fa93c1bb997ed72cbed6cdf4`
- keep the exception scoped to the single macOS qualification job and preserve immutable sources for every other caller
- refresh workflow authority, publication, and KFD projections

## Verification

- `./shifu check`
- `./shifu check:source`
- `./shifu xinfa:check`
- `./shifu xinfa:quality --check`
- `./shifu check:gate-catalog`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This operational fix changes only the bounded macOS qualification source binding; it does not alter product architecture or release authority."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The caller remains default-disabled, manual-only, one-job-at-a-time, and does not add signing, notarization, publication, or a second Host allocation path.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed