### PR TITLE
perf(dev-delivery): reuse linear-replay source proof

### DIFF
--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.1",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.1",
-    "sourceSha": "5b323be43af712622fb55c75dc4e9798742a625f"
+    "sourceSha": "6aaedd84a34cdf1937828c32a84baaf37f31885f"
   },
   "claims": [
     {

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "5b323be43af712622fb55c75dc4e9798742a625f",
+    "sourceSha": "6aaedd84a34cdf1937828c32a84baaf37f31885f",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:688886d29ec7be1d63b4a7cf6d4c8354ce1e025a885d0b84af137e409df107df"
   },

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:f981811de4ffaf52e205378b6ba15cc0ab674d06ccde4d67df2e5360caac4a1f"
+            "sha256": "sha256:9af13a01dfb36042bff368185c44e7814a032c64be302a5655a7e5e3631788a9"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/.github/workflows/affected-native-pr.yml
+++ b/.github/workflows/affected-native-pr.yml
@@ -76,9 +76,9 @@ jobs:
 
   source_acceptance:
     name: Candidate source acceptance
-    uses: kungfu-systems/buildchain/.github/workflows/check.yml@fb0ad6d84f10a1f9b872a799e035232d82558bd0
+    uses: kungfu-systems/buildchain/.github/workflows/check.yml@0ef9b58e12f5982e374cc2669a3d55dd009992e5
     with:
-      buildchain-ref: fb0ad6d84f10a1f9b872a799e035232d82558bd0
+      buildchain-ref: 0ef9b58e12f5982e374cc2669a3d55dd009992e5
       mode: source
       upload-artifacts: true
       source-proof-reuse: true

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.1",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.1",
-    "sourceSha": "5b323be43af712622fb55c75dc4e9798742a625f"
+    "sourceSha": "6aaedd84a34cdf1937828c32a84baaf37f31885f"
   },
   "claims": [
     {

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:f981811de4ffaf52e205378b6ba15cc0ab674d06ccde4d67df2e5360caac4a1f"
+            "sha256": "sha256:9af13a01dfb36042bff368185c44e7814a032c64be302a5655a7e5e3631788a9"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -146,9 +146,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:0143fcf52f42df0daa42860bc1d9148af6a7f309c81022c42982f9807d47320c",
+          "definitionDigest": "sha256:2adfce66c7ed383b2cbe79dc4e554245c5d6244eae545776490864dee675ffeb",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/check.yml@fb0ad6d84f10a1f9b872a799e035232d82558bd0"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/check.yml@0ef9b58e12f5982e374cc2669a3d55dd009992e5"],
           "steps": []
         },
         {

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -65,9 +65,9 @@
       "adapter": {
         "type": "buildchain-source",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/check.yml@fb0ad6d84f10a1f9b872a799e035232d82558bd0",
+        "uses": "kungfu-systems/buildchain/.github/workflows/check.yml@0ef9b58e12f5982e374cc2669a3d55dd009992e5",
         "with": {
-          "buildchain-ref": "fb0ad6d84f10a1f9b872a799e035232d82558bd0",
+          "buildchain-ref": "0ef9b58e12f5982e374cc2669a3d55dd009992e5",
           "mode": "source",
           "upload-artifacts": true,
           "source-proof-reuse": true,

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -80,7 +80,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:2a29f4a296292e77c53bbc7d3c2536c76f6e4fbbbfd1c547ae6d575c90e23162"
+          "sourceRoot": "sha256:3243e3902fbdb1d81570cffdd227d974b487a9fee02df883ad5c6112039c3f94"
         },
         {
           "path": ".github/workflows/dev-post-merge-advisory.yml",
@@ -874,5 +874,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:3bcb9211b58d7fae4402c942b3beefee98cb937b191ae51cb5ab673687828965"
+  "registryRoot": "sha256:39b3fab92ffb1d6f42c85a2abf61737dfbeac5a9aa4b409b084c8090b521e2b8"
 }

--- a/scripts/alpha-macos-overflow.test.mjs
+++ b/scripts/alpha-macos-overflow.test.mjs
@@ -476,7 +476,7 @@ test('workflow contract keeps candidates exact-source, independent, and publish-
   );
   assert.match(
     affectedNativeWorkflow,
-    /source_acceptance:[\s\S]*uses: kungfu-systems\/buildchain\/\.github\/workflows\/check\.yml@fb0ad6d84f10a1f9b872a799e035232d82558bd0[\s\S]*buildchain-ref: fb0ad6d84f10a1f9b872a799e035232d82558bd0[\s\S]*source-proof-reuse: true[\s\S]*source-proof-policy-paths-json: '\["\.github\/workflows\/affected-native-pr\.yml"\]'[\s\S]*source-proof-closure-paths-json: '\["\.buildchain\/buildchain\.toml","shifu","scripts\/source-acceptance\.mjs","scripts\/require-shifu\.mjs"\]'[\s\S]*source-proof-dependency-paths-json: '\["package\.json","pnpm-lock\.yaml"\]'[\s\S]*source-proof-required-contexts-json: '\["Candidate source acceptance \/ check"\]'/u,
+    /source_acceptance:[\s\S]*uses: kungfu-systems\/buildchain\/\.github\/workflows\/check\.yml@0ef9b58e12f5982e374cc2669a3d55dd009992e5[\s\S]*buildchain-ref: 0ef9b58e12f5982e374cc2669a3d55dd009992e5[\s\S]*source-proof-reuse: true[\s\S]*source-proof-policy-paths-json: '\["\.github\/workflows\/affected-native-pr\.yml"\]'[\s\S]*source-proof-closure-paths-json: '\["\.buildchain\/buildchain\.toml","shifu","scripts\/source-acceptance\.mjs","scripts\/require-shifu\.mjs"\]'[\s\S]*source-proof-dependency-paths-json: '\["package\.json","pnpm-lock\.yaml"\]'[\s\S]*source-proof-required-contexts-json: '\["Candidate source acceptance \/ check"\]'/u,
   );
   assert.match(
     affectedNativeWorkflow,


### PR DESCRIPTION
## Summary

- Pin the reusable Buildchain proof producer and consumer to protected merge `0ef9b58e12f5982e374cc2669a3d55dd009992e5`, which accepts GitHub merge queue linear replay only when every replayed commit has exact tree equivalence.
- Regenerate the KFD, workflow-authority, and publication roots for that exact runtime binding.
- Preserve fail-closed fallback to the full source gate whenever source, dependency, toolchain, plan, policy, closure, replay shape, or tree equivalence drifts.
- Preserve approval, Delivery Warrant, queue admission, protected merge, publication, and release authority unchanged.

This is the exact latest-base successor after the first hosted canary showed that native proof reuse reduced the required native path to 67 seconds, while source proof reuse missed because GitHub emitted a linear replay chain instead of a two-parent merge commit. Buildchain PR #2815 repaired that proof verifier without weakening its predicates. This PR binds Kungfu to the merged repair so a second hosted merge-group canary can measure the intended verification-only source path.

## Assignment

Native Assignment `2026-08-12-kungfu-merge-group-source-proof-reuse` under initiative `2026-07-28-kungfu-go-family-continuous-delivery`.

## Exact delivery coordinates

- Base at validation: `6cf3cd97afd539e68263bc45dcabb303d9fbc880`
- Head: `33587e47b1701c4bbc9ad5684100b4897e3c45fe`
- Work admission: `sha256:39678129cf9775677cc0f0f04ed3d5875d7cd08752f7018e143f126b4ba8d04d`
- Buildchain protected merge: `0ef9b58e12f5982e374cc2669a3d55dd009992e5`
- Buildchain protected repair PR: `#2815`

## Verification

- `./shifu test:alpha-macos-overflow`: 14/14 passed.
- Staged repository hook: latency 75/75, invariants 18/18, docs 147/147, and KFD matrix 22/22 passed.
- KFD Buildchain/support-matrix checks and release-publication qualification passed; generated evidence roots are current.
- Main Node source matrix reached 1129 passed, 11 skipped, and zero failed before the cold Python `uv` dependency unpack was interrupted locally; hosted exact-head source qualification remains required before Warrant admission.
- Buildchain linear-replay verifier passed its full `pnpm run check` suite with 1618 tests and its protected exact-head workflow before merge.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"This is a bounded dev delivery latency regression repair: it changes an exact protected Buildchain runtime pin and generated evidence roots without changing any accepted ADR record or implementation status."}
-->

## Evolution Map impact

Evolution impact: extends

The affected-native workflow consumes the protected Buildchain linear-replay proof contract; existing delivery authority and publication surfaces remain unchanged.

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Boundary: this only reuses an exact successful pull-request source proof inside the merge-group required check. Any missing, stale, ambiguous, mismatched, unverifiable, or policy-ineligible proof executes the full source path. It does not weaken review, Warrant, queue-admission, merge, publication, or release authority.

## Checklist

- [x] Commits are signed off
- [x] Workflow contracts, generated governance facts, publication roots, and tests are updated
