### PR TITLE
fix(build): bind alpha workflow shell channel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,9 +180,9 @@ jobs:
   build:
     needs: [preflight, windows-fast-sentinel, auditable-demo-fast-sentinel]
     if: ${{ always() && needs.preflight.result == 'success' && needs.windows-fast-sentinel.result == 'success' && needs.auditable-demo-fast-sentinel.result == 'success' && !inputs.fast-sentinels-only && fromJSON(inputs.macos-overflow-request-json || '{}').mode != 'control' }}
-    # Pin the workflow shell that routes signed macOS finalization to a native
-    # runner. The v3 tag can lag this fail-closed runtime contract.
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@dbad2f383a6ab93abd192c4edefb4689c9eebc78
+    # Use the official Alpha workflow shell so its channel and major identity
+    # are provable alongside the v3-alpha runtime and consumer contract lock.
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v3-alpha
     secrets:
       BUILDCHAIN_PROMOTION_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}
       BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -328,9 +328,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:b30e68805cacd5a0c5afccad3f9c20a51dc2ccf1850d3e55f4f4201ae0a9d959",
+          "definitionDigest": "sha256:eb62b8b7d5754de5d5e4169892724fdda360b5dfa2f1a5ef1221b5adbdf50b20",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN","KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@dbad2f383a6ab93abd192c4edefb4689c9eebc78"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@v3-alpha"],
           "steps": []
         },
         {

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -472,7 +472,7 @@
       "adapter": {
         "type": "buildchain-heavy-build",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@dbad2f383a6ab93abd192c4edefb4689c9eebc78",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@v3-alpha",
         "job": {
       "needs": [
         "preflight",

--- a/docs/release-promotion-rehearsal.contract.json
+++ b/docs/release-promotion-rehearsal.contract.json
@@ -8,7 +8,7 @@
   "buildchain": {
     "workflow_shell_ref": "v3-alpha",
     "workflow_shell_resolved_sha": "a60957e3ffc8f9a02f0e9419deebc8d35a3f7198",
-    "build_workflow_shell_sha": "dbad2f383a6ab93abd192c4edefb4689c9eebc78",
+    "build_workflow_shell_ref": "v3-alpha",
     "alpha": {
       "workflow_ref": "v3-alpha",
       "resolved_sha": "82701ca66f5366ade6ec694c9950d5d8d6db082d",

--- a/framework/release/publication-control-plane.mjs
+++ b/framework/release/publication-control-plane.mjs
@@ -101,19 +101,19 @@ export function validatePromotionWorkflowAuthority(
 }
 export function validateBuildWorkflowAuthority(
   buildWorkflow,
-  workflowShellSha,
+  workflowShellRef,
 ) {
-  if (!/^[0-9a-f]{40}$/u.test(workflowShellSha))
-    throw new Error('Build workflow shell revision is invalid');
+  if (workflowShellRef !== 'v3-alpha')
+    throw new Error('Build workflow shell channel is invalid');
   if (
     !buildWorkflow.includes(
-      `uses: kungfu-systems/buildchain/.github/workflows/.build.yml@${workflowShellSha}`,
+      `uses: kungfu-systems/buildchain/.github/workflows/.build.yml@${workflowShellRef}`,
     ) ||
     !/^\s+buildchain-ref: \$\{\{ inputs\.buildchain-ref \|\| 'v3-alpha' \}\}\s*$/mu.test(
       buildWorkflow,
     ) ||
-    buildWorkflow.includes(
-      'uses: kungfu-systems/buildchain/.github/workflows/.build.yml@v3',
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@v3\s*$/mu.test(
+      buildWorkflow,
     ) ||
     buildWorkflow.includes('kungfu-trader/workflows@v1')
   )
@@ -303,7 +303,7 @@ export function validateRegistry(r, { root = ROOT } = {}) {
   );
   validateBuildWorkflowAuthority(
     buildWorkflow,
-    promotionRehearsal.buildchain.build_workflow_shell_sha,
+    promotionRehearsal.buildchain.build_workflow_shell_ref,
   );
   const promotionWorkflow = fs.readFileSync(
     path.join(root, '.github/workflows/release-new-version.yml'),

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -136,7 +136,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:cc77602a38807e04a865bbe4a66ec2f05e428b28d9dc2acd4c14ccbb04a44f6c"
+          "sourceRoot": "sha256:a96b5b960733b122edd50520d4eb9cdcc76b4af84b19a40d5318684835d5947d"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",
@@ -874,5 +874,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:3bcb9211b58d7fae4402c942b3beefee98cb937b191ae51cb5ab673687828965"
+  "registryRoot": "sha256:34ba7421bdfe9a9d156cc2c2bb28022f682ae10450a99b08543f96f950faf399"
 }

--- a/scripts/alpha-macos-overflow.test.mjs
+++ b/scripts/alpha-macos-overflow.test.mjs
@@ -468,7 +468,7 @@ test('workflow contract keeps candidates exact-source, independent, and publish-
   );
   assert.match(
     workflow,
-    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@dbad2f383a6ab93abd192c4edefb4689c9eebc78/u,
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@v3-alpha/u,
   );
   assert.match(
     workflow,

--- a/scripts/alpha-promotion-preflight.test.mjs
+++ b/scripts/alpha-promotion-preflight.test.mjs
@@ -590,7 +590,7 @@ test('patrol, normal Alpha builds and sentinels keep one controller authority', 
   );
   assert.match(
     build,
-    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@dbad2f383a6ab93abd192c4edefb4689c9eebc78/u,
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@v3-alpha/u,
   );
   const preBuild = build.slice(0, build.indexOf('\n  build:'));
   assert.doesNotMatch(

--- a/scripts/kungfu-workflow-authority.mjs
+++ b/scripts/kungfu-workflow-authority.mjs
@@ -155,7 +155,7 @@ function immutableReference(reference) {
 }
 
 const BUILDCHAIN_V3_BUILD_ACTION =
-  'kungfu-systems/buildchain/.github/workflows/.build.yml@dbad2f383a6ab93abd192c4edefb4689c9eebc78';
+  'kungfu-systems/buildchain/.github/workflows/.build.yml@v3-alpha';
 const BUILDCHAIN_V3_PROMOTION_ACTION =
   'kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@v3-alpha';
 const BUILDCHAIN_V3_ALPHA_PROMOTION_ACTION =

--- a/scripts/release-promotion-rehearsal.mjs
+++ b/scripts/release-promotion-rehearsal.mjs
@@ -145,10 +145,10 @@ export function validateWorkflowSources(root, contract, overrides = {}) {
   requirePattern(
     build,
     new RegExp(
-      `uses: kungfu-systems/buildchain/\\.github/workflows/\\.build\\.yml@${contract.buildchain.build_workflow_shell_sha}`,
+      `uses: kungfu-systems/buildchain/\\.github/workflows/\\.build\\.yml@${contract.buildchain.build_workflow_shell_ref}`,
     ),
     findings,
-    'release-candidate build must consume the pinned native-finalization workflow contract',
+    'release-candidate build must consume the channel-bound native-finalization workflow contract',
   );
   requirePattern(
     build,

--- a/scripts/release-publication-control-plane.test.mjs
+++ b/scripts/release-publication-control-plane.test.mjs
@@ -44,22 +44,22 @@ test('checked registry closes workflows and invariants', () => {
   assert.equal(validateRegistry(v), v);
   assert.equal(status(v).sourceAcceptance, 'passed');
 });
-test('build authority pins the workflow shell while retaining runtime routing', () => {
+test('build authority binds the workflow shell channel while retaining runtime routing', () => {
   const source = fs.readFileSync('.github/workflows/build.yml', 'utf8');
   const contract = JSON.parse(
     fs.readFileSync('docs/release-promotion-rehearsal.contract.json', 'utf8'),
   );
-  const shellSha = contract.buildchain.build_workflow_shell_sha;
-  assert.equal(validateBuildWorkflowAuthority(source, shellSha), true);
+  const shellRef = contract.buildchain.build_workflow_shell_ref;
+  assert.equal(validateBuildWorkflowAuthority(source, shellRef), true);
   assert.throws(
     () => validateBuildWorkflowAuthority(source, '0'.repeat(40)),
-    /authority drift/u,
+    /shell channel is invalid/u,
   );
   assert.throws(
     () =>
       validateBuildWorkflowAuthority(
-        source.replace(`.build.yml@${shellSha}`, '.build.yml@v3'),
-        shellSha,
+        source.replace(`.build.yml@${shellRef}`, '.build.yml@v3'),
+        shellRef,
       ),
     /authority drift/u,
   );

--- a/scripts/verify-alpha-release-cut-lock.test.mjs
+++ b/scripts/verify-alpha-release-cut-lock.test.mjs
@@ -51,7 +51,7 @@ test('Alpha.2 r17 lock verifies the exact Release Cut and fixed runtimes', () =>
   );
 });
 
-test('Alpha.2 r17 keeps the Alpha runtime train while pinning the repaired workflow shell', () => {
+test('Alpha.2 r17 keeps the Alpha runtime train and channel-bound workflow shell', () => {
   assert.equal(LOCK.buildchain.build.ref, 'v3-alpha');
   assert.equal(
     LOCK.buildchain.build.resolvedSha,
@@ -80,7 +80,7 @@ test('Alpha.2 r17 keeps the Alpha runtime train while pinning the repaired workf
   );
   assert.match(
     build,
-    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@dbad2f383a6ab93abd192c4edefb4689c9eebc78/u,
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@v3-alpha/u,
   );
   assert.match(
     build,
@@ -90,7 +90,7 @@ test('Alpha.2 r17 keeps the Alpha runtime train while pinning the repaired workf
     promotion,
     /buildchain-ref: \$\{\{ startsWith\(inputs\.target-ref \|\| github\.event\.pull_request\.base\.ref, 'alpha\/'\) && 'v3-alpha' \|\| 'v3' \}\}/u,
   );
-  assert.match(build, /\.github\/workflows\/\.build\.yml@[0-9a-f]{40}/u);
+  assert.match(build, /\.github\/workflows\/\.build\.yml@v3-alpha/u);
 });
 
 test('candidate patrol verifies the frozen cut without settling from moving dev', () => {


### PR DESCRIPTION
The exact merged source Build retry (run 31886634260) failed closed at the trust gate before the platform matrix because the reusable Buildchain workflow was pinned by an opaque commit SHA, so the shell could not prove its channel or major against runtime v3-alpha.

This repair binds the caller to the official v3-alpha workflow shell and updates the checked authority, bindings, rehearsal contract, publication control plane, and impacted tests to treat that auditable release-channel ref as the workflow-shell identity. It does not add an override or weaken the fail-closed gate.

Verification:
- 71 impacted tests pass
- workflow authority closed world verified
- gate catalog: 38 gates, 7 profiles, 28 structured invocations, 38 workflows aligned
- publication control plane qualifies
- commit hook full source validation passes
- native run gate returned ok:true

ADR delivery / release declaration:

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Repair the existing Buildchain Alpha workflow-shell identity proof without changing an architecture contract or publication behavior"
}
-->