### PR TITLE
chore(kfd): anchor webhook qualification to protected base

### DIFF
--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.1",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.1",
-    "sourceSha": "4f837fb0faea192b830ea0626240ab972e9aee15"
+    "sourceSha": "1059834585bd12144e22be1991358486cff8e1ec"
   },
   "claims": [
     {

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "4f837fb0faea192b830ea0626240ab972e9aee15",
+    "sourceSha": "1059834585bd12144e22be1991358486cff8e1ec",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:688886d29ec7be1d63b4a7cf6d4c8354ce1e025a885d0b84af137e409df107df"
   },

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:0bd512d3a3ad5080fa9acffbbf555909a567c135b90c0d9f4bfa89f70c5c66e5"
+            "sha256": "sha256:f753334e07743723d42ba109d9882b82d2e5e1d07c0eeb76567e612b7184ba68"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.1",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.1",
-    "sourceSha": "4f837fb0faea192b830ea0626240ab972e9aee15"
+    "sourceSha": "1059834585bd12144e22be1991358486cff8e1ec"
   },
   "claims": [
     {

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:0bd512d3a3ad5080fa9acffbbf555909a567c135b90c0d9f4bfa89f70c5c66e5"
+            "sha256": "sha256:f753334e07743723d42ba109d9882b82d2e5e1d07c0eeb76567e612b7184ba68"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/docs/adr/KF-ADR-019f9f8a-9f40-7d6e-a4d2-5a334a9ab201.md
+++ b/docs/adr/KF-ADR-019f9f8a-9f40-7d6e-a4d2-5a334a9ab201.md
@@ -219,6 +219,13 @@ inspect, validate, and qualify operations produce inputs and evidence only;
 they do not install, activate, authorize, bind a listener, or grant credential
 or domain-action authority.
 
+PR #3175 is the r29 terminal-qualification evidence repair. It keeps this ADR
+at `staged` and makes no new implementation claim: KFD-2 and KFD-3 release
+evidence are rebound to protected base
+`1059834585bd12144e22be1991358486cff8e1ec`, which remains a real ancestor
+after GitHub merge-queue replay. The prior r28 delivery remains retained as PR
+`#3162` and merge `8f5a87a6275b10b26c848d9710354cdc2588fed2`.
+
 The current r25 linear protected-delivery successor is replayed on protected
 base `445b2fd84ec7f613ccbfc3d5f06980a3b07f0690`. Its pre-binding product
 head is `245513a6a3d7f19e01030f6f395cbaed86e49435`. That protected base now


### PR DESCRIPTION
## Summary

- r29 successor to PR #3162
- rebind KFD-2 and KFD-3 release evidence to protected base 1059834585bd12144e22be1991358486cff8e1ec
- keep the evidence source as a real ancestor after GitHub merge-queue replay

Native Assignment `2026-08-09-kungfu-kfx-webhook-terminal-qualification` under initiative `2026-08-09-kungfu-kfx-webhook-agent-authoring`.

## Verification

- staged source/governance/documentation/KFD gate passed at f0a992ac4d6b
- KFD Buildchain evidence and support matrix checks passed
- KFD source-binding and source-acceptance tests: 46/46
- portable Documentation Atlas bundle verification passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["KF-ADR-019f9f8a-9f40-7d6e-a4d2-5a334a9ab201"],
  "summary": "Anchor webhook terminal qualification evidence to a protected base ancestor",
  "verification": ["exact r29 staged gate at f0a992ac4d6b", "KFD Buildchain and support-matrix checks", "source binding 46/46", "portable bundle verify"]
}
-->

## Evolution Map impact

Evolution impact: extends

This is an evidence-binding repair for the existing KFX webhook terminal qualification and does not open a new authority transition.

## Checklist

- [x] Commits are signed off (DCO)
- [x] No credentials or secret material are persisted
- [x] This PR does not publish a release