### PR TITLE
fix(release): execute signed CLI starter plan

### DIFF
--- a/product/scripts/finalize-signed-cli-qualification.test.mjs
+++ b/product/scripts/finalize-signed-cli-qualification.test.mjs
@@ -381,6 +381,10 @@ test('post-sign Codex planning is credential-free and selects only the fixture p
   const source = fs.readFileSync(SCRIPT, 'utf8');
   assert.match(source, /!\['CODEX_HOME', 'OPENAI_API_KEY'\]\.includes\(key\)/u);
   assert.match(source, /agent\.defaultRuntimeProfile/u);
+  assert.match(
+    source,
+    /'starter-create',[\s\S]*?'--expected-plan-root',[\s\S]*?'--execute',[\s\S]*?'--json'/u,
+  );
   assert.match(source, /'run',[\s\S]*?'codex',[\s\S]*?'--plan'/u);
   assert.match(source, /realCodexRequired: false/u);
   assert.match(source, /providerCredentialsRead: false/u);

--- a/product/scripts/verify-cli-surface-qualification.mjs
+++ b/product/scripts/verify-cli-surface-qualification.mjs
@@ -482,6 +482,7 @@ function verifyCodexPlanWithoutCodex({
       projectPlan.planRoot,
       '--actor',
       'post-sign-smoke',
+      '--execute',
       '--json',
     ],
     { cwd: temporaryRoot, env },

--- a/scripts/run-core-affected-native.mjs
+++ b/scripts/run-core-affected-native.mjs
@@ -628,6 +628,7 @@ export function planFromChanged(
     '.github/workflows/affected-native-pr.yml',
     'framework/release/qualified-assignment-core-artifact.mjs',
     'framework/assignment-capture/qualified-assignment-core-consumer.mjs',
+    'product/scripts/verify-cli-surface-qualification.mjs',
     'scripts/check-shifu-cache-contract.mjs',
     'docs/shifu/artifact-contract.json',
     'docs/shifu/cache-contract.json',

--- a/scripts/run-core-affected-native.test.mjs
+++ b/scripts/run-core-affected-native.test.mjs
@@ -125,6 +125,7 @@ test('Qualified Core native consumer changes require the platform matrix', () =>
     'framework/agent-session/tests/runtime-port.native-peer.mjs',
     'framework/agent-session/tests/runtime-port.native.test.mjs',
     '.github/actions/qualified-core-candidate-build/action.yml',
+    'product/scripts/verify-cli-surface-qualification.mjs',
   ]) {
     const plan = planFromChanged(
       [file],


### PR DESCRIPTION
## Summary

Execute the reviewed Agent Work Starter mutation during the signed macOS CLI runtime smoke so finalization reaches the entitlement, Work Profile, PTY autoplay, and credential-free Codex plan checks.

## Related issue

Follow-up to the three-platform installer and first-run contract repair.

## Changes

- pass `--execute` to the post-sign `agent-work-lab starter-create` invocation
- pin that mutation boundary in the signed CLI qualification contract test

## Verification

- `./shifu test:cli-surface-qualification` (82/82 passed on the current dev base)
- repository staged gate passed during commit
- `./shifu check:source` reached all changed-surface gates; its full aggregate reported three unrelated infrastructure timeouts in disposable uv/cache and first-build fixtures

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix corrects execution of an already reviewed post-sign qualification plan and does not alter an architecture contract"
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change affects only signed artifact qualification. It does not publish or activate a release.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable; qualification internals only)
