### PR TITLE
fix(dev-delivery): bootstrap Conan for Warrant SDK builds

### DIFF
--- a/framework/dev-delivery/native-under-warrant.mjs
+++ b/framework/dev-delivery/native-under-warrant.mjs
@@ -223,6 +223,7 @@ export async function runNativeUnderWarrant(options, dependencies = {}) {
       const cmakeJs = sdkPath(cwd);
       const sdkEnvironment = {
         ...toolchainEnvironment,
+        KUNGFU_BUILDCHAIN_SOURCE_BUILD: '1',
         PATH: cmakeJs ? `${cmakeJs}:${process.env.PATH}` : process.env.PATH,
       };
       execute('Build Core SDK artifacts', ['build:core:sdk'], sdkEnvironment);

--- a/scripts/dev-pr-auto-merge.test.mjs
+++ b/scripts/dev-pr-auto-merge.test.mjs
@@ -252,6 +252,30 @@ test('two-phase native adapter runs both partitions and seals exact-head success
   );
 });
 
+test('two-phase native adapter bootstraps Conan for SDK Warrant builds', async (t) => {
+  const commands = [];
+  const value = nativeFixture((_cwd, name, args, environment) =>
+    commands.push({ name, args, environment }),
+  );
+  value.dependencies.readPlan = () => ({
+    schema: 'kungfu.core-affected-native-plan/v1',
+    closureComponents: [],
+    sdkQualification: { required: true },
+    devQueueQualification: {
+      shifuWorkspace: { required: false },
+      kfdVerifier: { required: false },
+    },
+  });
+  t.after(() => fs.rmSync(value.cwd, { recursive: true, force: true }));
+
+  await runNativeUnderWarrant(value.options, value.dependencies);
+
+  const sdkBuild = commands.find(
+    ({ name }) => name === 'Build Core SDK artifacts',
+  );
+  assert.equal(sdkBuild.environment.KUNGFU_BUILDCHAIN_SOURCE_BUILD, '1');
+});
+
 test('two-phase native adapter fails closed and replaces pending with failure', async (t) => {
   const value = nativeFixture((_cwd, name) => {
     if (name.includes('partition 0')) throw new Error('native shard failed');


### PR DESCRIPTION
## Summary

- Bootstrap Conan profile discovery for the SDK build executed inside a Delivery Warrant.
- Reuse the existing source-build path so Warrant native proof behaves like the already-passing source qualification.
- Keep the repair limited to the Warrant SDK environment; no architecture or build authority changes.

## Related issue

Unblocks the Delivery Warrant qualification path currently blocking #3029 and #3041.

## Changes

- Set `KUNGFU_BUILDCHAIN_SOURCE_BUILD=1` for the Warrant SDK subprocess.
- Assert the exact environment contract in the focused dev-delivery test.

## Verification

- `node --test scripts/dev-pr-auto-merge.test.mjs`: 10/10 passed.
- `./shifu exec -- biome check framework/dev-delivery/native-under-warrant.mjs scripts/dev-pr-auto-merge.test.mjs`: passed.
- Full pre-commit gates passed, including Production Graph, latency/cache, invariant, docs/ADR, and staged Biome checks.
- The same environment repair already passed the real clean-runner SDK build in #3041 source run 31597886580 attempt 2.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This fix only bootstraps Conan profile discovery for the existing Warrant SDK subprocess and does not alter architecture or build authority"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Boundary: this changes only the environment used by independent Delivery Warrant native proof. Exact-head admission, source CI, focused tests, and the full pre-commit suite provide verification.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required; behavior is covered by the executable contract test)