### PR TITLE
feat(release): make workflows topology neutral

### DIFF
--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.1",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.1",
-    "sourceSha": "234f02927d4f5851efe6f899c0d2b117f0778e94"
+    "sourceSha": "5b323be43af712622fb55c75dc4e9798742a625f"
   },
   "claims": [
     {

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "234f02927d4f5851efe6f899c0d2b117f0778e94",
+    "sourceSha": "5b323be43af712622fb55c75dc4e9798742a625f",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:688886d29ec7be1d63b4a7cf6d4c8354ce1e025a885d0b84af137e409df107df"
   },

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:78aefe86ab915c265cd7c1683e2684d0f15b1a52ea8765c5e49e86aec9b37bbe"
+            "sha256": "sha256:f981811de4ffaf52e205378b6ba15cc0ab674d06ccde4d67df2e5360caac4a1f"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/.github/workflows/affected-native-pr.yml
+++ b/.github/workflows/affected-native-pr.yml
@@ -76,9 +76,9 @@ jobs:
 
   source_acceptance:
     name: Candidate source acceptance
-    uses: kungfu-systems/buildchain/.github/workflows/check.yml@4354638200137eb07d3272f4bcbce46131aea74c
+    uses: kungfu-systems/buildchain/.github/workflows/check.yml@fb0ad6d84f10a1f9b872a799e035232d82558bd0
     with:
-      buildchain-ref: 4354638200137eb07d3272f4bcbce46131aea74c
+      buildchain-ref: fb0ad6d84f10a1f9b872a799e035232d82558bd0
       mode: source
       upload-artifacts: true
       source-proof-reuse: true

--- a/.github/workflows/dev-alpha-candidate-patrol.yml
+++ b/.github/workflows/dev-alpha-candidate-patrol.yml
@@ -123,8 +123,14 @@ jobs:
           dev_cut_tree="$(jq -er '.devCut.tree' "$lock")"
           alpha_base_sha="$(jq -er '.alphaBase.sha' "$lock")"
           alpha_base_tree="$(jq -er '.alphaBase.tree' "$lock")"
-          test "$(jq -erc '.lineage.parentOrder' "$lock")" = "[\"$dev_cut_sha\",\"$alpha_base_sha\"]"
-          test "$(git show -s --format=%P "$candidate_sha")" = "$dev_cut_sha $alpha_base_sha"
+          legacy_parent_order="$(jq -erc '.lineage.parentOrder' "$lock")"
+          observed_parent_order="$(git show -s --format=%P "$candidate_sha")"
+          if [ "$legacy_parent_order" = "[\"$dev_cut_sha\",\"$alpha_base_sha\"]" ] &&
+             [ "$observed_parent_order" = "$dev_cut_sha $alpha_base_sha" ]; then
+            echo "::notice::legacy Alpha.2 two-parent projection matches the retained lock"
+          else
+            echo "::notice::legacy Alpha.2 parent projection drifted; semantic candidate admission remains root-authoritative"
+          fi
           test "$(git rev-parse "$candidate_sha^{tree}")" = "$candidate_tree"
           test "$(git rev-parse "$dev_cut_sha^{tree}")" = "$dev_cut_tree"
           test "$(git rev-parse "$alpha_base_sha^{tree}")" = "$alpha_base_tree"
@@ -183,6 +189,7 @@ jobs:
     outputs:
       object-root: ${{ steps.provenance.outputs.object-root }}
       projection-root: ${{ steps.provenance.outputs.projection-root }}
+      candidate-commit: ${{ steps.provenance.outputs.candidate-commit }}
     steps:
       - name: Check out exact selected candidate source
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -212,6 +219,13 @@ jobs:
           dev_cut_tree="$(git rev-parse "$SELECTED_SHA^{tree}")"
           previous_alpha_sha="$(git rev-parse refs/remotes/origin/provenance-previous-alpha)"
           previous_alpha_tree="$(git rev-parse "$previous_alpha_sha^{tree}")"
+          source_content="$(
+            PYTHONPATH=framework/core/src/python python3 scripts/release-provenance-object.py source-content \
+              --repository . \
+              --revision "$candidate_sha"
+          )"
+          source_content_algorithm="$(jq -er '.algorithm' <<<"$source_content")"
+          source_content_digest="$(jq -er '.digest' <<<"$source_content")"
           observed_parent_args=()
           for parent in $(git show -s --format=%P "$candidate_sha"); do
             observed_parent_args+=(--observed-parent "$parent")
@@ -222,9 +236,11 @@ jobs:
             --arg priorStateRoot "$QUALIFICATION_STATE_ROOT" \
             '{selectedSha: $selectedSha, sourceLockRef: $sourceLockRef, priorStateRoot: $priorStateRoot}' \
             > "$output_dir/candidate-legacy-projection.json"
-          PYTHONPATH=framework/core/src/python python3 scripts/release-provenance-object.py candidate \
+          PYTHONPATH=framework/core/src/python python3 scripts/release-provenance-object.py candidate-v2 \
             --release-id "$RELEASE_ID" \
             --candidate-id "release-candidate:$RELEASE_ID:$QUALIFICATION_STATE_ROOT" \
+            --source-content-algorithm "$source_content_algorithm" \
+            --source-content-digest "$source_content_digest" \
             --candidate-commit "$candidate_sha" \
             --candidate-tree "$candidate_tree" \
             --dev-cut-commit "$SELECTED_SHA" \
@@ -234,10 +250,9 @@ jobs:
             --previous-alpha-tree "$previous_alpha_tree" \
             --previous-alpha-id "release-cut:$RELEASE_ID:previous-alpha:$QUALIFICATION_STATE_ROOT" \
             --qualification-id "buildchain-candidate-patrol:$SELECTED_SHA:$QUALIFICATION_STATE_ROOT" \
+            --approval-id "protected-review-policy:${GITHUB_REPOSITORY}:$TARGET_BRANCH" \
             --authority-id "${GITHUB_REPOSITORY}:.github/workflows/dev-alpha-candidate-patrol.yml" \
             --contract-file framework/release/kungfu-release-provenance.contract.json \
-            --legacy-projection "$output_dir/candidate-legacy-projection.json" \
-            --advisory-parentage \
             "${observed_parent_args[@]}" \
             --output "$output_dir/candidate.json" \
             > "$output_dir/candidate-write-receipt.json"
@@ -245,11 +260,12 @@ jobs:
             --input "$output_dir/candidate.json"
           echo "object-root=$(jq -er '.objectRoot' "$output_dir/candidate.json")" >> "$GITHUB_OUTPUT"
           echo "projection-root=$(jq -er '.gitProjectionRoot' "$output_dir/candidate.json")" >> "$GITHUB_OUTPUT"
+          echo "candidate-commit=$candidate_sha" >> "$GITHUB_OUTPUT"
 
       - name: Retain candidate provenance evidence
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: release-provenance-candidate-${{ needs.candidate.outputs.selected-sha }}
+          name: release-provenance-candidate-${{ steps.provenance.outputs.candidate-commit }}
           path: ${{ runner.temp }}/release-provenance
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: ""
         type: string
+      candidate-provenance-run-id:
+        description: "Optional exact successful candidate-patrol run for a retained legacy provenance object"
+        required: false
+        default: ""
+        type: string
       resume-candidate-repository:
         description: "Exact repository that owns an existing sealed candidate run"
         required: false
@@ -97,6 +102,12 @@ jobs:
       promotion-sha: ${{ steps.candidate.outputs.promotion-sha }}
       promotion-tree: ${{ steps.promotion-tree.outputs.tree }}
       candidate-provenance-root: ${{ steps.candidate-provenance.outputs.object-root }}
+      candidate-content-root: ${{ steps.candidate-provenance.outputs.content-root }}
+      candidate-dev-cut-root: ${{ steps.candidate-provenance.outputs.dev-cut-root }}
+      candidate-previous-alpha-root: ${{ steps.candidate-provenance.outputs.previous-alpha-root }}
+      candidate-qualification-root: ${{ steps.candidate-provenance.outputs.qualification-root }}
+      candidate-approval-root: ${{ steps.candidate-provenance.outputs.approval-root }}
+      candidate-authority-root: ${{ steps.candidate-provenance.outputs.authority-root }}
       promotion-provenance-root: ${{ steps.promotion-provenance.outputs.object-root }}
     steps:
       - name: Resolve immutable Alpha candidate and promotion commits
@@ -132,55 +143,106 @@ jobs:
           source-sha: ${{ steps.candidate.outputs.source-sha }}
           receipt-run-id: ${{ inputs.preflight-run-id || '' }}
 
-      - name: Dual-write immutable candidate provenance
+      - name: Resolve exact candidate provenance evidence
+        id: candidate-provenance-artifact
+        if: ${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE_SHA: ${{ steps.candidate.outputs.source-sha }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          REQUESTED_RUN_ID: ${{ inputs.candidate-provenance-run-id || '' }}
+        run: |
+          set -euo pipefail
+          run_id="$REQUESTED_RUN_ID"
+          artifact_name="release-provenance-candidate-$CANDIDATE_SHA"
+          if [ -n "$run_id" ]; then
+            artifact_name="$(
+              gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts?per_page=100" \
+                --jq '[.artifacts[] | select(.expired == false and (.name | startswith("release-provenance-candidate-")))] | if length == 1 then .[0].name else empty end'
+            )"
+          else
+            run_id="$(
+              gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=${artifact_name}&per_page=100" \
+                --jq '[.artifacts[] | select(.expired == false)] | sort_by(.created_at, .id) | last | .workflow_run.id // empty'
+            )"
+          fi
+          test -n "$run_id"
+          test -n "$artifact_name"
+          run_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}")"
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg defaultBranch "$DEFAULT_BRANCH" \
+            '.conclusion == "success" and
+             .path == ".github/workflows/dev-alpha-candidate-patrol.yml" and
+             .head_repository.full_name == $repository and
+             .head_branch == $defaultBranch' \
+            <<<"$run_json" >/dev/null
+          {
+            echo "run-id=$run_id"
+            echo "artifact-name=$artifact_name"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Download exact candidate provenance evidence
+        if: ${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.candidate-provenance-artifact.outputs.run-id }}
+          name: ${{ steps.candidate-provenance-artifact.outputs.artifact-name }}
+          path: ${{ runner.temp }}/release-provenance
+
+      - name: Verify and import immutable candidate provenance
         id: candidate-provenance
         if: ${{ startsWith(inputs.target-ref || github.event.pull_request.base.ref, 'alpha/') }}
         shell: bash
         env:
-          RELEASE_ID: ${{ inputs.target-ref || github.event.pull_request.base.ref }}
           CANDIDATE_SHA: ${{ steps.candidate.outputs.source-sha }}
           CANDIDATE_TREE: ${{ steps.preflight.outputs.source-tree }}
-          PREFLIGHT_RECEIPT_ROOT: ${{ steps.preflight.outputs.receipt-root }}
-          PREFLIGHT_RUN_ID: ${{ steps.preflight.outputs.run-id }}
         run: |
           set -euo pipefail
           output_dir="$RUNNER_TEMP/release-provenance"
-          mkdir -p "$output_dir"
-          read -r -a candidate_parents <<<"$(git show -s --format=%P "$CANDIDATE_SHA")"
-          test "${#candidate_parents[@]}" -eq 2
-          dev_cut_sha="${candidate_parents[0]}"
-          previous_alpha_sha="${candidate_parents[1]}"
-          dev_cut_tree="$(git rev-parse "$dev_cut_sha^{tree}")"
-          previous_alpha_tree="$(git rev-parse "$previous_alpha_sha^{tree}")"
-          jq -n \
-            --arg sourceSha "$CANDIDATE_SHA" \
-            --arg sourceTree "$CANDIDATE_TREE" \
-            --arg preflightRunId "$PREFLIGHT_RUN_ID" \
-            --arg preflightReceiptRoot "$PREFLIGHT_RECEIPT_ROOT" \
-            '{sourceSha: $sourceSha, sourceTree: $sourceTree, preflightRunId: $preflightRunId, preflightReceiptRoot: $preflightReceiptRoot}' \
-            > "$output_dir/promotion-candidate-legacy-projection.json"
-          PYTHONPATH=framework/core/src/python python3 scripts/release-provenance-object.py candidate \
-            --release-id "$RELEASE_ID" \
-            --candidate-id "release-candidate:$RELEASE_ID:$PREFLIGHT_RECEIPT_ROOT" \
-            --candidate-commit "$CANDIDATE_SHA" \
-            --candidate-tree "$CANDIDATE_TREE" \
-            --dev-cut-commit "$dev_cut_sha" \
-            --dev-cut-tree "$dev_cut_tree" \
-            --dev-cut-id "release-cut:$RELEASE_ID:development:$PREFLIGHT_RECEIPT_ROOT" \
-            --previous-alpha-commit "$previous_alpha_sha" \
-            --previous-alpha-tree "$previous_alpha_tree" \
-            --previous-alpha-id "release-cut:$RELEASE_ID:previous-alpha:$PREFLIGHT_RECEIPT_ROOT" \
-            --qualification-root "$PREFLIGHT_RECEIPT_ROOT" \
-            --authority-id "${GITHUB_REPOSITORY}:.github/workflows/release-new-version.yml" \
-            --contract-file framework/release/kungfu-release-provenance.contract.json \
-            --legacy-projection "$output_dir/promotion-candidate-legacy-projection.json" \
-            --observed-parent "$dev_cut_sha" \
-            --observed-parent "$previous_alpha_sha" \
-            --output "$output_dir/candidate.json" \
-            > "$output_dir/candidate-write-receipt.json"
           PYTHONPATH=framework/core/src/python python3 scripts/release-provenance-object.py verify \
             --input "$output_dir/candidate.json"
-          echo "object-root=$(jq -er '.objectRoot' "$output_dir/candidate.json")" >> "$GITHUB_OUTPUT"
+          test "$(git rev-parse "$CANDIDATE_SHA^{tree}")" = "$CANDIDATE_TREE"
+          jq -e \
+            --arg candidate "$CANDIDATE_SHA" \
+            --arg tree "$CANDIDATE_TREE" \
+            '(.schema == "kungfu.release-provenance-envelope/v1" or .schema == "kungfu.release-provenance-envelope/v2") and
+             .gitProjection.candidateCommit == $candidate and
+             .gitProjection.candidateTree == $tree' \
+            "$output_dir/candidate.json" >/dev/null
+          schema="$(jq -er '.schema' "$output_dir/candidate.json")"
+          if [ "$schema" = "kungfu.release-provenance-envelope/v2" ]; then
+            source_content="$(
+              PYTHONPATH=framework/core/src/python python3 scripts/release-provenance-object.py source-content \
+                --repository . \
+                --revision "$CANDIDATE_SHA"
+            )"
+            jq -e \
+              --arg algorithm "$(jq -er '.algorithm' <<<"$source_content")" \
+              --arg digest "$(jq -er '.digest' <<<"$source_content")" \
+              '.sourceContent.record.algorithm == $algorithm and .sourceContent.record.digest == $digest and .gitProjection.semanticAuthority == false' \
+              "$output_dir/candidate.json" >/dev/null
+          else
+            echo "::notice::verified retained v1 candidate provenance projection"
+          fi
+          jq -e '
+            [.identities.derivationRoot, .identities.acknowledgementRoot,
+             .identities.qualificationRoot, .identities.authorityRoot,
+             .identities.contractRoot] |
+            all(.[]; test("^sha256:[0-9a-f]{64}$"))
+          ' "$output_dir/candidate.json" >/dev/null
+          {
+            echo "object-root=$(jq -er '.objectRoot' "$output_dir/candidate.json")"
+            echo "content-root=$(jq -r '.identities.contentRoot // empty' "$output_dir/candidate.json")"
+            echo "dev-cut-root=$(jq -er '.identities.derivationRoot' "$output_dir/candidate.json")"
+            echo "previous-alpha-root=$(jq -er '.identities.acknowledgementRoot' "$output_dir/candidate.json")"
+            echo "qualification-root=$(jq -er '.identities.qualificationRoot' "$output_dir/candidate.json")"
+            echo "approval-root=$(jq -r '.identities.approvalRoot // empty' "$output_dir/candidate.json")"
+            echo "authority-root=$(jq -er '.identities.authorityRoot' "$output_dir/candidate.json")"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Checkout immutable promotion result
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.1",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.1",
-    "sourceSha": "234f02927d4f5851efe6f899c0d2b117f0778e94"
+    "sourceSha": "5b323be43af712622fb55c75dc4e9798742a625f"
   },
   "claims": [
     {

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:78aefe86ab915c265cd7c1683e2684d0f15b1a52ea8765c5e49e86aec9b37bbe"
+            "sha256": "sha256:f981811de4ffaf52e205378b6ba15cc0ab674d06ccde4d67df2e5360caac4a1f"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/docs/adr/KF-ADR-019fe996-1912-7144-8fa5-3fceaa416365.md
+++ b/docs/adr/KF-ADR-019fe996-1912-7144-8fa5-3fceaa416365.md
@@ -14,8 +14,8 @@ period: 2026-08-10
 theme: temporal-relation-fact-contract
 confidence: high
 evidence_grade: B
-last_reviewed: 2026-08-12
-ai_provenance: GPT-5 via Codex on 2026-08-10 and 2026-08-12; based on the accepted Fact kernel, immutable Assignments, and repository evidence; release vocabulary remains a bounded Profile projection and no production-publication claim is made
+last_reviewed: 2026-08-15
+ai_provenance: GPT-5 via Codex on 2026-08-10, 2026-08-12, and 2026-08-15; based on the accepted Fact kernel, immutable Assignments, and repository evidence; release vocabulary remains a bounded Profile projection and no production-publication claim is made
 ---
 
 # KF-ADR-019fe996-1912-7144-8fa5-3fceaa416365: Immutable temporal relations and bounded proof paths are first-class Facts
@@ -145,7 +145,11 @@ produce the same object root across root, linear, merge, reordered, octopus,
 flattened, and ff-only projections. Exact Git coordinates remain separately
 rooted evidence. The v1 reader remains unchanged, while migration retains the
 complete predecessor bytes and emits an explicit `succeeds` relation and rooted
-receipt. This stage does not switch the release workflows or claim publication.
+receipt. The release workflow cutover now computes a canonical file-set digest
+in Candidate Patrol, passes the exact v2 envelope through immutable retained
+evidence, and consumes its explicit history, qualification, approval-policy,
+and authority roots during promotion. Parent sequence and ancestry remain
+advisory projections; the cutover does not claim or execute publication.
 
 The temporal admission cutover independently roots every allowance's reason,
 scope, evidence, authority, and Cut. Its static and retained-material

--- a/docs/development/version-release-design.md
+++ b/docs/development/version-release-design.md
@@ -74,7 +74,13 @@ qualification, approval, and authority Facts. Exact commit, tree, ancestry, pare
 count, and parent order remain independently rooted observations. Merge, linear,
 flattened, reordered-parent, and ff-only delivery therefore cannot silently rewrite
 the declared history. Historical v1 objects retain their original roots and verifier;
-v1-to-v2 migration appends an explicit `succeeds` relation and rooted receipt.
+v1-to-v2 migration appends an explicit `succeeds` relation and rooted receipt. The
+candidate patrol computes the content digest from a canonical logical file set and
+retains the v2 envelope under the exact candidate commit. Promotion imports and
+verifies that envelope, including its content, development Cut, prior Alpha,
+qualification, approval-policy, and authority roots; it never reconstructs those
+meanings from Git parent positions. A manual legacy rehearsal must name the exact
+successful patrol run whose retained v1 envelope is being replayed.
 
 **3. A release tag carries weight = code-freeze ⊗ binary distribution, performed
 atomically.** kungfu ships **prebuilt cross-platform binaries** (node-pre-gyp artifacts via

--- a/docs/qualification/gates/release-and-promotion.md
+++ b/docs/qualification/gates/release-and-promotion.md
@@ -71,8 +71,14 @@ and tree OIDs and any parent sequence are retained in a separately rooted
 The v1 reader remains fail-closed and byte-compatible. Migration never rewrites
 the predecessor: it emits one independently verifiable v2 successor, a rooted
 `succeeds` relation, and a migration receipt binding both object and projection
-roots. This producer/API stage grants no publication or admission-default
-authority and does not change release workflow topology.
+roots. Candidate Patrol now retains the verified v2 envelope in an immutable
+artifact named by the exact candidate commit. `Release - New Version` resolves
+that exact successful patrol run, verifies the candidate commit, Git tree,
+canonical file-set digest, semantic relation roots, and non-authoritative
+projection, then supplies the unchanged envelope to promotion. It never assigns
+development Cut or prior Alpha meaning to parent positions. A manual legacy
+rehearsal may name one exact successful patrol run and remains on the unchanged
+v1 verifier. Neither path grants publication or admission-default authority.
 
 ### Fresh GitHub-hosted functional matrix
 

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -503,20 +503,20 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:73ec2ac48b58aaa17ffbc6b5854da451a9d09686ff81f2623c193fe3fbb540fb",
+          "definitionDigest": "sha256:93a2c634189f16dbc788e98303e6de96ddcb5528b766ae2ff38410a4ea1349c6",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
-          "steps": [{"index":1,"label":"name:Check out exact selected candidate source","definitionDigest":"sha256:cde048a2506248bd5e78b82f351f2e72cefcb3d17b6b8615a5dc510fe8348031"},{"index":2,"label":"id:provenance","definitionDigest":"sha256:621aba062e78063f2b4431cba167f2baecdb7b043bc08500a39a5b50eeb5e2d0"},{"index":3,"label":"name:Retain candidate provenance evidence","authority":"evidence-publication","definitionDigest":"sha256:6c78e24536d8f5d601ad57dd07fd1153329a14e9da32594385a4293f6159637c"}]
+          "steps": [{"index":1,"label":"name:Check out exact selected candidate source","definitionDigest":"sha256:cde048a2506248bd5e78b82f351f2e72cefcb3d17b6b8615a5dc510fe8348031"},{"index":2,"label":"id:provenance","definitionDigest":"sha256:052a8830cbdaaede0821872d247e6915b739f6e76505db239037310b8e24995f"},{"index":3,"label":"name:Retain candidate provenance evidence","authority":"evidence-publication","definitionDigest":"sha256:ed3601c8fb5c4191c1a2c09e86a8b46e93750fd64be8e0022b39b6cacf26467b"}]
         },
         {
           "id": "release-cut-lock",
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:41aa5e2118162c76122e5ef83dc623822672b1278e0623738fd9eea7f711573b",
+          "definitionDigest": "sha256:0fce481e02140aa8c1a8737a2c2cbc767f9929efe2dc5ee9c02afddd9435f2dc",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
-          "steps": [{"index":1,"label":"name:Check out the dev mirror verifier","definitionDigest":"sha256:8d92682cf7803f194bf70107c82b9ee6d73e0de0b37f91a3ed75850183e688e3"},{"index":2,"label":"name:Fetch exact frozen Release Cut objects","definitionDigest":"sha256:74cc2b6e4607b8069f49ae903e6992163f007c8fa940342ba28a2efa110d41ce"},{"index":3,"label":"id:lock","definitionDigest":"sha256:967767f31651f4ee94f694f8ddaef3c162467948579258a193bd5d018c337d09"}]
+          "steps": [{"index":1,"label":"name:Check out the dev mirror verifier","definitionDigest":"sha256:8d92682cf7803f194bf70107c82b9ee6d73e0de0b37f91a3ed75850183e688e3"},{"index":2,"label":"name:Fetch exact frozen Release Cut objects","definitionDigest":"sha256:74cc2b6e4607b8069f49ae903e6992163f007c8fa940342ba28a2efa110d41ce"},{"index":3,"label":"id:lock","definitionDigest":"sha256:3bee27f3b1e6c1a6d99fd1472b1df8a65e38b5aa5374e0255e65aad39b19acf1"}]
         },
         {
           "id": "resolve-channels",
@@ -1019,7 +1019,7 @@
     {
       "path": ".github/workflows/release-new-version.yml",
       "authority": "release-control",
-      "definitionDigest": "sha256:26ac5b52d5bf4475c2902d249827466c1c4355deabd05377688795138700c2f6",
+      "definitionDigest": "sha256:a3ccdf2003736088d75defd5e54b5650cb3e74a4b0ec2d22cb7b50d514402aec",
       "jobs": [
         {
           "id": "alpha-timeline",
@@ -1046,10 +1046,10 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:ab200c0bb8750671821cd1f54eca0e87ba7e1498f1d699935c611920f460e3ad",
+          "definitionDigest": "sha256:67a2e69b940567165564f322a8b939e05f0333bea4fce748593618395456808c",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
-          "steps": [{"index":1,"label":"id:candidate","definitionDigest":"sha256:b26ccd80ef6de735f425e42a2f6bc52b4d0473bf52771cc1d9c2efecb674843a"},{"index":2,"label":"name:Checkout immutable Alpha candidate","definitionDigest":"sha256:8f1ff28917c625d57760451e82ab1239ddf747a611068bf9c6ad1067ad8f6284"},{"index":3,"label":"uses:actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","definitionDigest":"sha256:a869cc671103a9106dc90b4275a4148de9a5d18cd3578a2642d8ae8076d8dbf0"},{"index":4,"label":"id:preflight","definitionDigest":"sha256:de360134fee9dbf785d19794d87d62f16b07c7bf2872c83ce97be75fa0b8a02f"},{"index":5,"label":"id:candidate-provenance","definitionDigest":"sha256:ff6f25aece19b6b486701d5320b9763aee9abcc71f87b8ed50b3a8252280ee48"},{"index":6,"label":"name:Checkout immutable promotion result","definitionDigest":"sha256:9ff1aa9f5707e1bed64e57983cf9e409bd19fc8146dd5aa1801e1f6d4b8413f4"},{"index":7,"label":"id:promotion-tree","definitionDigest":"sha256:391088f704e8df632f937c4fe9c1265efb3846849c489032170178e871bde248"},{"index":8,"label":"id:promotion-provenance","definitionDigest":"sha256:1030278360fcc0d344b4fff17b0b73e3ec8e5331dbe3a7c4378bdb8924fa4ddf"},{"index":9,"label":"name:Retain candidate and promotion provenance evidence","authority":"evidence-publication","definitionDigest":"sha256:609756f889dac78980de8022367dc8cc8a9c77c5b1d73422e5dd65db0531bcf6"},{"index":10,"label":"name:Rehearse the Kungfu promotion contract for a pull request","definitionDigest":"sha256:0af2d30832fe4041d9997fd0a331f528a62b23fba2e3c9cfc23e45dd8ab38947"},{"index":11,"label":"name:Rehearse the Kungfu promotion contract for a manual dry-run","definitionDigest":"sha256:ac10175c46721c013cdc70ec9c5db82713fabd00be703439cf665365bef6c05d"}]
+          "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
+          "steps": [{"index":1,"label":"id:candidate","definitionDigest":"sha256:b26ccd80ef6de735f425e42a2f6bc52b4d0473bf52771cc1d9c2efecb674843a"},{"index":2,"label":"name:Checkout immutable Alpha candidate","definitionDigest":"sha256:8f1ff28917c625d57760451e82ab1239ddf747a611068bf9c6ad1067ad8f6284"},{"index":3,"label":"uses:actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","definitionDigest":"sha256:a869cc671103a9106dc90b4275a4148de9a5d18cd3578a2642d8ae8076d8dbf0"},{"index":4,"label":"id:preflight","definitionDigest":"sha256:de360134fee9dbf785d19794d87d62f16b07c7bf2872c83ce97be75fa0b8a02f"},{"index":5,"label":"id:candidate-provenance-artifact","definitionDigest":"sha256:bfee41fd86537856f7cca54c756fa371288d46917f018d91bfc7c24ba28c44cb"},{"index":6,"label":"name:Download exact candidate provenance evidence","authority":"evidence-publication","definitionDigest":"sha256:cb92e9ec40b5afc9f7c4c8240dd26df8aa7c427a0676239eee6958bdb35e0602"},{"index":7,"label":"id:candidate-provenance","definitionDigest":"sha256:c66afa5369b121eece338304ceb91394665fb637c22fa7f4fd42f92ca67eb052"},{"index":8,"label":"name:Checkout immutable promotion result","definitionDigest":"sha256:9ff1aa9f5707e1bed64e57983cf9e409bd19fc8146dd5aa1801e1f6d4b8413f4"},{"index":9,"label":"id:promotion-tree","authority":"evidence-publication","definitionDigest":"sha256:391088f704e8df632f937c4fe9c1265efb3846849c489032170178e871bde248"},{"index":10,"label":"id:promotion-provenance","definitionDigest":"sha256:1030278360fcc0d344b4fff17b0b73e3ec8e5331dbe3a7c4378bdb8924fa4ddf"},{"index":11,"label":"name:Retain candidate and promotion provenance evidence","authority":"evidence-publication","definitionDigest":"sha256:609756f889dac78980de8022367dc8cc8a9c77c5b1d73422e5dd65db0531bcf6"},{"index":12,"label":"name:Rehearse the Kungfu promotion contract for a pull request","definitionDigest":"sha256:0af2d30832fe4041d9997fd0a331f528a62b23fba2e3c9cfc23e45dd8ab38947"},{"index":13,"label":"name:Rehearse the Kungfu promotion contract for a manual dry-run","definitionDigest":"sha256:ac10175c46721c013cdc70ec9c5db82713fabd00be703439cf665365bef6c05d"}]
         },
         {
           "id": "recover",

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -146,9 +146,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:38076a7d83487042470943ca2611d43422bf909083112a7b1c9dfb2fbfcd9139",
+          "definitionDigest": "sha256:0143fcf52f42df0daa42860bc1d9148af6a7f309c81022c42982f9807d47320c",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/check.yml@4354638200137eb07d3272f4bcbce46131aea74c"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/check.yml@fb0ad6d84f10a1f9b872a799e035232d82558bd0"],
           "steps": []
         },
         {

--- a/docs/qualification/gates/workflow-authority.md
+++ b/docs/qualification/gates/workflow-authority.md
@@ -120,7 +120,7 @@ without changing and refreshing the manifest fails the Gate catalog check.
 | `.github/workflows/queue-admission-lease.yml` | `admission` | qualification | none | diagnostic | token:read | none | 5 |
 | `.github/workflows/release-new-version.yml` | `alpha-timeline` | qualification | none | diagnostic | token:write | none | 11 |
 | `.github/workflows/release-new-version.yml` | `promote` | release-control | channel | qualifying | token:write, oidc, repo-secret:BUILDCHAIN_ISSUE_APP_ID+BUILDCHAIN_ISSUE_APP_PRIVATE_KEY+KUNGFU_ALPHA_CHANNEL_SIGNING_PRIVATE_KEY+KUNGFU_GITHUB_TOKEN+KUNGFU_GOVERNANCE_AUDITOR_APP_PRIVATE_KEY | none | 0 |
-| `.github/workflows/release-new-version.yml` | `promotion-contract` | qualification | none | diagnostic | token:read | none | 11 |
+| `.github/workflows/release-new-version.yml` | `promotion-contract` | qualification | none | diagnostic | token:read | none | 13 |
 | `.github/workflows/release-new-version.yml` | `recover` | release-control | channel | qualifying | token:write, oidc, repo-secret:BUILDCHAIN_ISSUE_APP_ID+BUILDCHAIN_ISSUE_APP_PRIVATE_KEY+KUNGFU_ALPHA_CHANNEL_SIGNING_PRIVATE_KEY+KUNGFU_GITHUB_TOKEN+KUNGFU_GOVERNANCE_AUDITOR_APP_PRIVATE_KEY | none | 0 |
 | `.github/workflows/release-new-version.yml` | `recovery-preflight` | qualification | none | diagnostic | token:read | none | 8 |
 | `.github/workflows/release-shifu.yml` | `build` | qualification | none | diagnostic | token:write, oidc | none | 7 |

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -65,9 +65,9 @@
       "adapter": {
         "type": "buildchain-source",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/check.yml@4354638200137eb07d3272f4bcbce46131aea74c",
+        "uses": "kungfu-systems/buildchain/.github/workflows/check.yml@fb0ad6d84f10a1f9b872a799e035232d82558bd0",
         "with": {
-          "buildchain-ref": "4354638200137eb07d3272f4bcbce46131aea74c",
+          "buildchain-ref": "fb0ad6d84f10a1f9b872a799e035232d82558bd0",
           "mode": "source",
           "upload-artifacts": true,
           "source-proof-reuse": true,

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -80,7 +80,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:698a614c0d65b19b177bdb056f3d9c90c9520266cf5d7f999e82bd5aeed37e20"
+          "sourceRoot": "sha256:2a29f4a296292e77c53bbc7d3c2536c76f6e4fbbbfd1c547ae6d575c90e23162"
         },
         {
           "path": ".github/workflows/dev-post-merge-advisory.yml",
@@ -874,5 +874,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:dc6f0ebca4602520772a633e4941c0cb107cb3fcfcf0cffcfa5206f0ec3073a6"
+  "registryRoot": "sha256:3bcb9211b58d7fae4402c942b3beefee98cb937b191ae51cb5ab673687828965"
 }

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -184,7 +184,7 @@
             "product-alpha",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:2826dbe5286ad47527e4df2fd904d6b9d0ebc197d8b7a4a53c67e9617eb2118d"
+          "sourceRoot": "sha256:715ccbb26a30b8cbeaeace3c5b7a1b5b5d84a5fe0cc2b97e91c0b0ab46dff104"
         },
         {
           "path": ".github/workflows/dev-delivery-warrant-terminal.yml",
@@ -343,7 +343,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:c9cf6b30e904d074dc67264a6a8392d83966d460eb0ff439ca14ea3e662d0801"
+          "sourceRoot": "sha256:ad1052b4a9f7ee29f0a0eedce1b8d03e036e56c851249a871dd1faa37af5893b"
         },
         {
           "path": ".github/workflows/release-shifu.yml",
@@ -874,5 +874,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:dc6f0ebca4602520772a633e4941c0cb107cb3fcfcf0cffcfa5206f0ec3073a6"
+  "registryRoot": "sha256:66adceb7cc54c8129048ce7b2f04211c28a4f238db6785b7e97011187b600ce8"
 }

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -184,7 +184,7 @@
             "product-alpha",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:2826dbe5286ad47527e4df2fd904d6b9d0ebc197d8b7a4a53c67e9617eb2118d"
+          "sourceRoot": "sha256:715ccbb26a30b8cbeaeace3c5b7a1b5b5d84a5fe0cc2b97e91c0b0ab46dff104"
         },
         {
           "path": ".github/workflows/dev-delivery-warrant-terminal.yml",
@@ -343,7 +343,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:c9cf6b30e904d074dc67264a6a8392d83966d460eb0ff439ca14ea3e662d0801"
+          "sourceRoot": "sha256:ad1052b4a9f7ee29f0a0eedce1b8d03e036e56c851249a871dd1faa37af5893b"
         },
         {
           "path": ".github/workflows/release-shifu.yml",
@@ -874,5 +874,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:3bcb9211b58d7fae4402c942b3beefee98cb937b191ae51cb5ab673687828965"
+  "registryRoot": "sha256:d113c80beb565fde2fd6c99d495c59a4ab2c1537868e473567f7e9f5ea79cd77"
 }

--- a/scripts/alpha-macos-overflow.test.mjs
+++ b/scripts/alpha-macos-overflow.test.mjs
@@ -476,7 +476,7 @@ test('workflow contract keeps candidates exact-source, independent, and publish-
   );
   assert.match(
     affectedNativeWorkflow,
-    /source_acceptance:[\s\S]*uses: kungfu-systems\/buildchain\/\.github\/workflows\/check\.yml@4354638200137eb07d3272f4bcbce46131aea74c[\s\S]*buildchain-ref: 4354638200137eb07d3272f4bcbce46131aea74c[\s\S]*source-proof-reuse: true[\s\S]*source-proof-policy-paths-json: '\["\.github\/workflows\/affected-native-pr\.yml"\]'[\s\S]*source-proof-closure-paths-json: '\["\.buildchain\/buildchain\.toml","shifu","scripts\/source-acceptance\.mjs","scripts\/require-shifu\.mjs"\]'[\s\S]*source-proof-dependency-paths-json: '\["package\.json","pnpm-lock\.yaml"\]'[\s\S]*source-proof-required-contexts-json: '\["Candidate source acceptance \/ check"\]'/u,
+    /source_acceptance:[\s\S]*uses: kungfu-systems\/buildchain\/\.github\/workflows\/check\.yml@fb0ad6d84f10a1f9b872a799e035232d82558bd0[\s\S]*buildchain-ref: fb0ad6d84f10a1f9b872a799e035232d82558bd0[\s\S]*source-proof-reuse: true[\s\S]*source-proof-policy-paths-json: '\["\.github\/workflows\/affected-native-pr\.yml"\]'[\s\S]*source-proof-closure-paths-json: '\["\.buildchain\/buildchain\.toml","shifu","scripts\/source-acceptance\.mjs","scripts\/require-shifu\.mjs"\]'[\s\S]*source-proof-dependency-paths-json: '\["package\.json","pnpm-lock\.yaml"\]'[\s\S]*source-proof-required-contexts-json: '\["Candidate source acceptance \/ check"\]'/u,
   );
   assert.match(
     affectedNativeWorkflow,

--- a/scripts/check-release-provenance-object.test.mjs
+++ b/scripts/check-release-provenance-object.test.mjs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
 
 const read = (path) => fs.readFileSync(path, 'utf8');
@@ -11,6 +14,38 @@ const contractPath =
   'framework/release/kungfu-release-provenance.contract.json';
 const artifactPath = 'config/release/kungfu-release-provenance.contract.json';
 const contract = readJson(contractPath);
+const ROOT = process.cwd();
+
+function git(repository, ...args) {
+  return execFileSync('git', args, {
+    cwd: repository,
+    encoding: 'utf8',
+  }).trim();
+}
+
+function sourceContent(repository, revision = 'HEAD') {
+  return JSON.parse(
+    execFileSync(
+      'python3',
+      [
+        'scripts/release-provenance-object.py',
+        'source-content',
+        '--repository',
+        repository,
+        '--revision',
+        revision,
+      ],
+      {
+        cwd: ROOT,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PYTHONPATH: path.join(ROOT, 'framework/core/src/python'),
+        },
+      },
+    ),
+  );
+}
 
 test('release provenance is a welded KFR2 semantic contract', () => {
   assert.equal(contract.status, 'implemented');
@@ -47,13 +82,17 @@ test('release provenance is a welded KFR2 semantic contract', () => {
   );
 });
 
-test('candidate and promotion flows dual-write and retain rooted evidence', () => {
+test('candidate and promotion workflows pass one topology-neutral rooted object', () => {
   const candidate = read('.github/workflows/dev-alpha-candidate-patrol.yml');
   const promotion = read('.github/workflows/release-new-version.yml');
 
-  assert.match(candidate, /release-provenance-object\.py candidate/);
+  assert.match(candidate, /release-provenance-object\.py candidate-v2/);
+  assert.match(candidate, /release-provenance-object\.py source-content/);
   assert.match(candidate, /release-provenance-object\.py verify/);
-  assert.match(candidate, /release-provenance-candidate-/);
+  assert.match(
+    candidate,
+    /release-provenance-candidate-\$\{\{ steps\.provenance\.outputs\.candidate-commit \}\}/,
+  );
   assert.match(candidate, /priorStateRoot/);
   assert.match(
     candidate,
@@ -67,30 +106,37 @@ test('candidate and promotion flows dual-write and retain rooted evidence', () =
     candidate,
     /--previous-alpha-id "release-cut:\$RELEASE_ID:previous-alpha:\$QUALIFICATION_STATE_ROOT"/,
   );
+  assert.match(candidate, /--approval-id "protected-review-policy:/);
+  assert.match(candidate, /observed_parent_args=\(\)/);
 
-  assert.match(promotion, /release-provenance-object\.py candidate/);
   assert.match(promotion, /release-provenance-object\.py promotion/);
   assert.match(promotion, /release-provenance-object\.py verify/);
+  assert.match(promotion, /actions\/download-artifact@/);
+  assert.match(promotion, /candidate-provenance-run-id/);
+  assert.match(promotion, /\.head_branch == \$defaultBranch/);
+  assert.match(
+    promotion,
+    /--candidate-envelope "\$output_dir\/candidate\.json"/,
+  );
   assert.match(promotion, /candidate-provenance-root/);
+  assert.match(promotion, /candidate-content-root/);
+  assert.match(promotion, /candidate-dev-cut-root/);
+  assert.match(promotion, /candidate-previous-alpha-root/);
+  assert.match(promotion, /candidate-qualification-root/);
+  assert.match(promotion, /candidate-approval-root/);
+  assert.match(promotion, /candidate-authority-root/);
   assert.match(promotion, /promotion-provenance-root/);
   assert.match(promotion, /release-provenance-promotion-/);
   assert.match(promotion, /candidate_ancestry_observed=false/);
   assert.match(
     promotion,
-    /--candidate-id "release-candidate:\$RELEASE_ID:\$PREFLIGHT_RECEIPT_ROOT"/,
-  );
-  assert.match(
-    promotion,
-    /--dev-cut-id "release-cut:\$RELEASE_ID:development:\$PREFLIGHT_RECEIPT_ROOT"/,
-  );
-  assert.match(
-    promotion,
-    /--previous-alpha-id "release-cut:\$RELEASE_ID:previous-alpha:\$PREFLIGHT_RECEIPT_ROOT"/,
-  );
-  assert.match(
-    promotion,
     /--promotion-id "release-promotion:\$\{\{ inputs\.target-ref \|\| github\.event\.pull_request\.base\.ref \}\}:\$PREFLIGHT_RECEIPT_ROOT"/,
   );
+  assert.doesNotMatch(
+    promotion,
+    /candidate_parents|candidate_parents\[[01]\]/u,
+  );
+  assert.doesNotMatch(promotion, /git show -s --format=%P/u);
 
   for (const workflow of [candidate, promotion]) {
     assert.doesNotMatch(workflow, /release-provenance-object\.py publication/);
@@ -106,6 +152,41 @@ test('candidate and promotion flows dual-write and retain rooted evidence', () =
       workflow,
       /--previous-alpha-id [^\n]*(?:previous_alpha_sha|PREVIOUS_ALPHA_SHA)/,
     );
+  }
+});
+
+test('canonical source content is stable across commit topology and changes on bytes', () => {
+  const repository = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-release-source-content-'),
+  );
+  try {
+    git(repository, 'init', '-q');
+    git(repository, 'config', 'user.name', 'Kungfu Test');
+    git(repository, 'config', 'user.email', 'test@libkungfu.dev');
+    fs.writeFileSync(path.join(repository, 'payload.txt'), 'same bytes\n');
+    git(repository, 'add', 'payload.txt');
+    git(repository, 'commit', '-q', '-m', 'initial');
+    const initial = sourceContent(repository);
+    git(
+      repository,
+      'commit',
+      '-q',
+      '--allow-empty',
+      '-m',
+      'different topology',
+    );
+    const transported = sourceContent(repository);
+    fs.writeFileSync(path.join(repository, 'payload.txt'), 'changed bytes\n');
+    git(repository, 'add', 'payload.txt');
+    git(repository, 'commit', '-q', '-m', 'change content');
+    const changed = sourceContent(repository);
+
+    assert.equal(initial.algorithm, 'sha256-canonical-file-set-v1');
+    assert.equal(initial.digest, transported.digest);
+    assert.equal(initial.contentRoot, transported.contentRoot);
+    assert.notEqual(initial.digest, changed.digest);
+  } finally {
+    fs.rmSync(repository, { force: true, recursive: true });
   }
 });
 

--- a/scripts/dev-alpha-candidate-patrol.test.mjs
+++ b/scripts/dev-alpha-candidate-patrol.test.mjs
@@ -139,6 +139,11 @@ test('candidate patrol is a thin Buildchain caller with exact channel and eviden
   assert.match(source, /name: Verify frozen Alpha Release Cut source lock/u);
   assert.match(source, /lock=\.buildchain\/alpha-release-cut-lock\.json/u);
   assert.match(source, /git show -s --format=%P/u);
+  assert.match(source, /legacy Alpha\.2 parent projection drifted/u);
+  assert.doesNotMatch(
+    source,
+    /test "\$\(git show -s --format=%P "\$candidate_sha"\)"/u,
+  );
   assert.match(
     source,
     /needs\.release-cut-lock\.outputs\.candidate-settlement-authorized == 'true'/u,

--- a/scripts/release-provenance-object.py
+++ b/scripts/release-provenance-object.py
@@ -6,8 +6,11 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import subprocess
 import sys
+import unicodedata
 from pathlib import Path
 from typing import Any
 
@@ -34,6 +37,163 @@ def _write(path: str, value: Any) -> None:
         json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
+
+
+def _git(repository: str, *args: str) -> bytes:
+    result = subprocess.run(
+        ["git", "-C", repository, *args],
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise ReleaseProvenanceError(
+            "source-content-read",
+            result.stderr.decode("utf-8", errors="replace").strip()
+            or f"git {' '.join(args)} failed",
+        )
+    return result.stdout
+
+
+def _git_blob_digests(
+    repository: str, object_ids: list[str]
+) -> dict[str, tuple[int, str]]:
+    unique_ids = list(dict.fromkeys(object_ids))
+    if not unique_ids:
+        return {}
+    process = subprocess.Popen(
+        ["git", "-C", repository, "cat-file", "--batch"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert process.stdin is not None
+    assert process.stdout is not None
+    process.stdin.write("".join(f"{object_id}\n" for object_id in unique_ids).encode())
+    process.stdin.close()
+    digests: dict[str, tuple[int, str]] = {}
+    for expected_id in unique_ids:
+        header = process.stdout.readline().decode("ascii", errors="replace").strip()
+        fields = header.split()
+        if len(fields) != 3 or fields[0] != expected_id or fields[1] != "blob":
+            process.kill()
+            raise ReleaseProvenanceError(
+                "source-content-read", f"unexpected git cat-file header: {header}"
+            )
+        size = int(fields[2])
+        content = process.stdout.read(size)
+        if len(content) != size or process.stdout.read(1) != b"\n":
+            process.kill()
+            raise ReleaseProvenanceError(
+                "source-content-read", f"truncated git blob: {expected_id}"
+            )
+        digests[expected_id] = (size, hashlib.sha256(content).hexdigest())
+    stderr = process.stderr.read() if process.stderr is not None else b""
+    if process.wait() != 0:
+        raise ReleaseProvenanceError(
+            "source-content-read",
+            stderr.decode("utf-8", errors="replace").strip()
+            or "git cat-file --batch failed",
+        )
+    return digests
+
+
+def _source_content(repository: str, revision: str) -> dict[str, Any]:
+    """Hash one revision as a canonical logical file set, not as a Git tree."""
+
+    source_entries: list[tuple[str, str, str, str]] = []
+    listing = _git(repository, "ls-tree", "-rz", "--full-tree", revision)
+    for raw in listing.split(b"\0"):
+        if not raw:
+            continue
+        metadata, separator, path_bytes = raw.partition(b"\t")
+        if not separator:
+            raise ReleaseProvenanceError(
+                "source-content-read", "git ls-tree entry has no path separator"
+            )
+        fields = metadata.decode("ascii").split()
+        if len(fields) != 3:
+            raise ReleaseProvenanceError(
+                "source-content-read", "git ls-tree entry has invalid metadata"
+            )
+        mode, object_type, object_id = fields
+        try:
+            logical_path = path_bytes.decode("utf-8")
+        except UnicodeDecodeError as error:
+            raise ReleaseProvenanceError(
+                "source-content-path", "source path is not valid UTF-8"
+            ) from error
+        if unicodedata.normalize("NFC", logical_path) != logical_path:
+            raise ReleaseProvenanceError(
+                "source-content-path", "source path is not NFC-normalized"
+            )
+        if object_type == "blob":
+            kind = {
+                "100644": "file",
+                "100755": "executable",
+                "120000": "symlink",
+            }.get(mode)
+            if kind is None:
+                raise ReleaseProvenanceError(
+                    "source-content-mode", f"unsupported blob mode: {mode}"
+                )
+        elif object_type == "commit" and mode == "160000":
+            kind = "submodule"
+        else:
+            raise ReleaseProvenanceError(
+                "source-content-mode",
+                f"unsupported source entry: mode={mode} type={object_type}",
+            )
+        source_entries.append((logical_path, kind, object_type, object_id))
+
+    blob_digests = _git_blob_digests(
+        repository,
+        [
+            object_id
+            for _, _, object_type, object_id in source_entries
+            if object_type == "blob"
+        ],
+    )
+    entries: list[dict[str, Any]] = []
+    for logical_path, kind, object_type, object_id in source_entries:
+        if object_type == "blob":
+            size, digest = blob_digests[object_id]
+        else:
+            content = object_id.encode("ascii")
+            size, digest = len(content), hashlib.sha256(content).hexdigest()
+        entries.append(
+            {
+                "bytes": size,
+                "contentSha256": digest,
+                "kind": kind,
+                "path": logical_path,
+            }
+        )
+
+    manifest = {
+        "schema": "kungfu.release-source-content-file-set/v1",
+        "entries": entries,
+    }
+    canonical = json.dumps(
+        manifest,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    algorithm = "sha256-canonical-file-set-v1"
+    digest = hashlib.sha256(canonical).hexdigest()
+    content_record = {
+        "schema": "kungfu.release-source-content/v1",
+        "algorithm": algorithm,
+        "digest": digest,
+    }
+    return {
+        "schema": "kungfu.release-source-content-digest/v1",
+        "algorithm": algorithm,
+        "digest": digest,
+        "contentRoot": semantic_root(content_record),
+        "entryCount": len(entries),
+        "manifestRoot": semantic_root(manifest),
+    }
 
 
 def _root_or_identity(root: str | None, identity: str | None, field: str) -> str:
@@ -154,6 +314,9 @@ def _parser() -> argparse.ArgumentParser:
     migration.add_argument("--output", required=True)
     migration_verification = commands.add_parser("verify-migration")
     migration_verification.add_argument("--input", required=True)
+    source_content = commands.add_parser("source-content")
+    source_content.add_argument("--repository", default=".")
+    source_content.add_argument("--revision", required=True)
     commands.add_parser("admission")
     return parser
 
@@ -185,6 +348,15 @@ def main(argv: list[str] | None = None) -> int:
             report = verify_migration(_json_file(args.input, {}))
             print(json.dumps(report, indent=2, sort_keys=True))
             return 0 if report["ok"] else 1
+        if args.command == "source-content":
+            print(
+                json.dumps(
+                    _source_content(args.repository, args.revision),
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+            return 0
         if args.command == "migrate-candidate":
             bundle = migrate_candidate_v1(
                 _json_file(args.input, {}),

--- a/scripts/verify-alpha-release-cut-lock.test.mjs
+++ b/scripts/verify-alpha-release-cut-lock.test.mjs
@@ -103,6 +103,14 @@ test('candidate patrol verifies the frozen cut without settling from moving dev'
   assert.match(patrol, /git show -s --format=%P/u);
   assert.match(
     patrol,
+    /semantic candidate admission remains root-authoritative/u,
+  );
+  assert.doesNotMatch(
+    patrol,
+    /test "\$\(git show -s --format=%P "\$candidate_sha"\)"/u,
+  );
+  assert.match(
+    patrol,
     /needs\.release-cut-lock\.outputs\.candidate-settlement-authorized == 'true'/u,
   );
 });


### PR DESCRIPTION
## Summary

Make active Kungfu release workflows consume explicit topology-independent candidate provenance instead of assigning semantic meaning to Git parent positions.

## Related issue

Implements Assignment `2026-08-12-kungfu-topology-neutral-release-workflows` after the protected topology-independent candidate contract landed in PR #3113.

## Changes

- Add a canonical source-content projection and topology-neutral candidate-v2 envelope with explicit dev Cut, prior Alpha acknowledgement, qualification, approval-policy, and authority roots.
- Make candidate patrol treat observed Git parents as projection-only evidence while preserving legacy two-parent verification.
- Make release promotion resolve and verify the exact candidate envelope without parsing candidate parents.
- Add root, linear, merge, reordered, octopus, flattened, ff-only, and same-tree/different-history coverage and refresh the workflow authority projection.
- Update the accepted release-provenance ADR and qualification documentation.

## Verification

- `./shifu check:release-provenance-object`
- `./shifu test:alpha-promotion-preflight` (94/94)
- `./shifu check:source`
- `./shifu gate:workflow-authority:refresh`
- `./shifu fix`
- `git diff --check`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "implemented",
  "adrs": ["KF-ADR-019fe996-1912-7144-8fa5-3fceaa416365"],
  "summary": "Deliver topology-neutral release workflow consumption of explicit provenance authority",
  "verification": [
    "Release provenance object JavaScript and Python qualification",
    "Alpha promotion preflight fixtures",
    "Exact-head source acceptance and workflow authority refresh"
  ]
}
-->

## Evolution Map impact

Evolution impact: extends

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This changes release evidence transport and validation. It does not publish a release, relax exact candidate/content/qualification/approval checks, or bypass protected delivery.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed