### PR TITLE
fix(ci): repair post-merge advisory authority lookup

### DIFF
--- a/.github/workflows/dev-post-merge-advisory.yml
+++ b/.github/workflows/dev-post-merge-advisory.yml
@@ -88,7 +88,8 @@ jobs:
             run_state="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" --jq '[.status,.conclusion] | @tsv')"
             [ "$run_state" = $'completed\tsuccess' ] || continue
             required_count="$(
-              gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs" \
+              gh api --method GET \
+                "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs" \
                 -f filter=latest -f per_page=100 \
                 --jq '[.jobs[] | select(.name == "affected-native / linux" and .status == "completed" and .conclusion == "success")] | length'
             )"

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -604,10 +604,10 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:2025ffe8ecc5c7d9560a4089f908ebaefc33e56b63c94c2871b81eb26bfd0294",
+          "definitionDigest": "sha256:bd715e5fd770c361f1d9a8724ec6894b3dbb0ff0817ae8cc48471951fff59094",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
-          "steps": [{"index":1,"label":"name:Check out exact protected Dev head","definitionDigest":"sha256:b745070a53e83fcc41ae641336ed629c7958805551ded69490d91cc96f5561ac"},{"index":2,"label":"id:target","definitionDigest":"sha256:deaf46c701a8d39f71506d2767466aa8352d3667f46dd5f01095564aab927bd5"},{"index":3,"label":"id:source","definitionDigest":"sha256:4d50ccc3c7fddc89c8bea0ebe4782052cf6cc8e026e529f0a486fbc646055190"},{"index":4,"label":"name:Retain exact advisory input","authority":"evidence-publication","definitionDigest":"sha256:aad1bac8a7e20493e6364ac4dab6559ddaa9bf0d12bcfb566155d76b157b8dbb"}]
+          "steps": [{"index":1,"label":"name:Check out exact protected Dev head","definitionDigest":"sha256:b745070a53e83fcc41ae641336ed629c7958805551ded69490d91cc96f5561ac"},{"index":2,"label":"id:target","definitionDigest":"sha256:deaf46c701a8d39f71506d2767466aa8352d3667f46dd5f01095564aab927bd5"},{"index":3,"label":"id:source","definitionDigest":"sha256:4321272d933fb9a24ea7ba438ae76da5136c982ba0874dfdf24fc2d7a200c5e7"},{"index":4,"label":"name:Retain exact advisory input","authority":"evidence-publication","definitionDigest":"sha256:aad1bac8a7e20493e6364ac4dab6559ddaa9bf0d12bcfb566155d76b157b8dbb"}]
         },
         {
           "id": "production_graph_parity",

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -87,7 +87,7 @@
           "classification": "non-publication",
           "owner": "kungfu-release",
           "surfaceIds": [],
-          "sourceRoot": "sha256:548fc2506a86e3c6dd1dca142e31c5ad7759f5804dfdd892f761d2d1a2307e66"
+          "sourceRoot": "sha256:257dae15f1a13d4b8584ad364d369c6b535624c0b1b9cd1c1f29c4a5ac77a3cc"
         },
         {
           "path": ".github/workflows/alpha-promotion-preflight.yml",
@@ -874,5 +874,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:195572f3bee5ed96b5d75e40bbf79d2bdb4190be9666854996d79a99598198fd"
+  "registryRoot": "sha256:882e25dae7e830bebe3b32a695dd02e1d0efce226ceaf0b814c6bdbae330e530"
 }

--- a/scripts/qualified-assignment-core-artifact.test.mjs
+++ b/scripts/qualified-assignment-core-artifact.test.mjs
@@ -2102,7 +2102,7 @@ test('workflows keep candidate and promotion outside untrusted PR authority', ()
   assert.doesNotMatch(advisoryWorkflow, /^\s{2}(pull_request|merge_group):/mu);
   assert.match(
     advisoryWorkflow,
-    /REF_PROTECTED: \$\{\{ github\.ref_protected \}\}[\s\S]*REF_PROTECTED" != true[\s\S]*affected-native-pr\.yml\/runs[\s\S]*-f event=merge_group[\s\S]*affected-native \/ linux[\s\S]*dev-candidate-plan-\$\{TARGET_SHA\}/u,
+    /REF_PROTECTED: \$\{\{ github\.ref_protected \}\}[\s\S]*REF_PROTECTED" != true[\s\S]*affected-native-pr\.yml\/runs[\s\S]*-f event=merge_group[\s\S]*gh api --method GET[\s\S]*actions\/runs\/\$\{run_id\}\/jobs[\s\S]*affected-native \/ linux[\s\S]*dev-candidate-plan-\$\{TARGET_SHA\}/u,
   );
   assert.match(
     advisoryWorkflow,


### PR DESCRIPTION
## Summary

- Force the advisory merge-group jobs query to use HTTP GET instead of `gh api` implicit POST.
- Refresh the closed-world workflow authority digest and freeze the GET requirement in regression coverage.
- Follow up the merged #3053 canary, which proved advisory work is non-blocking but exposed this 404 before the advisory lanes started.
- Supersede #3060 with a clean two-commit history rooted at protected `dev/v4/v4.0`; the protected queue replay is locally qualified.

## Assignment

Native Assignment `2026-08-12-kungfu-post-merge-advisory-workflow-decoupling` under initiative `2026-07-28-kungfu-go-family-continuous-delivery`.

## Verification

- `./shifu check:staged` passed.
- `node --test scripts/qualified-assignment-core-artifact.test.mjs` passed.
- `./shifu project-cut:queue-admission -- --base 7a3e0882009205db293ac54054b5d4dc9ab452a1 --head 1044c55e3375c8bed8e447a0670571a87982f896` returned `decision=qualified`.
- Hosted failure isolated to `gh api` POST on the Actions run-jobs endpoint; equivalent explicit GET returns the exact successful affected-native job.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"dev-delivery","intent":"stage-ready","adrs":["SHIFU-ADR-019f86da-4f90-79a1-bc85-4b542fecf011"],"summary":"Repair the exact-source post-merge advisory authority lookup without changing protected merge or release authority.","verification":["staged source gate","workflow authority regression","hosted canary failure reproduction","protected queue replay"]}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Boundary: this corrects a read-only hosted Actions query. It does not change required contexts, merge authority, release qualification, or publication behavior.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Workflow authority projection is refreshed
