### PR TITLE
fix(product): isolate post-sign PTY child mode

### DIFF
--- a/product/scripts/finalize-signed-cli-qualification.test.mjs
+++ b/product/scripts/finalize-signed-cli-qualification.test.mjs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -14,6 +15,7 @@ import {
 import {
   bindSignedMacosRuntimeQualification,
   finalizeSignedCliQualification,
+  ptyDriverSource,
   signedMacosRuntimeReceiptRoot,
   verifyCodesignEntitlements,
 } from './verify-cli-surface-qualification.mjs';
@@ -32,6 +34,48 @@ const JIT_EXECUTABLES = [
   'kungfu-episodes-cli-darwin-arm64/runtime/python/bin/python3',
   'kungfu-episodes-cli-darwin-arm64/runtime/python/bin/python3.13',
 ];
+
+test('post-sign PTY driver does not leak embedded Node mode into the CLI', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-pty-driver-'));
+  try {
+    const fakeNodePty = path.join(root, 'node-pty.cjs');
+    fs.writeFileSync(
+      fakeNodePty,
+      [
+        'module.exports = {',
+        '  spawn(command, args, options) {',
+        "    const output = `KUNGFU_TUI_DEMO_COMPLETE variant=${Object.hasOwn(options.env, 'KUNGFU_AS_VARIANT')}`;",
+        '    return {',
+        '      onData(callback) { callback(output); },',
+        '      onExit(callback) { callback({exitCode: 0}); },',
+        '      kill() {},',
+        '    };',
+        '  },',
+        '};',
+      ].join('\n'),
+    );
+    const result = spawnSync(
+      process.execPath,
+      [
+        '-e',
+        ptyDriverSource(),
+        fakeNodePty,
+        '/fixture/kungfu',
+        JSON.stringify(['agent-work-lab', 'autoplay']),
+        'KUNGFU_TUI_DEMO_COMPLETE variant=false',
+        '1000',
+      ],
+      {
+        encoding: 'utf8',
+        env: { ...process.env, KUNGFU_AS_VARIANT: 'node' },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /KUNGFU_TUI_DEMO_COMPLETE variant=false/u);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
 
 function qualification() {
   const report = {

--- a/product/scripts/verify-cli-surface-qualification.mjs
+++ b/product/scripts/verify-cli-surface-qualification.mjs
@@ -508,7 +508,7 @@ function verifyCodexPlanWithoutCodex({
   };
 }
 
-function ptyDriverSource() {
+export function ptyDriverSource() {
   return [
     'const nodePty = require(process.argv[1]);',
     'const command = process.argv[2];',
@@ -516,10 +516,12 @@ function ptyDriverSource() {
     'const expected = process.argv[4];',
     'const timeoutMs = Number(process.argv[5]);',
     "let output = '';",
-    "const child = nodePty.spawn(command, args, {name: 'xterm-256color', cols: 120, rows: 40, cwd: process.cwd(), env: process.env});",
+    'const childEnv = {...process.env};',
+    'delete childEnv.KUNGFU_AS_VARIANT;',
+    "const child = nodePty.spawn(command, args, {name: 'xterm-256color', cols: 120, rows: 40, cwd: process.cwd(), env: childEnv});",
     'child.onData((data) => { output += data; if (output.length > 64 * 1024 * 1024) { child.kill(); process.exit(93); } });',
     'const timeout = setTimeout(() => { child.kill(); process.exit(94); }, timeoutMs);',
-    'child.onExit(({exitCode}) => { clearTimeout(timeout); if (exitCode !== 0) process.exit(95); if (!output.includes(expected)) process.exit(96); process.stdout.write(output); process.exit(0); });',
+    'child.onExit(({exitCode}) => { clearTimeout(timeout); if (exitCode !== 0) { process.stderr.write(output); process.exit(95); } if (!output.includes(expected)) { process.stderr.write(output); process.exit(96); } process.stdout.write(output); process.exit(0); });',
   ].join('');
 }
 


### PR DESCRIPTION
## Summary

Keep the post-sign macOS CLI PTY smoke fail-closed without leaking the embedded Node launch mode into the standalone CLI under test.

## Related issue

Follow-up to the three-platform installer and first-run contract repair.

## Changes

- remove `KUNGFU_AS_VARIANT` from the PTY child environment before launching the standalone CLI
- preserve bounded PTY output on child failure or missing completion evidence
- execute the generated PTY driver in a regression test that starts with the contaminating parent environment

## Verification

- `node --test product/scripts/finalize-signed-cli-qualification.test.mjs` (15/15 passed)
- `./node_modules/.bin/biome check product/scripts/verify-cli-surface-qualification.mjs product/scripts/finalize-signed-cli-qualification.test.mjs`
- repository staged gate passed during commit
- local macOS node-pty reproduction: inherited variant exited 1; sanitized child emitted `KUNGFU_TUI_DEMO_COMPLETE` and exited 0

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix corrects environment isolation in an existing post-sign qualification and does not alter an architecture contract"
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change affects only the post-sign runtime qualification driver; evidence remains fail-closed and now exposes bounded offline-smoke output when it fails.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable; qualification internals only)