### PR TITLE
fix(maintainability): close current-head terminal evidence review gaps

### DIFF
--- a/framework/maintainability/terminal-evidence-matrix.json
+++ b/framework/maintainability/terminal-evidence-matrix.json
@@ -1,10 +1,52 @@
 {
-  "schema": "kungfu.maintainability-terminal-evidence-matrix/v3",
-  "goalId": "2026-07-29-kungfu-terminal-review-remediation",
+  "schema": "kungfu.maintainability-terminal-evidence-matrix/v4",
+  "goalId": "2026-08-08-kungfu-terminal-review-freeze-and-evidence-closure-v4",
   "predecessor": {
     "assignmentId": "2026-07-27-kungfu-maintainability-terminal-closure",
     "sealedStateRoot": "sha256:41449544ae9f64f6a6e6e7ae69f24c0fd9049e38beef4bba2bbed3e3e730e98c"
   },
+  "dependencies": [
+    {
+      "requiredAssignmentId": "2026-08-03-kungfu-terminal-review-freeze-and-evidence-closure-v3",
+      "assignmentId": "2026-08-03-kungfu-terminal-review-freeze-and-evidence-closure-v3",
+      "sealedStateRoot": "sha256:c0050b4f3ef0bab9c24c3a07336684fc2ef381c2e6cc462930973c02a10d6f68"
+    },
+    {
+      "requiredAssignmentId": "2026-08-03-kungfu-repository-hotspot-convergence",
+      "assignmentId": "2026-08-03-kungfu-repository-hotspot-convergence-v3",
+      "sealedStateRoot": "sha256:4ea0bb938ea173b986699baaac47e5040ffefe16b9ea494438b21c15700057e5"
+    },
+    {
+      "requiredAssignmentId": "2026-08-03-kungfu-strict-length-budget-authorization",
+      "assignmentId": "2026-08-03-kungfu-strict-length-budget-authorization-v2",
+      "sealedStateRoot": "sha256:43388c983b1ef8b16c5837c988bb5270ecbafed965846cd8848fbd85b17d7f8f"
+    },
+    {
+      "requiredAssignmentId": "2026-08-03-kungfu-unregistered-fragmentation-census",
+      "assignmentId": "2026-08-03-kungfu-unregistered-fragmentation-census-v2",
+      "sealedStateRoot": "sha256:3f65cc9ab367b06b75cac939dc9b48a52b0c775695b45e93ccd8514f9f3340e5"
+    },
+    {
+      "requiredAssignmentId": "2026-08-01-kungfu-protected-source-terminal-closure",
+      "assignmentId": "2026-08-01-kungfu-protected-source-terminal-closure",
+      "sealedStateRoot": "sha256:c3bf0d1a86ad403d4d2ea93a54d0110d45c59d7776dc457479064fe889ff6afe"
+    },
+    {
+      "requiredAssignmentId": "2026-07-31-kungfu-pyinstaller-total-retirement",
+      "assignmentId": "2026-07-31-kungfu-pyinstaller-total-retirement",
+      "sealedStateRoot": "sha256:416f55e4cb51dd8bcddfa0987bc73db2cd25b3cc3ccb10b5a451468922cbe4f7"
+    },
+    {
+      "requiredAssignmentId": "2026-08-01-kungfu-python-kfx-asyncio-performance-qualification",
+      "assignmentId": "2026-08-01-kungfu-python-kfx-asyncio-performance-qualification",
+      "sealedStateRoot": "sha256:d7657d21cdf54ab8ea7215a9a46aae341c7ea00c07b6c4a27daaf99923ccd892"
+    },
+    {
+      "requiredAssignmentId": "2026-07-29-kungfu-terminal-review-remediation",
+      "assignmentId": "2026-07-29-kungfu-terminal-review-remediation",
+      "sealedStateRoot": "sha256:d61e9d23660f8c41d35b74c3441cd0301ea9e1f524d614db0592b0edbd1294d1"
+    }
+  ],
   "sourceBinding": {
     "repository": "kungfu-systems/kungfu",
     "protectedBranch": "dev/v4/v4.0",
@@ -20,8 +62,122 @@
       }
     ]
   },
+  "reconciliation": {
+    "scopeAuthority": "The retained native Assignment request supplies the exact parent, dependency identities, and review-baseline pull requests. Live GitHub enumeration of open pull requests against the protected base is filtered by those immutable Assignment families; the matrix cannot suppress an observed in-scope open pull request.",
+    "branchPolicy": "Closed remediation pull-request head refs are retained as immutable audit and recovery coordinates only. They carry no delivery or continuation authority after the declared disposition.",
+    "pullRequests": [
+      {
+        "number": 2485,
+        "state": "CLOSED",
+        "headRef": "feature/runtime-surface-provenance-contract-v4",
+        "head": "6510df9df3a57c44cd2979febd892d30abfd84e8",
+        "disposition": "superseded-by",
+        "successor": 2495,
+        "successorHeadRef": "feature/runtime-surface-provenance-contract-v5",
+        "successorHead": "1ca9818760a0f5c0154c8886f08ff0f803175e5a",
+        "successorTree": "70c5b0b4cd923e7c3fd9d52aa6689e3966533bcf",
+        "successorState": "CLOSED"
+      },
+      {
+        "number": 2495,
+        "state": "CLOSED",
+        "headRef": "feature/runtime-surface-provenance-contract-v5",
+        "head": "1ca9818760a0f5c0154c8886f08ff0f803175e5a",
+        "disposition": "superseded-by",
+        "successor": 2507,
+        "successorHeadRef": "feature/runtime-surface-provenance-contract-v6",
+        "successorHead": "b2499473358c824c306fbfce9282a9fb1cf658a8",
+        "successorTree": "d27b35f218d0a7ee9af1be59f2925596897387ca",
+        "successorState": "CLOSED"
+      },
+      {
+        "number": 2507,
+        "state": "CLOSED",
+        "headRef": "feature/runtime-surface-provenance-contract-v6",
+        "head": "b2499473358c824c306fbfce9282a9fb1cf658a8",
+        "disposition": "superseded-by",
+        "successor": 2519,
+        "successorHeadRef": "feature/runtime-surface-provenance-contract-v7",
+        "successorHead": "3ad296ea5d1a31bd84863409254201e239bd4b64",
+        "successorTree": "d27b35f218d0a7ee9af1be59f2925596897387ca",
+        "successorState": "MERGED",
+        "successorMergeCommit": "1fa379e07dc7197714b233f6227800e79a6b871f"
+      },
+      {
+        "number": 2519,
+        "state": "MERGED",
+        "headRef": "feature/runtime-surface-provenance-contract-v7",
+        "head": "3ad296ea5d1a31bd84863409254201e239bd4b64",
+        "mergeCommit": "1fa379e07dc7197714b233f6227800e79a6b871f",
+        "disposition": "delivered"
+      },
+      {
+        "number": 2235,
+        "state": "CLOSED",
+        "headRef": "fix/protected-source-terminal-closure-replay19",
+        "head": "975f4eb623de687a094f19ebd7376068a9c8cf17",
+        "disposition": "superseded-by",
+        "successor": 2246,
+        "successorHeadRef": "fix/protected-source-terminal-closure-replay20",
+        "successorHead": "5d08b59cd229ab3a2bf3aedc0160057a8eaaa58e",
+        "successorTree": "9100a451304f13dbc4152e9c4c6f0a8d448519b4",
+        "successorState": "CLOSED"
+      },
+      {
+        "number": 2212,
+        "state": "CLOSED",
+        "headRef": "fix/protected-source-terminal-closure-replay13",
+        "head": "cda9c30d68f043fd33fcf56d067c376e984fe469",
+        "disposition": "superseded-by",
+        "successor": 2235,
+        "successorHeadRef": "fix/protected-source-terminal-closure-replay19",
+        "successorHead": "975f4eb623de687a094f19ebd7376068a9c8cf17",
+        "successorTree": "c1c7576a15fa5333cdfab7d63b16375cf8d5ca73",
+        "successorState": "CLOSED"
+      },
+      {
+        "number": 2193,
+        "state": "CLOSED",
+        "headRef": "fix/protected-source-terminal-closure-replay7",
+        "head": "5193abee554b09ecbf5df9dbbb86218165e29cae",
+        "disposition": "superseded-by",
+        "successor": 2235,
+        "successorHeadRef": "fix/protected-source-terminal-closure-replay19",
+        "successorHead": "975f4eb623de687a094f19ebd7376068a9c8cf17",
+        "successorTree": "c1c7576a15fa5333cdfab7d63b16375cf8d5ca73",
+        "successorState": "CLOSED"
+      },
+      {
+        "number": 2173,
+        "state": "CLOSED",
+        "headRef": "fix/protected-source-terminal-closure-replay3",
+        "head": "1e28c3325b224e3c0dc42a1dd7f351b24f3d3610",
+        "disposition": "superseded-by",
+        "successor": 2235,
+        "successorHeadRef": "fix/protected-source-terminal-closure-replay19",
+        "successorHead": "975f4eb623de687a094f19ebd7376068a9c8cf17",
+        "successorTree": "c1c7576a15fa5333cdfab7d63b16375cf8d5ca73",
+        "successorState": "CLOSED"
+      },
+      {
+        "number": 2109,
+        "state": "CLOSED",
+        "headRef": "feature/python-kfx-asyncio-performance-qualification",
+        "head": "ca9a8f37ac2ba45e4ff46209d7c2e540b6bd4d88",
+        "disposition": "historical-nonmerge"
+      },
+      {
+        "number": 1997,
+        "state": "MERGED",
+        "headRef": "fix/pyinstaller-total-retirement",
+        "head": "9939bda59696587520c944e7b02edf8f2198c5db",
+        "mergeCommit": "a2967f22d0d23766eb887168e8fffc41251bad54",
+        "disposition": "delivered"
+      }
+    ]
+  },
   "terminalEvidence": {
-    "schema": "kungfu.maintainability-terminal-evidence/v3",
+    "schema": "kungfu.maintainability-terminal-evidence/v4",
     "verifier": "framework/maintainability/terminal-evidence.mjs",
     "runGroups": [
       {
@@ -119,7 +275,7 @@
         "macos-arm64",
         "windows-x64"
       ],
-      "reviewDisposition": "terminalEvidence.reviewRule"
+      "reviewDisposition": "terminalEvidence.terminalReviewRule"
     },
     {
       "assignmentId": "2026-07-26-kungfu-responsibility-hotspot-decomposition",
@@ -152,7 +308,7 @@
         "macos-arm64",
         "windows-x64"
       ],
-      "reviewDisposition": "terminalEvidence.reviewRule"
+      "reviewDisposition": "terminalEvidence.terminalReviewRule"
     },
     {
       "assignmentId": "2026-07-26-kungfu-linux-product-qualification",
@@ -180,7 +336,7 @@
       "productPlatforms": [
         "linux-x64"
       ],
-      "reviewDisposition": "terminalEvidence.reviewRule"
+      "reviewDisposition": "terminalEvidence.terminalReviewRule"
     },
     {
       "assignmentId": "2026-07-26-kungfu-windows-product-qualification",
@@ -208,7 +364,7 @@
       "productPlatforms": [
         "windows-x64"
       ],
-      "reviewDisposition": "terminalEvidence.reviewRule"
+      "reviewDisposition": "terminalEvidence.terminalReviewRule"
     },
     {
       "assignmentId": "2026-07-26-kungfu-dogfood-operational-hardening",
@@ -233,7 +389,7 @@
       "productPlatforms": [
         "macos-arm64"
       ],
-      "reviewDisposition": "independently approved at both listed prerequisite commits and rechecked by terminalEvidence.reviewRule"
+      "reviewDisposition": "independently approved at both listed prerequisite commits and rechecked by terminalEvidence.terminalReviewRule"
     },
     {
       "assignmentId": "2026-07-27-kungfu-complexity-gate-integrity",
@@ -261,7 +417,7 @@
         "macos-arm64",
         "windows-x64"
       ],
-      "reviewDisposition": "terminalEvidence.reviewRule"
+      "reviewDisposition": "terminalEvidence.terminalReviewRule"
     },
     {
       "assignmentId": "2026-07-27-kungfu-readonly-source-acceptance-closure",
@@ -290,7 +446,7 @@
         "macos-arm64",
         "windows-x64"
       ],
-      "reviewDisposition": "terminalEvidence.reviewRule"
+      "reviewDisposition": "terminalEvidence.terminalReviewRule"
     }
   ]
 }

--- a/framework/maintainability/terminal-evidence-matrix.test.mjs
+++ b/framework/maintainability/terminal-evidence-matrix.test.mjs
@@ -2,6 +2,7 @@
 
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -12,7 +13,11 @@ import {
   parseCommandJson,
   parseTerminalReviewAttestation,
 } from '../terminal-evidence/live-observations.mjs';
-import { digestBytes, verifyTerminalEvidence } from './terminal-evidence.mjs';
+import {
+  digestBytes,
+  resolveRetainedPath,
+  verifyTerminalEvidence,
+} from './terminal-evidence.mjs';
 
 const ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -154,7 +159,27 @@ function fixture() {
       policy: 'explicit-expiry-retain-bytes-v1',
     },
     source: { kind: 'atlas-go-card', sourceId: fixtureMatrix.goalId },
-    workDefinition: { goal_id: fixtureMatrix.goalId },
+    workDefinition: {
+      goal_id: fixtureMatrix.goalId,
+      parent_assignment_identity: {
+        assignment_id: fixtureMatrix.dependencies[0].requiredAssignmentId,
+      },
+      dependency_identities: fixtureMatrix.dependencies
+        .slice(1)
+        .map(({ requiredAssignmentId }) => ({
+          assignment_id: requiredAssignmentId,
+        })),
+      review_baseline: {
+        open_pull_requests_at_review: [
+          '#2235',
+          '#2212',
+          '#2193',
+          '#2173',
+          '#2109',
+          '#1997',
+        ],
+      },
+    },
   };
   const requestRoot = retain(
     'assignment-request',
@@ -235,13 +260,70 @@ function fixture() {
   decision.review_root = independentReviewRoot;
   const assignmentSeal = {
     schema: 'kungfu.assignment-orchestration.sealed-state/v1',
-    assignment: { assignment_id: fixtureMatrix.goalId },
+    assignment: {
+      assignment_id: fixtureMatrix.goalId,
+      request_root: requestRoot,
+      capture_receipt_roots: [captureReceiptRoot],
+    },
     phase: 'continuation-decided',
+    query_proof_root: `sha256:${'7'.repeat(64)}`,
+    counts: {
+      completion_claims: 1,
+      independent_reviews: 1,
+      continuation_decisions: 1,
+    },
   };
+  const dependencies = fixtureMatrix.dependencies.map((dependency, index) => {
+    const seal = {
+      schema: 'kungfu.assignment-orchestration.sealed-state/v1',
+      assignment: {
+        assignment_id: dependency.assignmentId,
+        request_root: `sha256:${String(index + 1)
+          .repeat(64)
+          .slice(0, 64)}`,
+        capture_receipt_roots: [
+          `sha256:${String(index + 2)
+            .repeat(64)
+            .slice(0, 64)}`,
+        ],
+      },
+      phase: 'continuation-decided',
+      query_proof_root: `sha256:${String(index + 3)
+        .repeat(64)
+        .slice(0, 64)}`,
+      counts: {
+        completion_claims: 1,
+        independent_reviews: 1,
+        continuation_decisions: 1,
+      },
+    };
+    const sealedStateRoot = retain(
+      `dependency-seal-${index}`,
+      seal,
+      'dependency-seal',
+    );
+    retainedObjects.at(-1).assignmentId = dependency.assignmentId;
+    dependency.sealedStateRoot = sealedStateRoot;
+    return {
+      requiredAssignmentId: dependency.requiredAssignmentId,
+      assignmentId: dependency.assignmentId,
+      sealedStateRoot,
+    };
+  });
   const predecessorSeal = {
     schema: 'kungfu.assignment-orchestration.sealed-state/v1',
-    assignment: { assignment_id: fixtureMatrix.predecessor.assignmentId },
+    assignment: {
+      assignment_id: fixtureMatrix.predecessor.assignmentId,
+      request_root: `sha256:${'8'.repeat(64)}`,
+      capture_receipt_roots: [`sha256:${'9'.repeat(64)}`],
+    },
     phase: 'continuation-decided',
+    query_proof_root: `sha256:${'6'.repeat(64)}`,
+    counts: {
+      completion_claims: 1,
+      independent_reviews: 1,
+      continuation_decisions: 1,
+    },
   };
   const evidence = {
     schema: fixtureMatrix.terminalEvidence.schema,
@@ -324,6 +406,7 @@ function fixture() {
         'assignment-seal',
       ),
     },
+    dependencies,
     predecessor: {
       assignmentId: fixtureMatrix.predecessor.assignmentId,
       sealedStateRoot: retain(
@@ -347,6 +430,8 @@ function fixture() {
         headTree: TREE,
         protectedCommit: HEAD,
         protectedTree: TREE,
+        protectedCommitEnd: HEAD,
+        protectedTreeEnd: TREE,
       },
       delivery: {
         pullRequest: 2001,
@@ -364,6 +449,30 @@ function fixture() {
           tree: TREE,
           submittedAt: '2026-08-02T00:00:00Z',
         },
+      },
+      reconciliation: {
+        declaredPulls: fixtureMatrix.reconciliation.pullRequests.map(
+          (pull) => ({
+            number: pull.number,
+            state: pull.state,
+            baseRef: fixtureMatrix.sourceBinding.protectedBranch,
+            headRef: pull.headRef,
+            head: pull.head,
+            mergeCommit: pull.mergeCommit || '',
+            ...(pull.successor
+              ? {
+                  successor: pull.successor,
+                  successorState: pull.successorState,
+                  successorBaseRef: fixtureMatrix.sourceBinding.protectedBranch,
+                  successorHeadRef: pull.successorHeadRef,
+                  successorHead: pull.successorHead,
+                  successorTree: pull.successorTree,
+                  successorMergeCommit: pull.successorMergeCommit || '',
+                }
+              : {}),
+          }),
+        ),
+        openProtectedPulls: [],
       },
       terminalReview: {
         commentId: 4001,
@@ -428,8 +537,18 @@ function fixture() {
         ...baseLive.assignment,
         ...(overrides.assignment || {}),
       },
+      reconciliation: overrides.reconciliation || baseLive.reconciliation,
       runs: overrides.runs || baseLive.runs,
     };
+    const nativeRoots = new Map(
+      evidence.retainedObjects
+        .filter(({ kind }) =>
+          ['assignment-seal', 'dependency-seal', 'predecessor-seal'].includes(
+            kind,
+          ),
+        )
+        .map(({ path: pathname, root }) => [pathname, root]),
+    );
     return verifyTerminalEvidence(
       fixtureMatrix,
       candidate,
@@ -439,9 +558,28 @@ function fixture() {
         if (!bytes) throw new Error(`missing fixture ${relative}`);
         return bytes;
       },
+      (relative) => {
+        const expectedRoot = nativeRoots.get(relative);
+        const bytes = retainedBytes.get(relative);
+        const actualRoot = bytes
+          ? semanticRoot(JSON.parse(bytes.toString('utf8')))
+          : undefined;
+        return {
+          ok: actualRoot === expectedRoot,
+          state_root: expectedRoot,
+          phase: 'continuation-decided',
+          next_actions: [],
+        };
+      },
     );
   };
-  return { evidence, liveRuns, retainedBytes, verify };
+  return {
+    evidence,
+    liveRuns,
+    matrix: fixtureMatrix,
+    retainedBytes,
+    verify,
+  };
 }
 
 function clone(value) {
@@ -466,6 +604,32 @@ test('live observation parser preserves object and array authority payloads', ()
     { schema: 'test', ok: true },
   );
   assert.equal(parseTerminalReviewAttestation('not json'), undefined);
+});
+
+test('portable retained paths stay inside the evidence archive', (context) => {
+  const archive = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-evidence-'));
+  const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-outside-'));
+  context.after(() => {
+    fs.rmSync(archive, { recursive: true });
+    fs.rmSync(outside, { recursive: true });
+  });
+  const retained = path.join(archive, 'seal.json');
+  const outsideSeal = path.join(outside, 'seal.json');
+  fs.writeFileSync(retained, '{}\n');
+  fs.writeFileSync(outsideSeal, '{}\n');
+  fs.symlinkSync(outsideSeal, path.join(archive, 'escaped.json'));
+  assert.equal(
+    resolveRetainedPath(archive, 'seal.json'),
+    fs.realpathSync(retained),
+  );
+  assert.throws(
+    () => resolveRetainedPath(archive, '../seal.json'),
+    /ENOENT|escapes/u,
+  );
+  assert.throws(
+    () => resolveRetainedPath(archive, 'escaped.json'),
+    /escapes the evidence archive/u,
+  );
 });
 
 test('live run observation binds run and jobs to the declared attempt', () => {
@@ -515,20 +679,45 @@ test('live run observation binds run and jobs to the declared attempt', () => {
   );
 });
 
-test('terminal maintainability matrix declares an exact-head v3 contract', () => {
+test('terminal maintainability matrix declares an exact-head v4 contract', () => {
   assert.equal(
     matrix.schema,
-    'kungfu.maintainability-terminal-evidence-matrix/v3',
+    'kungfu.maintainability-terminal-evidence-matrix/v4',
   );
   assert.equal(matrix.sourceBinding.repository, 'kungfu-systems/kungfu');
   assert.equal(matrix.sourceBinding.protectedBranch, 'dev/v4/v4.0');
   assert.equal(
     matrix.terminalEvidence.schema,
-    'kungfu.maintainability-terminal-evidence/v3',
+    'kungfu.maintainability-terminal-evidence/v4',
   );
   assert.equal(repositoryPathExists(matrix.terminalEvidence.verifier), true);
   assert.match(matrix.sourceBinding.exactHeadRule, /reads Git HEAD/u);
   assert.deepEqual(matrix.exceptions, []);
+  assert.equal(matrix.dependencies.length, 8);
+  assert.match(matrix.reconciliation.branchPolicy, /audit and recovery/u);
+  assert.equal(matrix.reconciliation.pullRequests.length, 10);
+  assert.equal(
+    new Set(matrix.reconciliation.pullRequests.map(({ number }) => number))
+      .size,
+    10,
+  );
+  assert.equal(
+    new Set(matrix.dependencies.map(({ assignmentId }) => assignmentId)).size,
+    8,
+  );
+  assert.equal(
+    new Set(
+      matrix.dependencies.map(
+        ({ requiredAssignmentId }) => requiredAssignmentId,
+      ),
+    ).size,
+    8,
+  );
+  assert.equal(
+    new Set(matrix.dependencies.map(({ sealedStateRoot }) => sealedStateRoot))
+      .size,
+    8,
+  );
   for (const group of matrix.terminalEvidence.runGroups) {
     assert.equal(repositoryPathExists(group.workflowPath), true, group.role);
     assert.ok(group.requiredJobs.length > 0, group.role);
@@ -638,6 +827,37 @@ test('live HEAD, protected PR, merge, and review identities fail closed', () => 
       }),
     ).has('assignment-seal-query-proof-mismatch'),
   );
+  assert.ok(
+    issueCodes(
+      verify(evidence, { source: { protectedCommitEnd: OTHER_HEAD } }),
+    ).has('protected-head-toctou'),
+  );
+});
+
+test('missing v4 sets and request-authority substitution fail closed', () => {
+  const { evidence, matrix: fixtureMatrix, verify } = fixture();
+  const omitted = clone(evidence);
+  omitted.dependencies = undefined;
+  const omittedCodes = issueCodes(
+    verify(omitted, { reconciliation: { openProtectedPulls: [] } }),
+  );
+  assert.ok(omittedCodes.has('required-v4-field-missing'));
+  assert.ok(omittedCodes.has('reconciliation-set-missing'));
+
+  fixtureMatrix.dependencies = undefined;
+  assert.ok(issueCodes(verify(evidence)).has('required-v4-field-missing'));
+
+  const replacement = fixture();
+  const alternate = '2026-08-08-kungfu-unrelated-terminal-assignment';
+  replacement.matrix.dependencies[1].requiredAssignmentId = alternate;
+  replacement.matrix.dependencies[1].assignmentId = alternate;
+  replacement.evidence.dependencies[1].requiredAssignmentId = alternate;
+  replacement.evidence.dependencies[1].assignmentId = alternate;
+  assert.ok(
+    issueCodes(replacement.verify(replacement.evidence)).has(
+      'dependency-authority-set-mismatch',
+    ),
+  );
 });
 
 test('retained semantic roles, live runs, and artifact bytes fail closed', () => {
@@ -716,7 +936,7 @@ test('self-consistent declared runs cannot replace GitHub live truth', () => {
   );
   assert.ok(
     issueCodes(verify(wrongAttempt)).has('run-runAttempt-live-mismatch'),
-    'positive, retained, internally consistent attempt must still match live API',
+    'retained attempt identity must still match the live attempt endpoint',
   );
 
   const missingJob = clone(liveRuns);
@@ -740,5 +960,138 @@ test('self-consistent declared runs cannot replace GitHub live truth', () => {
   expired.find(({ role }) => role === 'product').artifacts[0].expired = true;
   assert.ok(
     issueCodes(verify(evidence, { runs: expired })).has('artifact-expired'),
+  );
+});
+
+test('dependency omission, rerooting, and non-terminal seals fail closed', () => {
+  const { evidence, retainedBytes, verify } = fixture();
+
+  const omitted = clone(evidence);
+  omitted.dependencies.pop();
+  assert.ok(issueCodes(verify(omitted)).has('missing-dependency'));
+  assert.ok(issueCodes(verify(omitted)).has('dependency-cardinality-mismatch'));
+
+  const rerooted = clone(evidence);
+  rerooted.dependencies[0].sealedStateRoot = `sha256:${'8'.repeat(64)}`;
+  assert.ok(
+    issueCodes(verify(rerooted)).has('dependency-sealedStateRoot-mismatch'),
+  );
+
+  const dependency = evidence.dependencies[0];
+  const retained = evidence.retainedObjects.find(
+    ({ root }) => root === dependency.sealedStateRoot,
+  );
+  const document = JSON.parse(
+    retainedBytes.get(retained.path).toString('utf8'),
+  );
+  document.phase = 'stage-ready';
+  retainedBytes.set(
+    retained.path,
+    Buffer.from(`${JSON.stringify(document)}\n`),
+  );
+  const codes = issueCodes(verify(evidence));
+  assert.ok(codes.has('retained-root-mismatch'));
+  assert.ok(codes.has('retained-seal-not-terminal'));
+
+  const forgedFixture = fixture();
+  const forged = clone(forgedFixture.evidence);
+  const forgedDependency = forged.dependencies[0];
+  const forgedRetained = forged.retainedObjects.find(
+    ({ root }) => root === forgedDependency.sealedStateRoot,
+  );
+  const forgedDocument = JSON.parse(
+    forgedFixture.retainedBytes.get(forgedRetained.path).toString('utf8'),
+  );
+  forgedDocument.assignment.objective = 'self-described replacement';
+  const forgedRoot = semanticRoot(forgedDocument);
+  forgedFixture.retainedBytes.set(
+    forgedRetained.path,
+    Buffer.from(`${JSON.stringify(forgedDocument)}\n`),
+  );
+  forgedRetained.root = forgedRoot;
+  forgedDependency.sealedStateRoot = forgedRoot;
+  forgedFixture.matrix.dependencies[0].sealedStateRoot = forgedRoot;
+  const forgedCodes = issueCodes(forgedFixture.verify(forged));
+  assert.ok(forgedCodes.has('retained-seal-native-root-mismatch'));
+  assert.ok(forgedCodes.has('retained-seal-native-verification-failed'));
+});
+
+test('remediation pull-request state and exact head drift fail closed', () => {
+  const { evidence, verify } = fixture();
+  const observed = {
+    declaredPulls: matrix.reconciliation.pullRequests.map((pull) => ({
+      number: pull.number,
+      state: pull.state,
+      baseRef: matrix.sourceBinding.protectedBranch,
+      headRef: pull.headRef,
+      head: pull.head,
+      mergeCommit: pull.mergeCommit || '',
+      ...(pull.successor
+        ? {
+            successor: pull.successor,
+            successorState: pull.successorState,
+            successorBaseRef: matrix.sourceBinding.protectedBranch,
+            successorHeadRef: pull.successorHeadRef,
+            successorHead: pull.successorHead,
+            successorTree: pull.successorTree,
+            successorMergeCommit: pull.successorMergeCommit || '',
+          }
+        : {}),
+    })),
+    openProtectedPulls: [],
+  };
+
+  const reopened = clone(observed);
+  reopened.declaredPulls[0].state = 'OPEN';
+  assert.ok(
+    issueCodes(verify(evidence, { reconciliation: reopened })).has(
+      'reconciliation-pr-state-mismatch',
+    ),
+  );
+
+  const moved = clone(observed);
+  moved.declaredPulls[1].head = OTHER_HEAD;
+  assert.ok(
+    issueCodes(verify(evidence, { reconciliation: moved })).has(
+      'reconciliation-pr-head-mismatch',
+    ),
+  );
+
+  const omitted = clone(observed);
+  omitted.declaredPulls.pop();
+  const codes = issueCodes(verify(evidence, { reconciliation: omitted }));
+  assert.ok(codes.has('missing-reconciliation-pr'));
+  assert.ok(codes.has('reconciliation-pr-cardinality-mismatch'));
+
+  const liveSuccessor = clone(observed);
+  liveSuccessor.declaredPulls[0].successorState = 'OPEN';
+  assert.ok(
+    issueCodes(verify(evidence, { reconciliation: liveSuccessor })).has(
+      'reconciliation-successor-not-terminal',
+    ),
+  );
+
+  const movedSuccessor = clone(observed);
+  movedSuccessor.declaredPulls[0].successorHead = OTHER_HEAD;
+  assert.ok(
+    issueCodes(verify(evidence, { reconciliation: movedSuccessor })).has(
+      'reconciliation-successorHead-mismatch',
+    ),
+  );
+
+  const unlistedOpen = clone(observed);
+  unlistedOpen.openProtectedPulls.push({
+    number: 9999,
+    state: 'OPEN',
+    baseRef: matrix.sourceBinding.protectedBranch,
+    headRef: 'fix/terminal-review-unlisted',
+    head: OTHER_HEAD,
+    headTree: TREE,
+    title: 'unlisted remediation',
+  });
+  assert.ok(
+    issueCodes(verify(evidence, { reconciliation: unlistedOpen })).has(
+      'reconciliation-in-scope-pr-open',
+    ),
   );
 });

--- a/framework/maintainability/terminal-evidence-matrix.test.mjs
+++ b/framework/maintainability/terminal-evidence-matrix.test.mjs
@@ -164,11 +164,14 @@ function fixture() {
       parent_assignment_identity: {
         assignment_id: fixtureMatrix.dependencies[0].requiredAssignmentId,
       },
-      dependency_identities: fixtureMatrix.dependencies
-        .slice(1)
-        .map(({ requiredAssignmentId }) => ({
+      // The retained v4 request repeats its parent in dependency_identities.
+      // Authority comparison is set-based, so this must not invent a ninth
+      // dependency or reject the one exact parent/dependency identity.
+      dependency_identities: fixtureMatrix.dependencies.map(
+        ({ requiredAssignmentId }) => ({
           assignment_id: requiredAssignmentId,
-        })),
+        }),
+      ),
       review_baseline: {
         open_pull_requests_at_review: [
           '#2235',

--- a/framework/maintainability/terminal-evidence.mjs
+++ b/framework/maintainability/terminal-evidence.mjs
@@ -639,7 +639,7 @@ function verifyDependencyAuthority(
     'duplicate-evidence-dependency-seal',
     issues,
   );
-  const authoritySet = [...requestIdentities].sort();
+  const authoritySet = [...new Set(requestIdentities)].sort();
   const matrixAuthoritySet = matrixDependencies
     .map(({ requiredAssignmentId }) => requiredAssignmentId)
     .sort();

--- a/framework/maintainability/terminal-evidence.mjs
+++ b/framework/maintainability/terminal-evidence.mjs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // @ts-check
 
+import { spawnSync } from 'node:child_process';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -12,6 +13,7 @@ import { semanticRoot } from '../project-cut/src/project-cut.mjs';
 import { collectTerminalLiveObservations } from '../terminal-evidence/live-observations.mjs';
 import {
   verifyLiveAssignment,
+  verifyLiveReconciliation,
   verifyLiveRuns,
 } from '../terminal-evidence/live-verification.mjs';
 import {
@@ -27,6 +29,81 @@ const ROOT = path.resolve(
 );
 const MATRIX_PATH = 'framework/maintainability/terminal-evidence-matrix.json';
 const SHA = /^[0-9a-f]{40}$/u;
+const ROOT_PATTERN = /^sha256:[0-9a-f]{64}$/u;
+const EXECUTABLE_INPUTS = [
+  MATRIX_PATH,
+  'framework/maintainability/terminal-evidence.mjs',
+  'framework/terminal-evidence/live-observations.mjs',
+  'framework/terminal-evidence/live-verification.mjs',
+  'framework/terminal-evidence/verification-primitives.mjs',
+];
+
+function command(program, args, cwd = ROOT) {
+  const result = spawnSync(program, args, {
+    cwd,
+    encoding: 'utf8',
+    shell: false,
+    env: process.env,
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `${program} ${args.join(' ')} failed: ${(
+        result.stderr || result.stdout || ''
+      ).trim()}`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+function terminalJson(output, label) {
+  const starts = [...output.matchAll(/(?:^|\n)\s*([\[{])/gu)];
+  for (const match of starts.reverse()) {
+    const start = (match.index || 0) + match[0].lastIndexOf(match[1]);
+    try {
+      return JSON.parse(output.slice(start).trim());
+    } catch {
+      // Earlier command output may contain bracketed log prefixes.
+    }
+  }
+  throw new Error(`${label} did not return terminal JSON`);
+}
+
+function assertHeadBoundInputs() {
+  const diff = spawnSync(
+    'git',
+    ['diff', '--quiet', 'HEAD', '--', ...EXECUTABLE_INPUTS],
+    { cwd: ROOT, shell: false },
+  );
+  if (diff.status !== 0) {
+    throw new Error('terminal evidence executable inputs differ from HEAD');
+  }
+  for (const relative of EXECUTABLE_INPUTS) {
+    const headBytes = command('git', ['show', `HEAD:${relative}`]);
+    const worktreeBytes = fs
+      .readFileSync(path.join(ROOT, relative), 'utf8')
+      .trimEnd();
+    if (headBytes !== worktreeBytes) {
+      throw new Error(`${relative} is not byte-bound to HEAD`);
+    }
+  }
+}
+
+function resolveRetainedPath(base, relative) {
+  if (typeof relative !== 'string' || path.isAbsolute(relative)) {
+    throw new Error('retained object path must be archive-relative');
+  }
+  const canonicalBase = fs.realpathSync(base);
+  const candidate = path.resolve(canonicalBase, relative);
+  const canonical = fs.realpathSync(candidate);
+  if (
+    canonical !== canonicalBase &&
+    !canonical.startsWith(`${canonicalBase}${path.sep}`)
+  ) {
+    throw new Error('retained object path escapes the evidence archive');
+  }
+  return canonical;
+}
 
 function digestBytes(bytes) {
   return `sha256:${crypto.createHash('sha256').update(bytes).digest('hex')}`;
@@ -59,6 +136,7 @@ function verifyRetainedBinding(
   matrix,
   live,
   issues,
+  sealVerification = undefined,
 ) {
   const mismatch = (code, target, actual, expected) =>
     exact(actual, expected, code, target, issues);
@@ -280,11 +358,14 @@ function verifyRetainedBinding(
       }
       break;
     case 'assignment-seal':
+    case 'dependency-seal':
     case 'predecessor-seal': {
       const expectedAssignment =
         object.kind === 'assignment-seal'
           ? matrix.goalId
-          : matrix.predecessor.assignmentId;
+          : object.kind === 'predecessor-seal'
+            ? matrix.predecessor.assignmentId
+            : object.assignmentId;
       mismatch(
         'retained-seal-schema',
         `${object.kind}.schema`,
@@ -297,15 +378,96 @@ function verifyRetainedBinding(
         document?.assignment?.assignment_id,
         expectedAssignment,
       );
+      if (!ROOT_PATTERN.test(document?.query_proof_root || '')) {
+        issues.push(
+          issue(
+            'retained-seal-query-proof-missing',
+            `${object.kind}.query_proof_root`,
+            'sealed Assignment has no exact native query-proof root',
+          ),
+        );
+      }
+      if (!ROOT_PATTERN.test(document?.assignment?.request_root || '')) {
+        issues.push(
+          issue(
+            'retained-seal-request-root-missing',
+            `${object.kind}.assignment.request_root`,
+            'sealed Assignment has no exact request root',
+          ),
+        );
+      }
       if (
-        object.kind === 'assignment-seal' &&
-        document?.phase !== 'continuation-decided'
+        !Array.isArray(document?.assignment?.capture_receipt_roots) ||
+        document.assignment.capture_receipt_roots.length === 0 ||
+        document.assignment.capture_receipt_roots.some(
+          (root) => !ROOT_PATTERN.test(root),
+        )
       ) {
         issues.push(
           issue(
+            'retained-seal-capture-root-missing',
+            `${object.kind}.assignment.capture_receipt_roots`,
+            'sealed Assignment has no exact capture receipt roots',
+          ),
+        );
+      }
+      if (document?.phase !== 'continuation-decided') {
+        issues.push(
+          issue(
             'retained-seal-not-terminal',
-            'assignment.seal.phase',
+            `${object.kind}.phase`,
             `sealed Assignment phase is ${String(document?.phase)}`,
+          ),
+        );
+      }
+      for (const field of [
+        'completion_claims',
+        'independent_reviews',
+        'continuation_decisions',
+      ]) {
+        if (
+          !Number.isInteger(document?.counts?.[field]) ||
+          document.counts[field] < 1
+        ) {
+          issues.push(
+            issue(
+              'retained-seal-terminal-chain-incomplete',
+              `${object.kind}.counts.${field}`,
+              `sealed Assignment has no ${field}`,
+            ),
+          );
+        }
+      }
+      if (sealVerification?.ok !== true) {
+        issues.push(
+          issue(
+            'retained-seal-native-verification-failed',
+            object.path,
+            'exact retained seal did not pass native verify-seal',
+          ),
+        );
+      }
+      mismatch(
+        'retained-seal-native-root-mismatch',
+        `${object.kind}.state_root`,
+        sealVerification?.state_root,
+        object.root,
+      );
+      mismatch(
+        'retained-seal-native-phase-mismatch',
+        `${object.kind}.verified_phase`,
+        sealVerification?.phase,
+        'continuation-decided',
+      );
+      if (
+        !Array.isArray(sealVerification?.next_actions) ||
+        sealVerification.next_actions.length !== 0
+      ) {
+        issues.push(
+          issue(
+            'retained-seal-native-actions-present',
+            `${object.kind}.next_actions`,
+            'native seal verification retains actions or omitted next_actions',
           ),
         );
       }
@@ -367,6 +529,182 @@ function verifyRetainedBinding(
   }
 }
 
+function requiredArray(value, target, issues) {
+  if (!Array.isArray(value)) {
+    issues.push(
+      issue(
+        'required-v4-field-missing',
+        target,
+        `${target} must be an explicit array`,
+      ),
+    );
+    return [];
+  }
+  return value;
+}
+
+function retainedDocument(root, kind, retained, readBytes, issues) {
+  const object = retained.get(root);
+  if (!object || object.kind !== kind) {
+    issues.push(
+      issue(
+        'retained-authority-missing',
+        root || kind,
+        `retained ${kind} authority is missing`,
+      ),
+    );
+    return undefined;
+  }
+  try {
+    const result = retainedRoot(readBytes(object.path), object);
+    if (typeof result === 'string' || result.root !== root) {
+      throw new Error(`${kind} authority root does not match retained bytes`);
+    }
+    return result.document;
+  } catch (error) {
+    issues.push(
+      issue(
+        'retained-authority-unreadable',
+        object.path || root,
+        error instanceof Error ? error.message : String(error),
+      ),
+    );
+    return undefined;
+  }
+}
+
+function verifyDependencyAuthority(
+  matrix,
+  evidence,
+  request,
+  references,
+  issues,
+) {
+  const matrixDependencies = requiredArray(
+    matrix.dependencies,
+    'matrix.dependencies',
+    issues,
+  );
+  const evidenceDependencies = requiredArray(
+    evidence.dependencies,
+    'evidence.dependencies',
+    issues,
+  );
+  const requestDependencies = requiredArray(
+    request?.workDefinition?.dependency_identities,
+    'assignment.request.workDefinition.dependency_identities',
+    issues,
+  );
+  const requestIdentities = [
+    request?.workDefinition?.parent_assignment_identity?.assignment_id,
+    ...requestDependencies.map(({ assignment_id }) => assignment_id),
+  ];
+  if (requestIdentities.some((identity) => !identity)) {
+    issues.push(
+      issue(
+        'request-dependency-identity-missing',
+        'assignment.request.workDefinition',
+        'parent or dependency Assignment identity is absent',
+      ),
+    );
+  }
+  uniqueBy(
+    matrixDependencies,
+    'requiredAssignmentId',
+    'duplicate-required-dependency',
+    issues,
+  );
+  uniqueBy(matrixDependencies, 'assignmentId', 'duplicate-dependency', issues);
+  uniqueBy(
+    matrixDependencies,
+    'sealedStateRoot',
+    'duplicate-dependency-seal',
+    issues,
+  );
+  uniqueBy(
+    evidenceDependencies,
+    'requiredAssignmentId',
+    'duplicate-evidence-required-dependency',
+    issues,
+  );
+  uniqueBy(
+    evidenceDependencies,
+    'assignmentId',
+    'duplicate-evidence-dependency',
+    issues,
+  );
+  uniqueBy(
+    evidenceDependencies,
+    'sealedStateRoot',
+    'duplicate-evidence-dependency-seal',
+    issues,
+  );
+  const authoritySet = [...requestIdentities].sort();
+  const matrixAuthoritySet = matrixDependencies
+    .map(({ requiredAssignmentId }) => requiredAssignmentId)
+    .sort();
+  if (JSON.stringify(matrixAuthoritySet) !== JSON.stringify(authoritySet)) {
+    issues.push(
+      issue(
+        'dependency-authority-set-mismatch',
+        'matrix.dependencies',
+        'matrix dependency authority set differs from immutable request',
+      ),
+    );
+  }
+  const declaredDependencies = new Map(
+    evidenceDependencies.map((dependency) => [
+      dependency.requiredAssignmentId,
+      dependency,
+    ]),
+  );
+  for (const dependency of matrixDependencies) {
+    const declared = declaredDependencies.get(dependency.requiredAssignmentId);
+    if (!declared) {
+      issues.push(
+        issue(
+          'missing-dependency',
+          dependency.requiredAssignmentId,
+          'required terminal dependency or declared successor is absent',
+        ),
+      );
+      continue;
+    }
+    for (const field of [
+      'requiredAssignmentId',
+      'assignmentId',
+      'sealedStateRoot',
+    ]) {
+      exact(
+        declared[field],
+        dependency[field],
+        `dependency-${field}-mismatch`,
+        `${dependency.requiredAssignmentId}.${field}`,
+        issues,
+      );
+    }
+    requiredRoot(
+      references,
+      declared.sealedStateRoot,
+      `${dependency.requiredAssignmentId}.sealedStateRoot`,
+      'dependency-seal',
+      issues,
+    );
+  }
+  if (
+    evidenceDependencies.length !== matrixDependencies.length ||
+    matrixDependencies.length !== authoritySet.length
+  ) {
+    issues.push(
+      issue(
+        'dependency-cardinality-mismatch',
+        'dependencies',
+        'request, matrix, and evidence dependency sets differ',
+      ),
+    );
+  }
+}
+
 /**
  * Verify one terminal evidence set against facts observed outside the set.
  *
@@ -378,12 +716,37 @@ export function verifyTerminalEvidence(
   evidence,
   live,
   readBytes = (relative) => fs.readFileSync(path.resolve(relative)),
+  verifySeal = undefined,
 ) {
   const issues = [];
   const references = new Map();
+  const retainedObjects = requiredArray(
+    evidence.retainedObjects,
+    'evidence.retainedObjects',
+    issues,
+  );
+  const retained = new Map(retainedObjects.map((entry) => [entry.root, entry]));
+  const request = retainedDocument(
+    evidence.assignment?.requestRoot,
+    'assignment-request',
+    retained,
+    readBytes,
+    issues,
+  );
+  requiredArray(
+    matrix.terminalEvidence?.runGroups,
+    'matrix.terminalEvidence.runGroups',
+    issues,
+  );
+  requiredArray(evidence.runs, 'evidence.runs', issues);
+  requiredArray(
+    matrix.reconciliation?.pullRequests,
+    'matrix.reconciliation.pullRequests',
+    issues,
+  );
   exact(
     matrix.schema,
-    'kungfu.maintainability-terminal-evidence-matrix/v3',
+    'kungfu.maintainability-terminal-evidence-matrix/v4',
     'matrix-schema',
     'matrix.schema',
     issues,
@@ -449,6 +812,20 @@ export function verifyTerminalEvidence(
     live.source?.protectedTree,
     'protected-tree-mismatch',
     'live.source.protectedTree',
+    issues,
+  );
+  exact(
+    live.source?.protectedCommitEnd,
+    live.source?.protectedCommit,
+    'protected-head-toctou',
+    'live.source.protectedCommitEnd',
+    issues,
+  );
+  exact(
+    live.source?.protectedTreeEnd,
+    live.source?.protectedTree,
+    'protected-tree-toctou',
+    'live.source.protectedTreeEnd',
     issues,
   );
   exact(
@@ -706,6 +1083,8 @@ export function verifyTerminalEvidence(
   );
 
   verifyLiveAssignment(matrix, evidence, live, references, issues);
+  verifyLiveReconciliation(matrix, live, request, issues);
+  verifyDependencyAuthority(matrix, evidence, request, references, issues);
   exact(
     evidence.predecessor?.assignmentId,
     matrix.predecessor.assignmentId,
@@ -730,10 +1109,7 @@ export function verifyTerminalEvidence(
 
   verifyLiveRuns(matrix, evidence, live, references, issues);
 
-  uniqueBy(evidence.retainedObjects, 'root', 'duplicate-retained-root', issues);
-  const retained = new Map(
-    (evidence.retainedObjects || []).map((entry) => [entry.root, entry]),
-  );
+  uniqueBy(retainedObjects, 'root', 'duplicate-retained-root', issues);
   for (const [root, reference] of references) {
     const object = retained.get(root);
     if (!object) {
@@ -765,6 +1141,34 @@ export function verifyTerminalEvidence(
         object.path || root,
         issues,
       );
+      let sealVerification;
+      if (
+        ['assignment-seal', 'dependency-seal', 'predecessor-seal'].includes(
+          object.kind,
+        )
+      ) {
+        if (typeof verifySeal !== 'function') {
+          issues.push(
+            issue(
+              'native-seal-verifier-missing',
+              object.path || root,
+              'native verify-seal callback is required',
+            ),
+          );
+        } else {
+          try {
+            sealVerification = verifySeal(object.path);
+          } catch (error) {
+            issues.push(
+              issue(
+                'native-seal-verification-error',
+                object.path || root,
+                error instanceof Error ? error.message : String(error),
+              ),
+            );
+          }
+        }
+      }
       verifyRetainedBinding(
         object,
         typeof result === 'string' ? undefined : result.document,
@@ -772,6 +1176,7 @@ export function verifyTerminalEvidence(
         matrix,
         live,
         issues,
+        sealVerification,
       );
     } catch (error) {
       issues.push(
@@ -804,14 +1209,15 @@ function parseArgs(argv) {
       options.protectedRef = argv[++index] || '';
     else throw new Error(`unknown argument '${value}'`);
   }
-  if (!options.evidence || !options.delivery) {
-    throw new Error('--evidence and --delivery are required');
+  if (!options.evidence || !options.delivery || !options.protectedRef) {
+    throw new Error('--evidence, --delivery, and --protected-ref are required');
   }
   return options;
 }
 
 function main() {
   const options = parseArgs(process.argv.slice(2));
+  assertHeadBoundInputs();
   const matrix = JSON.parse(
     fs.readFileSync(path.join(ROOT, MATRIX_PATH), 'utf8'),
   );
@@ -824,12 +1230,38 @@ function main() {
     throw new Error('delivery input does not match the retained delivery root');
   }
   const expectedProtectedRef = `refs/remotes/origin/${matrix.sourceBinding.protectedBranch}`;
-  if (options.protectedRef && options.protectedRef !== expectedProtectedRef) {
+  if (options.protectedRef !== expectedProtectedRef) {
     throw new Error(`protected ref must be ${expectedProtectedRef}`);
   }
+  const localProtectedCommit = command('git', [
+    'rev-parse',
+    options.protectedRef,
+  ]);
   const live = collectTerminalLiveObservations(matrix, evidence);
-  const report = verifyTerminalEvidence(matrix, evidence, live, (relative) =>
-    fs.readFileSync(path.resolve(path.dirname(evidencePath), String(relative))),
+  if (
+    localProtectedCommit !== live.source?.protectedCommit ||
+    localProtectedCommit !== live.source?.protectedCommitEnd
+  ) {
+    throw new Error('local and live protected refs do not identify one cut');
+  }
+  const report = verifyTerminalEvidence(
+    matrix,
+    evidence,
+    live,
+    (relative) =>
+      fs.readFileSync(
+        resolveRetainedPath(path.dirname(evidencePath), relative),
+      ),
+    (relative) => {
+      const sealPath = resolveRetainedPath(
+        path.dirname(evidencePath),
+        relative,
+      );
+      return terminalJson(
+        command(path.join(ROOT, 'shifu'), ['work', 'verify-seal', sealPath]),
+        'kungfu work verify-seal',
+      );
+    },
   );
   process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
   if (report.issues.length) process.exitCode = 1;
@@ -849,4 +1281,4 @@ if (
   }
 }
 
-export { digestBytes };
+export { digestBytes, resolveRetainedPath };

--- a/framework/terminal-evidence/live-observations.mjs
+++ b/framework/terminal-evidence/live-observations.mjs
@@ -60,9 +60,17 @@ function gitTree(commit) {
   return git(['rev-parse', `${commit}^{tree}`]);
 }
 
-function githubTree(repository, commit) {
-  return gh(`/repos/${repository}/git/commits/${encodeURIComponent(commit)}`)
-    .tree?.sha;
+function requiredArray(value, label) {
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} must be an array`);
+  }
+  return value;
+}
+
+function githubTree(repository, commit, observe = gh) {
+  return observe(
+    `/repos/${repository}/git/commits/${encodeURIComponent(commit)}`,
+  ).tree?.sha;
 }
 
 function canonicalSealPath(root) {
@@ -218,6 +226,80 @@ function observeDelivery(matrix, head, headTree) {
   };
 }
 
+function observeReconciliation(matrix, observe = gh) {
+  const repository = matrix.sourceBinding.repository;
+  const pulls = new Map();
+  const observePull = (number) => {
+    if (!pulls.has(number)) {
+      pulls.set(number, observe(`/repos/${repository}/pulls/${number}`));
+    }
+    return pulls.get(number);
+  };
+  const declaredPulls = requiredArray(
+    matrix.reconciliation?.pullRequests,
+    'matrix.reconciliation.pullRequests',
+  ).map((required) => {
+    const pull = observePull(required.number);
+    const successor = required.successor
+      ? observePull(required.successor)
+      : undefined;
+    return {
+      number: pull.number,
+      state:
+        pull.state === 'closed' && pull.merged_at
+          ? 'MERGED'
+          : pull.state?.toUpperCase() || '',
+      baseRef: pull.base?.ref || '',
+      headRef: pull.head?.ref || '',
+      head: pull.head?.sha || '',
+      mergeCommit: pull.merge_commit_sha || '',
+      ...(successor
+        ? {
+            successor: successor.number,
+            successorState:
+              successor.state === 'closed' && successor.merged_at
+                ? 'MERGED'
+                : successor.state?.toUpperCase() || '',
+            successorBaseRef: successor.base?.ref || '',
+            successorHeadRef: successor.head?.ref || '',
+            successorHead: successor.head?.sha || '',
+            successorTree: githubTree(
+              repository,
+              successor.head?.sha || '',
+              observe,
+            ),
+            successorMergeCommit: successor.merged_at
+              ? successor.merge_commit_sha || ''
+              : '',
+          }
+        : {}),
+    };
+  });
+  const openPullPayload = requiredArray(
+    observe(
+      `/repos/${repository}/pulls?state=open&base=${encodeURIComponent(
+        matrix.sourceBinding.protectedBranch,
+      )}&per_page=100`,
+    ),
+    'GitHub open protected pull requests',
+  );
+  if (openPullPayload.length === 100) {
+    throw new Error(
+      'open protected pull-request enumeration reached its hard page bound',
+    );
+  }
+  const openProtectedPulls = openPullPayload.map((pull) => ({
+    number: pull.number,
+    state: pull.state?.toUpperCase() || '',
+    baseRef: pull.base?.ref || '',
+    headRef: pull.head?.ref || '',
+    head: pull.head?.sha || '',
+    headTree: githubTree(repository, pull.head?.sha || '', observe),
+    title: pull.title || '',
+  }));
+  return { declaredPulls, openProtectedPulls };
+}
+
 function terminalReviewAttestation(body) {
   try {
     const value = JSON.parse(String(body || '').trim());
@@ -311,20 +393,37 @@ function observeRun(matrix, declared, observe = gh) {
   };
 }
 
-export function collectTerminalLiveObservations(matrix, evidence) {
-  const head = git(['rev-parse', 'HEAD']);
-  const headTree = gitTree(head);
-  const protectedRef = gh(
-    `/repos/${matrix.sourceBinding.repository}/git/ref/heads/${encodeURIComponent(
+function observeProtectedSource(matrix, observe = gh) {
+  const repository = matrix.sourceBinding.repository;
+  const ref = observe(
+    `/repos/${repository}/git/ref/heads/${encodeURIComponent(
       matrix.sourceBinding.protectedBranch,
     )}`,
   );
-  const protectedCommit = protectedRef.object?.sha || '';
-  const protectedTree = githubTree(
-    matrix.sourceBinding.repository,
-    protectedCommit,
-  );
+  const commit = ref.object?.sha || '';
+  return { commit, tree: githubTree(repository, commit, observe) };
+}
+
+export function collectTerminalLiveObservations(
+  matrix,
+  evidence,
+  observe = gh,
+) {
+  requiredArray(evidence.runs, 'evidence.runs');
+  const head = git(['rev-parse', 'HEAD']);
+  const headTree = gitTree(head);
+  const protectedStart = observeProtectedSource(matrix, observe);
   const delivery = observeDelivery(matrix, head, headTree);
+  const reconciliation = observeReconciliation(matrix, observe);
+  const terminalReview = observeTerminalReview(
+    matrix,
+    delivery.pullRequest,
+    head,
+    headTree,
+  );
+  const assignment = observeAssignment(matrix, evidence);
+  const runs = evidence.runs.map((run) => observeRun(matrix, run, observe));
+  const protectedEnd = observeProtectedSource(matrix, observe);
   return {
     schema: 'kungfu.terminal-live-observations/v1',
     observedAt: new Date().toISOString(),
@@ -333,23 +432,22 @@ export function collectTerminalLiveObservations(matrix, evidence) {
       protectedBranch: matrix.sourceBinding.protectedBranch,
       head,
       headTree,
-      protectedCommit,
-      protectedTree,
+      protectedCommit: protectedStart.commit,
+      protectedTree: protectedStart.tree,
+      protectedCommitEnd: protectedEnd.commit,
+      protectedTreeEnd: protectedEnd.tree,
     },
     delivery,
-    terminalReview: observeTerminalReview(
-      matrix,
-      delivery.pullRequest,
-      head,
-      headTree,
-    ),
-    assignment: observeAssignment(matrix, evidence),
-    runs: (evidence.runs || []).map((run) => observeRun(matrix, run)),
+    reconciliation,
+    terminalReview,
+    assignment,
+    runs,
   };
 }
 
 export {
   jsonOutput as parseCommandJson,
   observeRun,
+  observeReconciliation,
   terminalReviewAttestation as parseTerminalReviewAttestation,
 };

--- a/framework/terminal-evidence/live-verification.mjs
+++ b/framework/terminal-evidence/live-verification.mjs
@@ -166,6 +166,223 @@ export function verifyLiveAssignment(
   }
 }
 
+function assignmentFamily(assignmentId) {
+  const family = String(assignmentId || '')
+    .replace(/^\d{4}-\d{2}-\d{2}-kungfu-/u, '')
+    .replace(/-v\d+$/u, '');
+  return family.startsWith('terminal-review-') ? 'terminal-review' : family;
+}
+
+function authoritativePullScope(request, issues) {
+  const work = request?.workDefinition;
+  const dependencies = work?.dependency_identities;
+  const baseline = work?.review_baseline?.open_pull_requests_at_review;
+  if (!Array.isArray(dependencies)) {
+    issues.push(
+      issue(
+        'request-dependencies-missing',
+        'assignment.request.workDefinition.dependency_identities',
+        'immutable Assignment request has no dependency identities',
+      ),
+    );
+  }
+  if (!Array.isArray(baseline)) {
+    issues.push(
+      issue(
+        'request-reconciliation-scope-missing',
+        'assignment.request.workDefinition.review_baseline.open_pull_requests_at_review',
+        'immutable Assignment request has no pull-request review baseline',
+      ),
+    );
+  }
+  const identities = [
+    work?.parent_assignment_identity?.assignment_id,
+    ...(Array.isArray(dependencies)
+      ? dependencies.map(({ assignment_id }) => assignment_id)
+      : []),
+  ].filter(Boolean);
+  const families = new Set(identities.map(assignmentFamily).filter(Boolean));
+  const pullNumbers = new Set(
+    (Array.isArray(baseline) ? baseline : [])
+      .map((value) => /^#([1-9][0-9]*)$/u.exec(String(value)))
+      .filter(Boolean)
+      .map((match) => Number(match[1])),
+  );
+  return { families, pullNumbers };
+}
+
+export function verifyLiveReconciliation(matrix, live, request, issues) {
+  const requiredPulls = matrix.reconciliation?.pullRequests;
+  const observedPulls = live.reconciliation?.declaredPulls;
+  const openProtectedPulls = live.reconciliation?.openProtectedPulls;
+  if (!Array.isArray(requiredPulls) || !Array.isArray(observedPulls)) {
+    issues.push(
+      issue(
+        'reconciliation-set-missing',
+        'reconciliation.pullRequests',
+        'required and observed pull-request sets must be arrays',
+      ),
+    );
+    return;
+  }
+  if (!Array.isArray(openProtectedPulls)) {
+    issues.push(
+      issue(
+        'reconciliation-open-scope-missing',
+        'live.reconciliation.openProtectedPulls',
+        'live open protected pull-request enumeration is missing',
+      ),
+    );
+    return;
+  }
+  uniqueBy(requiredPulls, 'number', 'duplicate-reconciliation-pr', issues);
+  uniqueBy(observedPulls, 'number', 'duplicate-live-reconciliation-pr', issues);
+  const observedByNumber = new Map(
+    observedPulls.map((pull) => [pull.number, pull]),
+  );
+  for (const required of requiredPulls) {
+    const observed = observedByNumber.get(required.number);
+    if (!observed) {
+      issues.push(
+        issue(
+          'missing-reconciliation-pr',
+          `pullRequests.${required.number}`,
+          'required remediation pull request was not observed',
+        ),
+      );
+      continue;
+    }
+    for (const field of ['number', 'state', 'headRef', 'head']) {
+      exact(
+        observed[field],
+        required[field],
+        `reconciliation-pr-${field}-mismatch`,
+        `pullRequests.${required.number}.${field}`,
+        issues,
+      );
+    }
+    exact(
+      observed.baseRef,
+      matrix.sourceBinding.protectedBranch,
+      'reconciliation-pr-base-mismatch',
+      `pullRequests.${required.number}.baseRef`,
+      issues,
+    );
+    if (required.state === 'MERGED') {
+      exact(
+        observed.mergeCommit,
+        required.mergeCommit,
+        'reconciliation-pr-merge-mismatch',
+        `pullRequests.${required.number}.mergeCommit`,
+        issues,
+      );
+    }
+    if (
+      required.disposition === 'superseded-by' &&
+      (!Number.isInteger(required.successor) || required.successor < 1)
+    ) {
+      issues.push(
+        issue(
+          'reconciliation-successor-missing',
+          `pullRequests.${required.number}.successor`,
+          'superseded pull request has no exact successor identity',
+        ),
+      );
+    }
+    if (required.disposition === 'superseded-by') {
+      exact(
+        observed.successor,
+        required.successor,
+        'reconciliation-successor-mismatch',
+        `pullRequests.${required.number}.successor`,
+        issues,
+      );
+      if (!['CLOSED', 'MERGED'].includes(observed.successorState)) {
+        issues.push(
+          issue(
+            'reconciliation-successor-not-terminal',
+            `pullRequests.${required.number}.successorState`,
+            'superseding pull request remains actionable',
+          ),
+        );
+      }
+      exact(
+        observed.successorBaseRef,
+        matrix.sourceBinding.protectedBranch,
+        'reconciliation-successor-base-mismatch',
+        `pullRequests.${required.number}.successorBaseRef`,
+        issues,
+      );
+      for (const field of [
+        'successorState',
+        'successorHeadRef',
+        'successorHead',
+        'successorTree',
+        'successorMergeCommit',
+      ]) {
+        exact(
+          observed[field] || '',
+          required[field] || '',
+          `reconciliation-${field}-mismatch`,
+          `pullRequests.${required.number}.${field}`,
+          issues,
+        );
+      }
+    }
+    if (
+      !['superseded-by', 'delivered', 'historical-nonmerge'].includes(
+        required.disposition,
+      )
+    ) {
+      issues.push(
+        issue(
+          'reconciliation-disposition-invalid',
+          `pullRequests.${required.number}.disposition`,
+          'pull request disposition is not terminal',
+        ),
+      );
+    }
+  }
+  if (observedPulls.length !== requiredPulls.length) {
+    issues.push(
+      issue(
+        'reconciliation-pr-cardinality-mismatch',
+        'reconciliation.pullRequests',
+        'live remediation pull-request set differs from the matrix',
+      ),
+    );
+  }
+  const authority = authoritativePullScope(request, issues);
+  const requiredNumbers = new Set(requiredPulls.map(({ number }) => number));
+  for (const number of authority.pullNumbers) {
+    if (!requiredNumbers.has(number)) {
+      issues.push(
+        issue(
+          'reconciliation-authority-pr-missing',
+          `pullRequests.${number}`,
+          'immutable Assignment review-baseline pull request is absent',
+        ),
+      );
+    }
+  }
+  for (const pull of openProtectedPulls) {
+    const inScope =
+      authority.pullNumbers.has(pull.number) ||
+      [...authority.families].some((family) =>
+        String(pull.headRef || '').includes(family),
+      );
+    if (inScope) {
+      issues.push(
+        issue(
+          'reconciliation-in-scope-pr-open',
+          `openPullRequests.${pull.number}`,
+          `in-scope protected pull request ${pull.headRef} remains open`,
+        ),
+      );
+    }
+  }
+}
+
 function verifyRequiredArtifact(
   required,
   artifactRule,


### PR DESCRIPTION
Ports the independently reviewed terminal-evidence P1 remediations onto the current dev/v4/v4.0 protected head.

This change binds live runs to native attempts, validates immutable Assignment request sets and dependency seals, and requires exact remediation PR/head identity while deduplicating request-authority identities.

Validation:
- ./shifu check:source
- node --test framework/maintainability/terminal-evidence-matrix.test.mjs

Supersedes #2629.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Terminal evidence verification hardening does not alter an architecture contract"
}
-->