### PR TITLE
fix(shifu): preserve Windows launcher line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,11 @@
 # formatter results and generated evidence independent of core.autocrlf.
 * text=auto eol=lf
 
+# cmd.exe cannot reliably resolve labels across parenthesized block boundaries
+# from LF-only batch files. Keep the canonical Windows launcher checked out
+# with native CRLF bytes on every host while Git continues to normalize it.
+shifu.cmd text eol=crlf
+
 # Canonical contract bytes are hashed and compared byte-for-byte. Keep their
 # line endings independent of the checkout platform.
 framework/config/*.contract.json text eol=lf

--- a/scripts/check-shifu-entry-contract.test.mjs
+++ b/scripts/check-shifu-entry-contract.test.mjs
@@ -238,6 +238,15 @@ test('Windows source Kungfu route projects built TUI Product paths', () => {
   );
 });
 
+test('Windows launcher is checked out with cmd-safe line endings', () => {
+  const result = spawnSync('git', ['check-attr', 'eol', '--', 'shifu.cmd'], {
+    cwd: ROOT,
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), 'shifu.cmd: eol: crlf');
+});
+
 test('cached pinned uv activates Work after Qualified Core materialization', (t) => {
   if (process.platform === 'win32') {
     t.skip('POSIX launcher contract');
@@ -482,7 +491,9 @@ test('Xinfa source entry prefers hash-pinned wasm and preserves native fallback'
 
 test('Xinfa quality uses the source resolver and forwards one Windows mode', () => {
   const posix = fs.readFileSync(path.join(ROOT, 'shifu'), 'utf8');
-  const windows = fs.readFileSync(path.join(ROOT, 'shifu.cmd'), 'utf8');
+  const windows = fs
+    .readFileSync(path.join(ROOT, 'shifu.cmd'), 'utf8')
+    .replaceAll('\r\n', '\n');
   const posixBlock = posix.match(/xinfa:quality\)[\s\S]*?;;/u)?.[0];
   const windowsBlock = windows.match(
     /:xinfaquality[\s\S]*?(?=\r?\n:projectcut\r?\n)/u,


### PR DESCRIPTION
## Summary

- enforce CRLF checkout semantics for shifu.cmd through .gitattributes
- add an executable entry-contract assertion for the eol attribute
- normalize fixture reads so the source assertion remains platform-neutral

## Evidence

The exact protected-source Product Build run 31860898871 failed on Windows with: The system cannot find the batch label specified - native. Linux and macOS did not expose this cmd.exe label-resolution defect.

Local validation on b772b46e568a6901d5e8d5c5bd2c64b35f083fa4:
- focused shifu entry-contract tests: 44 total, 41 pass, 3 Windows-host-only skips
- ./shifu check:source: 1130 pass, 11 expected skips, 0 failures in the Node suite; all Python/runtime/desktop source gates pass
- ./shifu build:core: pass

Post-merge Product Build and Dev Verify will qualify the exact protected commit across Linux, macOS, and Windows.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix changes only Git checkout line endings for the existing Windows launcher and adds a contract assertion; it does not alter an architecture contract or ADR record."
}
-->

## Evolution Map impact

Evolution impact: none