### PR TITLE
fix(cli): handle dynamic commands in help

### DIFF
--- a/framework/core/src/python/kungfu/cli/commands/__init__.py
+++ b/framework/core/src/python/kungfu/cli/commands/__init__.py
@@ -72,14 +72,12 @@ class PrioritizedCommandGroup(click.Group):
     def list_commands_for_help(self, ctx):
         """reorder the list of commands when listing the help"""
         commands = super(PrioritizedCommandGroup, self).list_commands(ctx)
-        prioritized = filter(
-            lambda command: self.help_priorities[command] > 0, commands
-        )
         return (
             c[1]
             for c in sorted(
                 (self.help_priorities.get(command, self.DEFAULT_PRIORITY), command)
-                for command in prioritized
+                for command in commands
+                if self.help_priorities.get(command, self.DEFAULT_PRIORITY) > 0
             )
         )
 

--- a/framework/core/tests/python/test_work_authority_surface.py
+++ b/framework/core/tests/python/test_work_authority_surface.py
@@ -4,6 +4,8 @@ from datetime import UTC, datetime
 import importlib
 import json
 
+from click.testing import CliRunner
+
 from kungfu import assignment_close, assignment_evidence
 from kungfu.cli.commands import __registry__  # noqa: F401
 from kungfu.cli.commands import assignment_review
@@ -15,6 +17,13 @@ def test_click_tree_exposes_one_work_family_and_no_assignment_alias():
     assert "work" in kfc.commands
     assert "assignment" not in kfc.commands
     assert kfc.commands["work"].name == "work"
+
+
+def test_work_help_accepts_hidden_commands_added_without_a_priority():
+    result = CliRunner().invoke(kfc, ["work", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "runtime-host" not in result.output
 
 
 def test_work_family_contains_only_profile_backed_orchestration_commands():


### PR DESCRIPTION
## Summary

- use the declared default priority for dynamically registered CLI commands
- keep non-positive-priority commands hidden from normal help
- cover the real `kungfu work --help` surface

## Validation

- `./shifu test:work-authority`
- `./shifu test:cli-surface-contract`
- `./shifu check:source`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This focused CLI help-ordering bug fix does not alter an architecture contract or ADR record."
}
-->

## Governance risk check

- [x] none of the above

Signed-off-by: Keren Dong <keren.dong+cx@kungfu.link>

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA4LTEyLWt1bmdmdS13b3JrLWhlbHAtZHluYW1pYy1jb21tYW5kLXByaW9yaXR5IiwiZGVsaXZlcnlDbGFzcyI6Im5hdGl2ZS1wcm9vZi1yZXF1aXJlZCIsImRldkhlYWQiOiJiMDAxNzQwZmJkMGZmZjQ4ZTM3YTg2Yzc4NDk0NDMyYjIxM2JiMzJjIiwicHVsbFJlcXVlc3RIZWFkIjoiODhmNmNkZGVhZmMwOThhZDk0MWNiOTcyMDhkYTk5MWRlOGNiMzMxZSIsInJlcGxheWVkQ2FuZGlkYXRlIjoiMGNmYjcxY2RjMzllOGE5N2JlZmJiMWZlODA3OWI0YTFhZGExYjRkMiIsInJlcGxheWVkVHJlZSI6ImFlZGIyYmQxNGJmZWUwMmUwZGU3N2M2MzhlNWZhM2UyZTZlMzFlMmYiLCJxdWV1ZUF0dGVtcHQiOiI4OGY2Y2RkZWFmYzA5OGFkOTQxY2I5NzIwOGRhOTkxZGU4Y2IzMzFlQGIwMDE3NDBmYmQwZmZmNDhlMzdhODZjNzg0OTQ0MzJiMjEzYmIzMmMiLCJhZG1pc3Npb25Qcm9vZlJvb3QiOiJzaGEyNTY6MWU4Njg0OTJhOWQ3YWFiNDAzMTYxYjAzMDcwMDEwOTgzZTZiOWNiZmYzODE0MmMwZTNkZDZlM2IxNDhhZjkxNCIsImFkbWlzc2lvblByb29mUm9vdHMiOlsic2hhMjU2OjFlODY4NDkyYTlkN2FhYjQwMzE2MWIwMzA3MDAxMDk4M2U2YjljYmZmMzgxNDJjMGUzZGQ2ZTNiMTQ4YWY5MTQiLCJzaGEyNTY6OTM4MWQ4MTRmNzZkOTQ2ODhhYTUwN2FkZDA3MmRiNDY2NDBkM2MzMjI0NGEzMmIwMzJjODRkMWJmOWQ4YWIyZCJdLCJzdGF0dXNDb250ZXh0IjoiUXVldWUgZmFtaWx5IGxlYXNlL2Q5OWYzYTkxNjY3MzllMGQiLCJsZWFzZVJvb3QiOiJzaGEyNTY6MTM4Zjk4ZmJkMzEwOWVhNzRlOTAyMGZmYzY1NTAwOTZjNDZkYmRkNGJhMGRhZmYxMDBkYjYxNjBhM2RmN2VjYSJ9 -->