### PR TITLE
feat(dev-delivery): reuse exact source proof in merge groups

### DIFF
--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.1",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.1",
-    "sourceSha": "2223a1d9a1e7485340451cddb07a72f05ed6c54f"
+    "sourceSha": "e55f66aa86b11781bbf15245695b432bd5a52062"
   },
   "claims": [
     {

--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.1",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.1",
-    "sourceSha": "001a3764e55191e1430ff21a772f5ecbcdff6d8f"
+    "sourceSha": "2223a1d9a1e7485340451cddb07a72f05ed6c54f"
   },
   "claims": [
     {

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "001a3764e55191e1430ff21a772f5ecbcdff6d8f",
+    "sourceSha": "2223a1d9a1e7485340451cddb07a72f05ed6c54f",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:688886d29ec7be1d63b4a7cf6d4c8354ce1e025a885d0b84af137e409df107df"
   },

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "2223a1d9a1e7485340451cddb07a72f05ed6c54f",
+    "sourceSha": "e55f66aa86b11781bbf15245695b432bd5a52062",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:688886d29ec7be1d63b4a7cf6d4c8354ce1e025a885d0b84af137e409df107df"
   },

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:d544bee1aec2e204310695b32782106b148d15af875592d202dcc7f04f5e2a3b"
+            "sha256": "sha256:45be3a6c86f6f8471a216730baeef82696680d0f003cb79cc0e31398fd6a5613"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:45be3a6c86f6f8471a216730baeef82696680d0f003cb79cc0e31398fd6a5613"
+            "sha256": "sha256:51c13274619baa7832d4bacc49fa9bb5c359d7a2b525ccfc247a6c7429732c09"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/.github/workflows/affected-native-pr.yml
+++ b/.github/workflows/affected-native-pr.yml
@@ -70,11 +70,16 @@ jobs:
 
   source_acceptance:
     name: Candidate source acceptance
-    uses: kungfu-systems/buildchain/.github/workflows/check.yml@58e48d73ae7fef0dd06ae02baf6d090e4da5487d
+    uses: kungfu-systems/buildchain/.github/workflows/check.yml@4354638200137eb07d3272f4bcbce46131aea74c
     with:
-      buildchain-ref: 58e48d73ae7fef0dd06ae02baf6d090e4da5487d
+      buildchain-ref: 4354638200137eb07d3272f4bcbce46131aea74c
       mode: source
       upload-artifacts: true
+      source-proof-reuse: true
+      source-proof-policy-paths-json: '[".github/workflows/affected-native-pr.yml"]'
+      source-proof-closure-paths-json: '[".buildchain/buildchain.toml","shifu","scripts/source-acceptance.mjs","scripts/require-shifu.mjs"]'
+      source-proof-dependency-paths-json: '["package.json","pnpm-lock.yaml"]'
+      source-proof-required-contexts-json: '["Candidate source acceptance / check"]'
 
   cancel_after_source_failure:
     name: Stop selected lanes after source failure

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.1",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.1",
-    "sourceSha": "2223a1d9a1e7485340451cddb07a72f05ed6c54f"
+    "sourceSha": "e55f66aa86b11781bbf15245695b432bd5a52062"
   },
   "claims": [
     {

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.1",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.1",
-    "sourceSha": "001a3764e55191e1430ff21a772f5ecbcdff6d8f"
+    "sourceSha": "2223a1d9a1e7485340451cddb07a72f05ed6c54f"
   },
   "claims": [
     {

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:d544bee1aec2e204310695b32782106b148d15af875592d202dcc7f04f5e2a3b"
+            "sha256": "sha256:45be3a6c86f6f8471a216730baeef82696680d0f003cb79cc0e31398fd6a5613"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:45be3a6c86f6f8471a216730baeef82696680d0f003cb79cc0e31398fd6a5613"
+            "sha256": "sha256:51c13274619baa7832d4bacc49fa9bb5c359d7a2b525ccfc247a6c7429732c09"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/docs/qualification/gates/source-and-governance.md
+++ b/docs/qualification/gates/source-and-governance.md
@@ -18,7 +18,7 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Evidence:** unified Gate receipt; no separate artifact is currently required.
 - **Diagnosis:** `./shifu gate explain gate.catalog --profile <profile>`; reproduce with `./shifu gate run gate.catalog` on a capable runner.
 - **Cost:** light; timeout 600 seconds.
-- **Current source:** .github/workflows/affected-native-pr.yml (source_acceptance; every dev pull request and merge-group candidate inside the staged required aggregate); .github/workflows/dev-verify-patrol.yml (verify; daily or manual on dev); .github/workflows/build.yml (build; alpha or release pull request, or a manual exact-source publish-none macOS candidate under the queue-aware overflow controller); .github/workflows/release-new-version.yml (promotion-contract; merged alpha or release pull request, or manual source-locked dry-run measurement); .github/workflows/publish-layer-artifacts.yml (verify-publication; manually executed public layer publication)
+- **Current source:** .github/workflows/affected-native-pr.yml (source_acceptance; every dev pull request and merge-group candidate inside the staged required aggregate; an exact accepted pull-request proof may satisfy merge-group source acceptance only when source, base movement, policy, closure, dependency, runtime, required-context, and controller-receipt predicates all match, otherwise the full source gate runs); .github/workflows/dev-verify-patrol.yml (verify; daily or manual on dev); .github/workflows/build.yml (build; alpha or release pull request, or a manual exact-source publish-none macOS candidate under the queue-aware overflow controller); .github/workflows/release-new-version.yml (promotion-contract; merged alpha or release pull request, or manual source-locked dry-run measurement); .github/workflows/publish-layer-artifacts.yml (verify-publication; manually executed public layer publication)
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:gate.catalog -->
 
@@ -73,9 +73,18 @@ Each section is bound to the registry id by the catalog meta gate.
 - **Diagnosis:** `./shifu gate explain source.acceptance --profile <profile>`; reproduce with `./shifu gate run source.acceptance` on a capable runner.
 - **Cost:** light; timeout 1800 seconds. This budget covers cold shared-runner
   Project Cut composition while retaining a bounded failure signal.
-- **Current source:** .github/workflows/affected-native-pr.yml (source_acceptance; every dev pull request and merge-group candidate inside the staged required aggregate). The standalone .github/workflows/source-acceptance.yml is manual-only.
+- **Current source:** .github/workflows/affected-native-pr.yml (source_acceptance; every dev pull request and merge-group candidate inside the staged required aggregate; an exact accepted pull-request proof may satisfy merge-group source acceptance only when source, base movement, policy, closure, dependency, runtime, required-context, and controller-receipt predicates all match, otherwise the full source gate runs). The standalone .github/workflows/source-acceptance.yml is manual-only.
 - **Retirement:** remove only after every selecting profile and workflow binding is migrated or explicitly replaced, with the registry and matrix changed in the same review.
 <!-- /gate-doc:source.acceptance -->
+
+The pull-request run seals an exact Buildchain source-qualification proof. A
+merge-group run may reuse it only when the source head, merge composition,
+protected-base movement, source-policy and execution-closure paths, dependency
+inputs, Buildchain runtime, required context, and controller receipt all match.
+The reused lifecycle remains explicit that the source command was not executed
+again. Missing or stale evidence, an unknown base delta, path overlap, or any
+predicate mismatch fails closed to the full `./shifu check:source` path; proof
+reuse does not grant approval, Warrant, queue, merge, or publication authority.
 
 <a id="source-changed-scope"></a>
 <!-- gate-doc:source.changed-scope -->

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -146,9 +146,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:959385f0d70ee1a9d092e6a9a0c4884329f73c6f9b270aa333c374bbad1161b0",
+          "definitionDigest": "sha256:38076a7d83487042470943ca2611d43422bf909083112a7b1c9dfb2fbfcd9139",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/check.yml@58e48d73ae7fef0dd06ae02baf6d090e4da5487d"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/check.yml@4354638200137eb07d3272f4bcbce46131aea74c"],
           "steps": []
         },
         {

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -61,15 +61,20 @@
         "gate.catalog",
         "source.acceptance"
       ],
-      "activation": "every dev pull request and merge-group candidate inside the staged required aggregate",
+      "activation": "every dev pull request and merge-group candidate inside the staged required aggregate; an exact accepted pull-request proof may satisfy merge-group source acceptance only when source, base movement, policy, closure, dependency, runtime, required-context, and controller-receipt predicates all match, otherwise the full source gate runs",
       "adapter": {
         "type": "buildchain-source",
         "kind": "job-uses",
-    "uses": "kungfu-systems/buildchain/.github/workflows/check.yml@58e48d73ae7fef0dd06ae02baf6d090e4da5487d",
-    "with": {
-      "buildchain-ref": "58e48d73ae7fef0dd06ae02baf6d090e4da5487d",
+        "uses": "kungfu-systems/buildchain/.github/workflows/check.yml@4354638200137eb07d3272f4bcbce46131aea74c",
+        "with": {
+          "buildchain-ref": "4354638200137eb07d3272f4bcbce46131aea74c",
           "mode": "source",
-          "upload-artifacts": true
+          "upload-artifacts": true,
+          "source-proof-reuse": true,
+          "source-proof-policy-paths-json": "[\".github/workflows/affected-native-pr.yml\"]",
+          "source-proof-closure-paths-json": "[\".buildchain/buildchain.toml\",\"shifu\",\"scripts/source-acceptance.mjs\",\"scripts/require-shifu.mjs\"]",
+          "source-proof-dependency-paths-json": "[\"package.json\",\"pnpm-lock.yaml\"]",
+          "source-proof-required-contexts-json": "[\"Candidate source acceptance / check\"]"
         }
       }
     },

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -80,7 +80,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:096baffb33982b1a16b97cea094c461f864486506d2b2aea6768e3251cf37d28"
+          "sourceRoot": "sha256:6d18f041472ab0df6b6b9365f0421ab8a40f6664a9f38811844a56be70b3b869"
         },
         {
           "path": ".github/workflows/dev-post-merge-advisory.yml",
@@ -874,5 +874,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:fbeb9496738381984393d1a402bb13512589ac785eb34ec0765fef94cfbd666f"
+  "registryRoot": "sha256:65c9e99ef97e920dfc0df96401f4a2f6d7acbdd3b064ccd2edd088f453d864c7"
 }

--- a/scripts/alpha-macos-overflow.test.mjs
+++ b/scripts/alpha-macos-overflow.test.mjs
@@ -476,7 +476,7 @@ test('workflow contract keeps candidates exact-source, independent, and publish-
   );
   assert.match(
     affectedNativeWorkflow,
-    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/check\.yml@58e48d73ae7fef0dd06ae02baf6d090e4da5487d[\s\S]*buildchain-ref: 58e48d73ae7fef0dd06ae02baf6d090e4da5487d/u,
+    /source_acceptance:[\s\S]*uses: kungfu-systems\/buildchain\/\.github\/workflows\/check\.yml@4354638200137eb07d3272f4bcbce46131aea74c[\s\S]*buildchain-ref: 4354638200137eb07d3272f4bcbce46131aea74c[\s\S]*source-proof-reuse: true[\s\S]*source-proof-policy-paths-json: '\["\.github\/workflows\/affected-native-pr\.yml"\]'[\s\S]*source-proof-closure-paths-json: '\["\.buildchain\/buildchain\.toml","shifu","scripts\/source-acceptance\.mjs","scripts\/require-shifu\.mjs"\]'[\s\S]*source-proof-dependency-paths-json: '\["package\.json","pnpm-lock\.yaml"\]'[\s\S]*source-proof-required-contexts-json: '\["Candidate source acceptance \/ check"\]'/u,
   );
   assert.match(
     affectedNativeWorkflow,


### PR DESCRIPTION
## Summary

- Enable exact accepted PR source-proof reuse for the required merge-group source-acceptance gate.
- Pin the reusable Buildchain action and runtime to protected v4 merge `4354638200137eb07d3272f4bcbce46131aea74c`.
- Fail closed to full source acceptance whenever proof, source, base, policy, closure, dependency, toolchain, plan, or required-context predicates drift.
- Preserve approval, Warrant, queue-admission, merge, publication, and release authority unchanged.

This PR is the latest-base linear successor to closed #3106. It rebuilds the same narrow semantic change directly on the current protected Dev base, adds the newly required publication-control-plane root closure, and contains no historical replay conflict.

## Assignment

Native Assignment `2026-08-12-kungfu-merge-group-source-proof-reuse` under initiative `2026-07-28-kungfu-go-family-continuous-delivery`.

## Exact delivery coordinates

- Base at validation: `df271a2e6fac2c7efdf6f54b13d4c836d4325b33`
- Head: `5fad92b293a0eed8c9cc5b872e513f27f9ab8f44`
- Work admission: `sha256:199bd7bd6f205f50183d3be712db0d501a11263c9e760db22d65885b507951f0`
- Buildchain protected v4 merge: `4354638200137eb07d3272f4bcbce46131aea74c`

## Verification

- `./shifu project-cut:queue-admission -- --base df271a2e6fac2c7efdf6f54b13d4c836d4325b33 --head HEAD`: qualified, 4 replayed commits, zero diagnostics.
- `./shifu check:source`: 1140 total Node tests, 1129 passed, 11 explicitly skipped, 0 failed; Phase B Python, Agent Work, runtime upgrade, desktop update, tooling typecheck, formatting, and zero-write checks also passed.
- Dev required Gate latency contracts: 75/75.
- Kungfu invariant system: 18/18.
- KFD evidence and support matrix checks passed.
- Release publication control plane: 38 workflows, 10 surfaces, qualifying.
- Protected hosted source qualification remains required before queue admission.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"This is a bounded dev delivery latency regression repair: it changes proof consumption and generated evidence bindings without changing any accepted ADR record or implementation status."}
-->

## Evolution Map impact

Evolution impact: extends

The affected-native workflow consumes the protected Buildchain exact-proof reuse contract; existing delivery authority and publication surfaces remain unchanged.

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Boundary: this only reuses exact successful source evidence inside the merge-group required check. Any mismatch executes the full source path. It does not weaken review, Warrant, queue-admission, merge, publication, or release authority.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Workflow contracts, generated governance facts, publication roots, and documentation are updated