### PR TITLE
feat(dev-delivery): reuse exact source proof in merge groups

### DIFF
--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.1",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.1",
-    "sourceSha": "8a1d61bfe70fe15b427caa1a35f54aa96cd4a452"
+    "sourceSha": "701f3abb6c8b39bc729259f06eea04c60fdcf84a"
   },
   "claims": [
     {

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "8a1d61bfe70fe15b427caa1a35f54aa96cd4a452",
+    "sourceSha": "701f3abb6c8b39bc729259f06eea04c60fdcf84a",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:688886d29ec7be1d63b4a7cf6d4c8354ce1e025a885d0b84af137e409df107df"
   },

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:96ace21bfe655c1fa148a15e2ef64aca52a8b0859aecff708427968c24125ea5"
+            "sha256": "sha256:28af28fcfc78f9aee83b29687c681968fc316b56f78ed202ce23ac1c153fdfaa"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/.github/workflows/affected-native-pr.yml
+++ b/.github/workflows/affected-native-pr.yml
@@ -70,9 +70,9 @@ jobs:
 
   source_acceptance:
     name: Candidate source acceptance
-    uses: kungfu-systems/buildchain/.github/workflows/check.yml@a2637a8bb7869faa1d239b04ee6ded3a1c1318b1
+    uses: kungfu-systems/buildchain/.github/workflows/check.yml@4354638200137eb07d3272f4bcbce46131aea74c
     with:
-      buildchain-ref: a2637a8bb7869faa1d239b04ee6ded3a1c1318b1
+      buildchain-ref: 4354638200137eb07d3272f4bcbce46131aea74c
       mode: source
       upload-artifacts: true
       source-proof-reuse: true

--- a/.github/workflows/affected-native-pr.yml
+++ b/.github/workflows/affected-native-pr.yml
@@ -70,11 +70,16 @@ jobs:
 
   source_acceptance:
     name: Candidate source acceptance
-    uses: kungfu-systems/buildchain/.github/workflows/check.yml@58e48d73ae7fef0dd06ae02baf6d090e4da5487d
+    uses: kungfu-systems/buildchain/.github/workflows/check.yml@a2637a8bb7869faa1d239b04ee6ded3a1c1318b1
     with:
-      buildchain-ref: 58e48d73ae7fef0dd06ae02baf6d090e4da5487d
+      buildchain-ref: a2637a8bb7869faa1d239b04ee6ded3a1c1318b1
       mode: source
       upload-artifacts: true
+      source-proof-reuse: true
+      source-proof-policy-paths-json: '[".github/workflows/affected-native-pr.yml"]'
+      source-proof-closure-paths-json: '[".buildchain/buildchain.toml","shifu","scripts/source-acceptance.mjs","scripts/require-shifu.mjs"]'
+      source-proof-dependency-paths-json: '["package.json","pnpm-lock.yaml"]'
+      source-proof-required-contexts-json: '["Candidate source acceptance / check"]'
 
   cancel_after_source_failure:
     name: Stop selected lanes after source failure

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.1",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.1",
-    "sourceSha": "8a1d61bfe70fe15b427caa1a35f54aa96cd4a452"
+    "sourceSha": "701f3abb6c8b39bc729259f06eea04c60fdcf84a"
   },
   "claims": [
     {

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:96ace21bfe655c1fa148a15e2ef64aca52a8b0859aecff708427968c24125ea5"
+            "sha256": "sha256:28af28fcfc78f9aee83b29687c681968fc316b56f78ed202ce23ac1c153fdfaa"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/docs/qualification/gates/source-and-governance.md
+++ b/docs/qualification/gates/source-and-governance.md
@@ -18,7 +18,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Evidence:** unified Gate receipt; no separate artifact is currently required.
 - **Diagnosis:** `./shifu gate explain gate.catalog --profile <profile>`; reproduce with `./shifu gate run gate.catalog` on a capable runner.
 - **Cost:** light; timeout 600 seconds.
-- **Current source:** .github/workflows/affected-native-pr.yml (source_acceptance; every dev pull request and merge-group candidate inside the staged required aggregate); .github/workflows/dev-verify-patrol.yml (verify; daily or manual on dev); .github/workflows/build.yml (build; alpha or release pull request, or a manual exact-source publish-none macOS candidate under the queue-aware overflow controller); .github/workflows/release-new-version.yml (promotion-contract; merged alpha or release pull request, or manual source-locked dry-run measurement); .github/workflows/publish-layer-artifacts.yml (verify-publication; manually executed public layer publication)
+- **Current source:** .github/workflows/affected-native-pr.yml (source_acceptance; every dev pull request and merge-group candidate inside the staged required aggregate; an exact accepted pull-request proof may satisfy merge-group source acceptance only when source, base movement, policy, closure, dependency, runtime, required-context, and controller-receipt predicates all match, otherwise the full source gate runs); .github/workflows/dev-verify-patrol.yml (verify; daily or manual on dev); .github/workflows/build.yml (build; alpha or release pull request, or a manual exact-source publish-none macOS candidate under the queue-aware overflow controller); .github/workflows/release-new-version.yml (promotion-contract; merged alpha or release pull request, or manual source-locked dry-run measurement); .github/workflows/publish-layer-artifacts.yml (verify-publication; manually executed public layer publication)
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:gate.catalog -->
 
@@ -73,9 +73,18 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Diagnosis:** `./shifu gate explain source.acceptance --profile <profile>`; reproduce with `./shifu gate run source.acceptance` on a capable runner.
 - **Cost:** light; timeout 1800 seconds. This budget covers cold shared-runner
   Project Cut composition while retaining a bounded failure signal.
-- **Current source:** .github/workflows/affected-native-pr.yml (source_acceptance; every dev pull request and merge-group candidate inside the staged required aggregate). The standalone .github/workflows/source-acceptance.yml is manual-only.
+- **Current source:** .github/workflows/affected-native-pr.yml (source_acceptance; every dev pull request and merge-group candidate inside the staged required aggregate; an exact accepted pull-request proof may satisfy merge-group source acceptance only when source, base movement, policy, closure, dependency, runtime, required-context, and controller-receipt predicates all match, otherwise the full source gate runs). The standalone .github/workflows/source-acceptance.yml is manual-only.
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:source.acceptance -->
+
+The pull-request run seals an exact Buildchain source-qualification proof. A
+merge-group run may reuse it only when the source head, merge composition,
+protected-base movement, source-policy and execution-closure paths, dependency
+inputs, Buildchain runtime, required context, and controller receipt all match.
+The reused lifecycle remains explicit that the source command was not executed
+again. Missing or stale evidence, an unknown base delta, path overlap, or any
+predicate mismatch fails closed to the full `./shifu check:source` path; proof
+reuse does not grant approval, Warrant, queue, merge, or publication authority.
 
 <a id="source-changed-scope"></a>
 <!-- gate-doc:source.changed-scope -->

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -146,9 +146,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:5c12fa2cac42c7d5fedd95eb1fef64c86e4c8ccf8c41428629a7165b0af2cb04",
+          "definitionDigest": "sha256:38076a7d83487042470943ca2611d43422bf909083112a7b1c9dfb2fbfcd9139",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/check.yml@a2637a8bb7869faa1d239b04ee6ded3a1c1318b1"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/check.yml@4354638200137eb07d3272f4bcbce46131aea74c"],
           "steps": []
         },
         {

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -146,9 +146,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:959385f0d70ee1a9d092e6a9a0c4884329f73c6f9b270aa333c374bbad1161b0",
+          "definitionDigest": "sha256:5c12fa2cac42c7d5fedd95eb1fef64c86e4c8ccf8c41428629a7165b0af2cb04",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/check.yml@58e48d73ae7fef0dd06ae02baf6d090e4da5487d"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/check.yml@a2637a8bb7869faa1d239b04ee6ded3a1c1318b1"],
           "steps": []
         },
         {

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -65,9 +65,9 @@
       "adapter": {
         "type": "buildchain-source",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/check.yml@a2637a8bb7869faa1d239b04ee6ded3a1c1318b1",
+        "uses": "kungfu-systems/buildchain/.github/workflows/check.yml@4354638200137eb07d3272f4bcbce46131aea74c",
         "with": {
-          "buildchain-ref": "a2637a8bb7869faa1d239b04ee6ded3a1c1318b1",
+          "buildchain-ref": "4354638200137eb07d3272f4bcbce46131aea74c",
           "mode": "source",
           "upload-artifacts": true,
           "source-proof-reuse": true,

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -61,15 +61,20 @@
         "gate.catalog",
         "source.acceptance"
       ],
-      "activation": "every dev pull request and merge-group candidate inside the staged required aggregate",
+      "activation": "every dev pull request and merge-group candidate inside the staged required aggregate; an exact accepted pull-request proof may satisfy merge-group source acceptance only when source, base movement, policy, closure, dependency, runtime, required-context, and controller-receipt predicates all match, otherwise the full source gate runs",
       "adapter": {
         "type": "buildchain-source",
         "kind": "job-uses",
-    "uses": "kungfu-systems/buildchain/.github/workflows/check.yml@58e48d73ae7fef0dd06ae02baf6d090e4da5487d",
-    "with": {
-      "buildchain-ref": "58e48d73ae7fef0dd06ae02baf6d090e4da5487d",
+        "uses": "kungfu-systems/buildchain/.github/workflows/check.yml@a2637a8bb7869faa1d239b04ee6ded3a1c1318b1",
+        "with": {
+          "buildchain-ref": "a2637a8bb7869faa1d239b04ee6ded3a1c1318b1",
           "mode": "source",
-          "upload-artifacts": true
+          "upload-artifacts": true,
+          "source-proof-reuse": true,
+          "source-proof-policy-paths-json": "[\".github/workflows/affected-native-pr.yml\"]",
+          "source-proof-closure-paths-json": "[\".buildchain/buildchain.toml\",\"shifu\",\"scripts/source-acceptance.mjs\",\"scripts/require-shifu.mjs\"]",
+          "source-proof-dependency-paths-json": "[\"package.json\",\"pnpm-lock.yaml\"]",
+          "source-proof-required-contexts-json": "[\"Candidate source acceptance / check\"]"
         }
       }
     },

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -80,7 +80,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:ab3472d69a4764c1291df6052982898629e730bba96e39362c90646b42df1bb9"
+          "sourceRoot": "sha256:abc8951003dcdd3c938417a6a83f489f6f64cdbb3aed8aa56656dc44a8accf2c"
         },
         {
           "path": ".github/workflows/dev-post-merge-advisory.yml",
@@ -874,5 +874,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:dbfff51da598c374fdd1d3d91c33c6dbcfd586a85bb8b9f2e1206790233ec92e"
+  "registryRoot": "sha256:0aeffe51bae7bd44ae59158dd460b12e9b3fec35900d4b38c379db5f537b2e76"
 }

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -80,7 +80,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:abc8951003dcdd3c938417a6a83f489f6f64cdbb3aed8aa56656dc44a8accf2c"
+          "sourceRoot": "sha256:cea259ef04ef4276233fb552874b82e3a0cbdc58fdc3e82ea414a2ef80991792"
         },
         {
           "path": ".github/workflows/dev-post-merge-advisory.yml",
@@ -874,5 +874,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:0aeffe51bae7bd44ae59158dd460b12e9b3fec35900d4b38c379db5f537b2e76"
+  "registryRoot": "sha256:76e854d8a820cfbdf8e4531560ea70743f24cab567e645f27e72270665ac95d6"
 }

--- a/scripts/alpha-macos-overflow.test.mjs
+++ b/scripts/alpha-macos-overflow.test.mjs
@@ -476,7 +476,7 @@ test('workflow contract keeps candidates exact-source, independent, and publish-
   );
   assert.match(
     affectedNativeWorkflow,
-    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/check\.yml@58e48d73ae7fef0dd06ae02baf6d090e4da5487d[\s\S]*buildchain-ref: 58e48d73ae7fef0dd06ae02baf6d090e4da5487d/u,
+    /source_acceptance:[\s\S]*uses: kungfu-systems\/buildchain\/\.github\/workflows\/check\.yml@a2637a8bb7869faa1d239b04ee6ded3a1c1318b1[\s\S]*buildchain-ref: a2637a8bb7869faa1d239b04ee6ded3a1c1318b1[\s\S]*source-proof-reuse: true[\s\S]*source-proof-policy-paths-json: '\["\.github\/workflows\/affected-native-pr\.yml"\]'[\s\S]*source-proof-closure-paths-json: '\["\.buildchain\/buildchain\.toml","shifu","scripts\/source-acceptance\.mjs","scripts\/require-shifu\.mjs"\]'[\s\S]*source-proof-dependency-paths-json: '\["package\.json","pnpm-lock\.yaml"\]'[\s\S]*source-proof-required-contexts-json: '\["Candidate source acceptance \/ check"\]'/u,
   );
   assert.match(
     affectedNativeWorkflow,

--- a/scripts/alpha-macos-overflow.test.mjs
+++ b/scripts/alpha-macos-overflow.test.mjs
@@ -476,7 +476,7 @@ test('workflow contract keeps candidates exact-source, independent, and publish-
   );
   assert.match(
     affectedNativeWorkflow,
-    /source_acceptance:[\s\S]*uses: kungfu-systems\/buildchain\/\.github\/workflows\/check\.yml@a2637a8bb7869faa1d239b04ee6ded3a1c1318b1[\s\S]*buildchain-ref: a2637a8bb7869faa1d239b04ee6ded3a1c1318b1[\s\S]*source-proof-reuse: true[\s\S]*source-proof-policy-paths-json: '\["\.github\/workflows\/affected-native-pr\.yml"\]'[\s\S]*source-proof-closure-paths-json: '\["\.buildchain\/buildchain\.toml","shifu","scripts\/source-acceptance\.mjs","scripts\/require-shifu\.mjs"\]'[\s\S]*source-proof-dependency-paths-json: '\["package\.json","pnpm-lock\.yaml"\]'[\s\S]*source-proof-required-contexts-json: '\["Candidate source acceptance \/ check"\]'/u,
+    /source_acceptance:[\s\S]*uses: kungfu-systems\/buildchain\/\.github\/workflows\/check\.yml@4354638200137eb07d3272f4bcbce46131aea74c[\s\S]*buildchain-ref: 4354638200137eb07d3272f4bcbce46131aea74c[\s\S]*source-proof-reuse: true[\s\S]*source-proof-policy-paths-json: '\["\.github\/workflows\/affected-native-pr\.yml"\]'[\s\S]*source-proof-closure-paths-json: '\["\.buildchain\/buildchain\.toml","shifu","scripts\/source-acceptance\.mjs","scripts\/require-shifu\.mjs"\]'[\s\S]*source-proof-dependency-paths-json: '\["package\.json","pnpm-lock\.yaml"\]'[\s\S]*source-proof-required-contexts-json: '\["Candidate source acceptance \/ check"\]'/u,
   );
   assert.match(
     affectedNativeWorkflow,


### PR DESCRIPTION
## Summary

- Enable exact accepted PR source-proof reuse for the required merge-group source-acceptance gate.
- Pin the reusable Buildchain action and runtime to protected v4 merge `4354638200137eb07d3272f4bcbce46131aea74c`.
- Fail closed to full source acceptance whenever proof, source, base, policy, closure, dependency, toolchain, plan, or required-context predicates drift.
- Preserve approval, Warrant, queue-admission, merge, publication, and release authority unchanged.

This PR is the latest-base linear successor to #3095; it contains the same narrow change plus regenerated KFD evidence roots required by the current protected base.

## Assignment

Native Assignment `2026-08-12-kungfu-merge-group-source-proof-reuse` under initiative `2026-07-28-kungfu-go-family-continuous-delivery`.

## Exact delivery coordinates

- Base at validation: `001a3764e55191e1430ff21a772f5ecbcdff6d8f`
- Head: `2a49001427e1d242f5790e39d39b410d276a10fc`
- Work admission: `sha256:345e413b777c828997b3bc915ae256cd7103bb3b8031ea003fad77e9ce8f1b1c`
- Buildchain protected v4 merge: `4354638200137eb07d3272f4bcbce46131aea74c`

## Verification

- Latest-base source main suite: 1140 total Node tests, 1129 passed, 11 explicitly skipped, 0 failed.
- `./shifu check:gate-catalog`: 38 gates, 7 profiles, 28 invocations, 38 workflows.
- Dev required Gate latency contracts: 75/75.
- `./shifu test:alpha-macos-overflow`: 14/14.
- KFD evidence, support matrix, generated governance roots, staged gate, and diff hygiene passed.
- Protected hosted source qualification remains required before queue admission.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"This is a bounded dev delivery latency regression repair: it changes proof consumption and generated evidence bindings without changing any accepted ADR record or implementation status."}
-->

## Evolution Map impact

Evolution impact: extends

The affected-native workflow consumes the protected Buildchain exact-proof reuse contract; existing delivery authority and publication surfaces remain unchanged.

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Boundary: this only reuses exact successful source evidence inside the merge-group required check. Any mismatch executes the full source path. It does not weaken review, Warrant, queue-admission, merge, publication, or release authority.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Workflow contracts, generated governance facts, and documentation are updated

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6IjIwMjYtMDctMjgta3VuZ2Z1LWdvLWZhbWlseS1jb250aW51b3VzLWRlbGl2ZXJ5IiwiYXNzaWdubWVudElkIjoiMjAyNi0wOC0xMi1rdW5nZnUtbWVyZ2UtZ3JvdXAtc291cmNlLXByb29mLXJldXNlIiwiZGVsaXZlcnlDbGFzcyI6Im5hdGl2ZS1wcm9vZi1yZXF1aXJlZCIsImRldkhlYWQiOiIwMDFhMzc2NGU1NTE5MWUxNDMwZmYyMWE3NzJmNWVjYmNkZmY2ZDhmIiwicHVsbFJlcXVlc3RIZWFkIjoiMmE0OTAwMTQyN2UxZDI0MmY1NzkwZTM5ZDM5YjQxMGQyNzZhMTBmYyIsInJlcGxheWVkQ2FuZGlkYXRlIjoiMGM2M2IyZmQxNzI0M2FkODAyNWQ1ZDUxMjI0YTg3ZWY5ZWQ0MGU4ZCIsInJlcGxheWVkVHJlZSI6ImQzZmU3YjM3N2EzYTVkYTYwMGZkMGU0NjY0MzNkYzg5NzE2OWY0ZGIiLCJxdWV1ZUF0dGVtcHQiOiIyYTQ5MDAxNDI3ZTFkMjQyZjU3OTBlMzlkMzliNDEwZDI3NmExMGZjQDAwMWEzNzY0ZTU1MTkxZTE0MzBmZjIxYTc3MmY1ZWNiY2RmZjZkOGYiLCJhZG1pc3Npb25Qcm9vZlJvb3QiOiJzaGEyNTY6M2Q1YjZmNTMyMWM0MTQxMmQ2NjUwZDJiMDI2YWU0Yjc0MGVhMzE1MTQ2ZmY2NGI2ODI1MzVkYTlmZGJiY2M1NCIsImFkbWlzc2lvblByb29mUm9vdHMiOlsic2hhMjU2OjNkNWI2ZjUzMjFjNDE0MTJkNjY1MGQyYjAyNmFlNGI3NDBlYTMxNTE0NmZmNjRiNjgyNTM1ZGE5ZmRiYmNjNTQiLCJzaGEyNTY6NmU1YTIwNDNjOTMyN2NiNzMxYjJjZjhmYjU0MGYyZjQ2ZmJlMjg3MGQ5NjQwNDAyYmE4MzcxY2ZiYzhkOGRmZCIsInNoYTI1NjplNWMwMzcwYjJmMjNlYTZkZDdlMGY3ZDY3OGI3ZDYwMjkwNjBmMmEwMGFkZjMzZDIxZDg4YzkwMjBiYWJkNTU3Il0sInN0YXR1c0NvbnRleHQiOiJRdWV1ZSBmYW1pbHkgbGVhc2UvZWNhYzY3YmNlYmZhZTNiZiIsImxlYXNlUm9vdCI6InNoYTI1Njo0YjFlZGMyNjIxYmY2N2Y0YWJhZDIyNjRkODA5NWE5NjliNDc5YmMwZGVmNzY0ZGVkMTE3ZTAyY2UxNjk2MzU4In0 -->