### PR TITLE
perf(dev-delivery): bind exact PR-head source proof

### DIFF
--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.1",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.1",
-    "sourceSha": "fa3b82ce07f1e8701ebce92db0c9d36d890e87ca"
+    "sourceSha": "8c19040fdb8f25935ea3d28f82ec38f0ff27adcf"
   },
   "claims": [
     {

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "fa3b82ce07f1e8701ebce92db0c9d36d890e87ca",
+    "sourceSha": "8c19040fdb8f25935ea3d28f82ec38f0ff27adcf",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:688886d29ec7be1d63b4a7cf6d4c8354ce1e025a885d0b84af137e409df107df"
   },

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:3923e2fae2593aca648226ebf28ef099639868ee1fcd0c6f8a62a5a2b9c73720"
+            "sha256": "sha256:db371415d32cada468aae3637e956d7075308a39a5ff7368188d8041c353b4be"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/.github/workflows/affected-native-pr.yml
+++ b/.github/workflows/affected-native-pr.yml
@@ -76,9 +76,9 @@ jobs:
 
   source_acceptance:
     name: Candidate source acceptance
-    uses: kungfu-systems/buildchain/.github/workflows/check.yml@4354638200137eb07d3272f4bcbce46131aea74c
+    uses: kungfu-systems/buildchain/.github/workflows/check.yml@fb0ad6d84f10a1f9b872a799e035232d82558bd0
     with:
-      buildchain-ref: 4354638200137eb07d3272f4bcbce46131aea74c
+      buildchain-ref: fb0ad6d84f10a1f9b872a799e035232d82558bd0
       mode: source
       upload-artifacts: true
       source-proof-reuse: true

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.1",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.1",
-    "sourceSha": "fa3b82ce07f1e8701ebce92db0c9d36d890e87ca"
+    "sourceSha": "8c19040fdb8f25935ea3d28f82ec38f0ff27adcf"
   },
   "claims": [
     {

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:3923e2fae2593aca648226ebf28ef099639868ee1fcd0c6f8a62a5a2b9c73720"
+            "sha256": "sha256:db371415d32cada468aae3637e956d7075308a39a5ff7368188d8041c353b4be"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -146,9 +146,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:38076a7d83487042470943ca2611d43422bf909083112a7b1c9dfb2fbfcd9139",
+          "definitionDigest": "sha256:0143fcf52f42df0daa42860bc1d9148af6a7f309c81022c42982f9807d47320c",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/check.yml@4354638200137eb07d3272f4bcbce46131aea74c"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/check.yml@fb0ad6d84f10a1f9b872a799e035232d82558bd0"],
           "steps": []
         },
         {

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -65,9 +65,9 @@
       "adapter": {
         "type": "buildchain-source",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/check.yml@4354638200137eb07d3272f4bcbce46131aea74c",
+        "uses": "kungfu-systems/buildchain/.github/workflows/check.yml@fb0ad6d84f10a1f9b872a799e035232d82558bd0",
         "with": {
-          "buildchain-ref": "4354638200137eb07d3272f4bcbce46131aea74c",
+          "buildchain-ref": "fb0ad6d84f10a1f9b872a799e035232d82558bd0",
           "mode": "source",
           "upload-artifacts": true,
           "source-proof-reuse": true,

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -80,7 +80,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:698a614c0d65b19b177bdb056f3d9c90c9520266cf5d7f999e82bd5aeed37e20"
+          "sourceRoot": "sha256:2a29f4a296292e77c53bbc7d3c2536c76f6e4fbbbfd1c547ae6d575c90e23162"
         },
         {
           "path": ".github/workflows/dev-post-merge-advisory.yml",
@@ -874,5 +874,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:dc6f0ebca4602520772a633e4941c0cb107cb3fcfcf0cffcfa5206f0ec3073a6"
+  "registryRoot": "sha256:3bcb9211b58d7fae4402c942b3beefee98cb937b191ae51cb5ab673687828965"
 }

--- a/scripts/alpha-macos-overflow.test.mjs
+++ b/scripts/alpha-macos-overflow.test.mjs
@@ -476,7 +476,7 @@ test('workflow contract keeps candidates exact-source, independent, and publish-
   );
   assert.match(
     affectedNativeWorkflow,
-    /source_acceptance:[\s\S]*uses: kungfu-systems\/buildchain\/\.github\/workflows\/check\.yml@4354638200137eb07d3272f4bcbce46131aea74c[\s\S]*buildchain-ref: 4354638200137eb07d3272f4bcbce46131aea74c[\s\S]*source-proof-reuse: true[\s\S]*source-proof-policy-paths-json: '\["\.github\/workflows\/affected-native-pr\.yml"\]'[\s\S]*source-proof-closure-paths-json: '\["\.buildchain\/buildchain\.toml","shifu","scripts\/source-acceptance\.mjs","scripts\/require-shifu\.mjs"\]'[\s\S]*source-proof-dependency-paths-json: '\["package\.json","pnpm-lock\.yaml"\]'[\s\S]*source-proof-required-contexts-json: '\["Candidate source acceptance \/ check"\]'/u,
+    /source_acceptance:[\s\S]*uses: kungfu-systems\/buildchain\/\.github\/workflows\/check\.yml@fb0ad6d84f10a1f9b872a799e035232d82558bd0[\s\S]*buildchain-ref: fb0ad6d84f10a1f9b872a799e035232d82558bd0[\s\S]*source-proof-reuse: true[\s\S]*source-proof-policy-paths-json: '\["\.github\/workflows\/affected-native-pr\.yml"\]'[\s\S]*source-proof-closure-paths-json: '\["\.buildchain\/buildchain\.toml","shifu","scripts\/source-acceptance\.mjs","scripts\/require-shifu\.mjs"\]'[\s\S]*source-proof-dependency-paths-json: '\["package\.json","pnpm-lock\.yaml"\]'[\s\S]*source-proof-required-contexts-json: '\["Candidate source acceptance \/ check"\]'/u,
   );
   assert.match(
     affectedNativeWorkflow,


### PR DESCRIPTION
## Summary

- Pin the reusable Buildchain proof producer and consumer to protected merge fb0ad6d84f10a1f9b872a799e035232d82558bd0, which binds pull-request proof checkout to the true PR head SHA.
- Regenerate the KFD and publication roots for that exact runtime binding.
- Preserve fail-closed fallback to the full source gate whenever exact proof identity or policy predicates drift.
- Preserve approval, Warrant, queue-admission, merge, publication, and release authority unchanged.

This is the fresh protected-base successor after #3123 safely merged through the full fallback path. Its hosted merge-group canary must now prove that the exact PR-head artifact is located, downloaded, and verified, with the install/check lifecycle skipped.

## Assignment

Native Assignment 2026-08-12-kungfu-merge-group-source-proof-reuse under initiative 2026-07-28-kungfu-go-family-continuous-delivery.

## Exact delivery coordinates

- Base at validation: d94e34e110293c3223e709a709dd2561052ca1c2
- Head: 685a740668e16827b10e14df64164f57ba0e10b9
- Work admission: sha256:fac4734035694ab9a8901c9e3cd03176fe55d48da46d55c05100cb96c45486b9
- Buildchain protected v4 merge: fb0ad6d84f10a1f9b872a799e035232d82558bd0

## Verification

- ./shifu project-cut:queue-admission -- --base d94e34e110293c3223e709a709dd2561052ca1c2 --head HEAD: qualified, 2 replayed commits, zero diagnostics.
- ./shifu check:source: passed at exact head, including Python Agent Work 40/40, runtime upgrade 134/134, desktop update adapter 73/73, tooling typecheck, changed-source format, and zero-write validation.
- Focused affected-native workflow and authority contracts: 27/27.
- KFD evidence, support matrix, and release publication roots regenerated and validated.
- Protected hosted exact-head source qualification remains required before Warrant admission.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"This is a bounded dev delivery latency regression repair: it changes exact proof producer bindings and generated evidence roots without changing any accepted ADR record or implementation status."}
-->

## Evolution Map impact

Evolution impact: extends

The affected-native workflow consumes the protected Buildchain exact-PR-head proof contract; existing delivery authority and publication surfaces remain unchanged.

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Boundary: this only reuses an exact successful pull-request source proof inside the merge-group required check. Any mismatch executes the full source path. It does not weaken review, Warrant, queue-admission, merge, publication, or release authority.

## Checklist

- [x] Commits are signed off
- [x] Workflow contracts, generated governance facts, publication roots, and tests are updated
