### PR TITLE
fix(release): forward-port Alpha.2 v3-alpha and Windows launch repair

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,11 @@
 # formatter results and generated evidence independent of core.autocrlf.
 * text=auto eol=lf
 
+# cmd.exe cannot reliably resolve labels across parenthesized block boundaries
+# from LF-only batch files. Keep the canonical Windows launcher checked out
+# with native CRLF bytes on every host while Git continues to normalize it.
+shifu.cmd text eol=crlf
+
 # Canonical contract bytes are hashed and compared byte-for-byte. Keep their
 # line endings independent of the checkout platform.
 framework/config/*.contract.json text eol=lf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,9 +180,10 @@ jobs:
   build:
     needs: [preflight, windows-fast-sentinel, auditable-demo-fast-sentinel]
     if: ${{ always() && needs.preflight.result == 'success' && needs.windows-fast-sentinel.result == 'success' && needs.auditable-demo-fast-sentinel.result == 'success' && !inputs.fast-sentinels-only && fromJSON(inputs.macos-overflow-request-json || '{}').mode != 'control' }}
-    # Pin the workflow shell that routes signed macOS finalization to a native
-    # runner. The v3 tag can lag this fail-closed runtime contract.
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@dbad2f383a6ab93abd192c4edefb4689c9eebc78
+    # Alpha build and runtime resolution must consume the same floating
+    # v3-alpha channel contract; mixing an exact workflow shell with the
+    # Alpha runtime leaves channel/major identity ambiguous at the trust gate.
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v3-alpha
     secrets:
       BUILDCHAIN_PROMOTION_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}
       BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -328,9 +328,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:b30e68805cacd5a0c5afccad3f9c20a51dc2ccf1850d3e55f4f4201ae0a9d959",
+          "definitionDigest": "sha256:eb62b8b7d5754de5d5e4169892724fdda360b5dfa2f1a5ef1221b5adbdf50b20",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN","KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@dbad2f383a6ab93abd192c4edefb4689c9eebc78"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@v3-alpha"],
           "steps": []
         },
         {

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -467,7 +467,7 @@
       "adapter": {
         "type": "buildchain-heavy-build",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@dbad2f383a6ab93abd192c4edefb4689c9eebc78",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@v3-alpha",
         "job": {
       "needs": [
         "preflight",

--- a/docs/release-promotion-rehearsal.contract.json
+++ b/docs/release-promotion-rehearsal.contract.json
@@ -8,7 +8,6 @@
   "buildchain": {
     "workflow_shell_ref": "v3-alpha",
     "workflow_shell_resolved_sha": "a60957e3ffc8f9a02f0e9419deebc8d35a3f7198",
-    "build_workflow_shell_sha": "dbad2f383a6ab93abd192c4edefb4689c9eebc78",
     "alpha": {
       "workflow_ref": "v3-alpha",
       "resolved_sha": "82701ca66f5366ade6ec694c9950d5d8d6db082d",

--- a/framework/release/publication-control-plane.mjs
+++ b/framework/release/publication-control-plane.mjs
@@ -101,19 +101,22 @@ export function validatePromotionWorkflowAuthority(
 }
 export function validateBuildWorkflowAuthority(
   buildWorkflow,
-  workflowShellSha,
+  workflowShellRef,
 ) {
-  if (!/^[0-9a-f]{40}$/u.test(workflowShellSha))
-    throw new Error('Build workflow shell revision is invalid');
+  if (workflowShellRef !== 'v3-alpha')
+    throw new Error('Build workflow shell channel is invalid');
   if (
     !buildWorkflow.includes(
-      `uses: kungfu-systems/buildchain/.github/workflows/.build.yml@${workflowShellSha}`,
+      `uses: kungfu-systems/buildchain/.github/workflows/.build.yml@${workflowShellRef}`,
     ) ||
     !/^\s+buildchain-ref: \$\{\{ inputs\.buildchain-ref \|\| 'v3-alpha' \}\}\s*$/mu.test(
       buildWorkflow,
     ) ||
-    buildWorkflow.includes(
-      'uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v3',
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@v3(?:\s|$)/mu.test(
+      buildWorkflow,
+    ) ||
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@[0-9a-f]{40}/u.test(
+      buildWorkflow,
     ) ||
     buildWorkflow.includes('kungfu-trader/workflows@v1')
   )
@@ -303,7 +306,7 @@ export function validateRegistry(r, { root = ROOT } = {}) {
   );
   validateBuildWorkflowAuthority(
     buildWorkflow,
-    promotionRehearsal.buildchain.build_workflow_shell_sha,
+    promotionRehearsal.buildchain.workflow_shell_ref,
   );
   const promotionWorkflow = fs.readFileSync(
     path.join(root, '.github/workflows/release-new-version.yml'),

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -136,7 +136,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:cc77602a38807e04a865bbe4a66ec2f05e428b28d9dc2acd4c14ccbb04a44f6c"
+      "sourceRoot": "sha256:c730306e169f975e70f43baad7b01d104a45d5d0e9c60a8a52e08a3d5c4a2469"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",
@@ -874,5 +874,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:4bd9df2d687e419f6f028e7e81bff89116a3c287cfb2a7b0b301d10467d03087"
+  "registryRoot": "sha256:49499cbda598b74cd1194d4b91c16b7edc023a7a81d5e43b1e576bbfae80667b"
 }

--- a/scripts/alpha-macos-overflow.test.mjs
+++ b/scripts/alpha-macos-overflow.test.mjs
@@ -468,7 +468,7 @@ test('workflow contract keeps candidates exact-source, independent, and publish-
   );
   assert.match(
     workflow,
-    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@dbad2f383a6ab93abd192c4edefb4689c9eebc78/u,
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@v3-alpha/u,
   );
   assert.match(
     workflow,

--- a/scripts/alpha-promotion-preflight.test.mjs
+++ b/scripts/alpha-promotion-preflight.test.mjs
@@ -590,7 +590,7 @@ test('patrol, normal Alpha builds and sentinels keep one controller authority', 
   );
   assert.match(
     build,
-    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@dbad2f383a6ab93abd192c4edefb4689c9eebc78/u,
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@v3-alpha/u,
   );
   const preBuild = build.slice(0, build.indexOf('\n  build:'));
   assert.doesNotMatch(

--- a/scripts/check-shifu-entry-contract.test.mjs
+++ b/scripts/check-shifu-entry-contract.test.mjs
@@ -238,6 +238,15 @@ test('Windows source Kungfu route projects built TUI Product paths', () => {
   );
 });
 
+test('Windows launcher is checked out with cmd-safe line endings', () => {
+  const result = spawnSync('git', ['check-attr', 'eol', '--', 'shifu.cmd'], {
+    cwd: ROOT,
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), 'shifu.cmd: eol: crlf');
+});
+
 test('cached pinned uv activates Work after Qualified Core materialization', (t) => {
   if (process.platform === 'win32') {
     t.skip('POSIX launcher contract');

--- a/scripts/check-shifu-entry-contract.test.mjs
+++ b/scripts/check-shifu-entry-contract.test.mjs
@@ -491,7 +491,9 @@ test('Xinfa source entry prefers hash-pinned wasm and preserves native fallback'
 
 test('Xinfa quality uses the source resolver and forwards one Windows mode', () => {
   const posix = fs.readFileSync(path.join(ROOT, 'shifu'), 'utf8');
-  const windows = fs.readFileSync(path.join(ROOT, 'shifu.cmd'), 'utf8');
+  const windows = fs
+    .readFileSync(path.join(ROOT, 'shifu.cmd'), 'utf8')
+    .replaceAll('\r\n', '\n');
   const posixBlock = posix.match(/xinfa:quality\)[\s\S]*?;;/u)?.[0];
   const windowsBlock = windows.match(
     /:xinfaquality[\s\S]*?(?=\r?\n:projectcut\r?\n)/u,

--- a/scripts/kungfu-workflow-authority.mjs
+++ b/scripts/kungfu-workflow-authority.mjs
@@ -155,7 +155,7 @@ function immutableReference(reference) {
 }
 
 const BUILDCHAIN_V3_BUILD_ACTION =
-  'kungfu-systems/buildchain/.github/workflows/.build.yml@dbad2f383a6ab93abd192c4edefb4689c9eebc78';
+  'kungfu-systems/buildchain/.github/workflows/.build.yml@v3-alpha';
 const BUILDCHAIN_V3_PROMOTION_ACTION =
   'kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@v3-alpha';
 const BUILDCHAIN_V3_ALPHA_PROMOTION_ACTION =

--- a/scripts/release-promotion-rehearsal.mjs
+++ b/scripts/release-promotion-rehearsal.mjs
@@ -145,10 +145,22 @@ export function validateWorkflowSources(root, contract, overrides = {}) {
   requirePattern(
     build,
     new RegExp(
-      `uses: kungfu-systems/buildchain/\\.github/workflows/\\.build\\.yml@${contract.buildchain.build_workflow_shell_sha}`,
+      `uses: kungfu-systems/buildchain/\\.github/workflows/\\.build\\.yml@${escapeRegExp(contract.buildchain.workflow_shell_ref)}`,
     ),
     findings,
-    'release-candidate build must consume the pinned native-finalization workflow contract',
+    'release-candidate build must consume the v3-alpha floating workflow contract',
+  );
+  forbidPattern(
+    build,
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@[0-9a-f]{40}/u,
+    findings,
+    'release-candidate build must not pin the workflow shell to an exact Buildchain SHA',
+  );
+  forbidPattern(
+    build,
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@v3(?:\s|$)/u,
+    findings,
+    'Alpha release-candidate build must not consume the stable v3 workflow contract',
   );
   requirePattern(
     build,

--- a/scripts/release-promotion-rehearsal.test.mjs
+++ b/scripts/release-promotion-rehearsal.test.mjs
@@ -430,6 +430,28 @@ test('candidate build rejects a committed exact Buildchain runtime pin', () => {
   );
 });
 
+test('candidate build rejects an exact or stable Buildchain workflow shell', () => {
+  const buildPath = CONTRACT.workflows.build;
+  const original = fs.readFileSync(path.join(ROOT, buildPath), 'utf8');
+  for (const workflowShellRef of [
+    '733812ff9405241705f5f267fe2e5ec6351e1a2d',
+    'v3',
+  ]) {
+    const drifted = original.replace(
+      'uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v3-alpha',
+      `uses: kungfu-systems/buildchain/.github/workflows/.build.yml@${workflowShellRef}`,
+    );
+    assert.notEqual(drifted, original);
+    const result = validateWorkflowSources(ROOT, CONTRACT, { build: drifted });
+    assert.equal(result.ok, false);
+    assert.ok(
+      result.findings.some((entry) =>
+        entry.message.includes('workflow contract'),
+      ),
+    );
+  }
+});
+
 test('PR-stage builds reject a premature publish-source lock', () => {
   const buildPath = CONTRACT.workflows.build;
   const original = fs.readFileSync(path.join(ROOT, buildPath), 'utf8');

--- a/scripts/release-publication-control-plane.test.mjs
+++ b/scripts/release-publication-control-plane.test.mjs
@@ -44,22 +44,25 @@ test('checked registry closes workflows and invariants', () => {
   assert.equal(validateRegistry(v), v);
   assert.equal(status(v).sourceAcceptance, 'passed');
 });
-test('build authority pins the workflow shell while retaining runtime routing', () => {
+test('build authority keeps the workflow shell and runtime on v3-alpha', () => {
   const source = fs.readFileSync('.github/workflows/build.yml', 'utf8');
   const contract = JSON.parse(
     fs.readFileSync('docs/release-promotion-rehearsal.contract.json', 'utf8'),
   );
-  const shellSha = contract.buildchain.build_workflow_shell_sha;
-  assert.equal(validateBuildWorkflowAuthority(source, shellSha), true);
+  const shellRef = contract.buildchain.workflow_shell_ref;
+  assert.equal(validateBuildWorkflowAuthority(source, shellRef), true);
   assert.throws(
-    () => validateBuildWorkflowAuthority(source, '0'.repeat(40)),
-    /authority drift/u,
+    () => validateBuildWorkflowAuthority(source, 'v3'),
+    /channel is invalid/u,
   );
   assert.throws(
     () =>
       validateBuildWorkflowAuthority(
-        source.replace(`.build.yml@${shellSha}`, '.build.yml@v3'),
-        shellSha,
+        source.replace(
+          `.build.yml@${shellRef}`,
+          `.build.yml@${'0'.repeat(40)}`,
+        ),
+        shellRef,
       ),
     /authority drift/u,
   );

--- a/scripts/verify-alpha-release-cut-lock.test.mjs
+++ b/scripts/verify-alpha-release-cut-lock.test.mjs
@@ -51,7 +51,7 @@ test('Alpha.2 r17 lock verifies the exact Release Cut and fixed runtimes', () =>
   );
 });
 
-test('Alpha.2 r17 keeps the Alpha runtime train while pinning the repaired workflow shell', () => {
+test('Alpha.2 r17 keeps the Alpha workflow shell and runtime on one channel', () => {
   assert.equal(LOCK.buildchain.build.ref, 'v3-alpha');
   assert.equal(
     LOCK.buildchain.build.resolvedSha,
@@ -80,7 +80,7 @@ test('Alpha.2 r17 keeps the Alpha runtime train while pinning the repaired workf
   );
   assert.match(
     build,
-    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@dbad2f383a6ab93abd192c4edefb4689c9eebc78/u,
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@v3-alpha/u,
   );
   assert.match(
     build,
@@ -90,7 +90,7 @@ test('Alpha.2 r17 keeps the Alpha runtime train while pinning the repaired workf
     promotion,
     /buildchain-ref: \$\{\{ startsWith\(inputs\.target-ref \|\| github\.event\.pull_request\.base\.ref, 'alpha\/'\) && 'v3-alpha' \|\| 'v3' \}\}/u,
   );
-  assert.match(build, /\.github\/workflows\/\.build\.yml@[0-9a-f]{40}/u);
+  assert.doesNotMatch(build, /\.github\/workflows\/\.build\.yml@[0-9a-f]{40}/u);
 });
 
 test('candidate patrol verifies the frozen cut without settling from moving dev', () => {


### PR DESCRIPTION
## Summary

Forward-port the two minimal Alpha.2 r20 blocker repairs to protected dev without changing the frozen Release Cut or making dev an Alpha Build input.

## Exact patch roots

- protected dev base: `a698f22d2ac72e6224280255505b6a2b30a1dcf0`
- forward-port head: `4a948936e6a3cb953dcf2569e3df7ba3d97ee852`
- r20 v3-alpha repair: `43d0511837399fae9b51fe6c0602bc34e1b996e8` -> dev `e8eb92f9e02bb3d03655e0bd1ef4d37725491737`
- shared v3-alpha patch-id: `ca33c565791244147a52324a16b6a1f79a8e10a0`
- r20 Windows repair: `5371d162eea6a805dfc695969fe81e41c7f7d9d7` -> dev `839e164a28c6046306b1f1ba98b7c02e47ce2c02`
- r20 CRLF test repair: `000d93cf761a71c95d04d62aabc3c87635501c07` -> dev `4a948936e6a3cb953dcf2569e3df7ba3d97ee852`
- shared CRLF test patch-id: `54f637c7fccef73a4e70c9c19dfa8572d219e161`
- shared Windows patch-id: `941ea450487f0e6369d02c4c6cc26d02e54b56f8`

## Changes

- Keep Alpha build, promotion, and recovery on the floating `v3-alpha` contract.
- Check out `shifu.cmd` with CRLF so Windows cmd can resolve labels across block boundaries.
- Add a regression test for the Windows launcher line-ending contract.

## Verification

- r20 managed staged pre-commit gate passed in full.
- 52 targeted lifecycle tests passed; 3 Windows-host-only cases skipped locally.
- Index checkout verified `shifu.cmd` contains CRLF throughout.
- Both repairs have byte-identical stable patch IDs between r20 and this dev forward-port.
- Exact work-admission receipt verified for the pushed head.

## Release governance

The frozen r20 candidate remains the only Alpha Build input. This dev mirror is a publication gate only. Independent review, exact-head Warrant, merge queue, and every platform Gate remain required. Buildchain v4 is not involved.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This is a byte-identical forward-port of two minimal Alpha.2 release blockers and does not change architecture authority."
}
-->

## Evolution Map impact

Evolution impact: extends

This forward-port preserves the accepted Alpha.2 release stage and introduces no new Era.

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation and machine-verifiable authority updated