### PR TITLE
chore(kfd): rebind webhook qualification after dev advance

### DIFF
--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.1",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.1",
-    "sourceSha": "caf4e883d999a1f60e43e2e32a37c8c146e36270"
+    "sourceSha": "757c38383cd55075028d8f5ac70907aa888c47dd"
   },
   "claims": [
     {

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "caf4e883d999a1f60e43e2e32a37c8c146e36270",
+    "sourceSha": "757c38383cd55075028d8f5ac70907aa888c47dd",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:688886d29ec7be1d63b4a7cf6d4c8354ce1e025a885d0b84af137e409df107df"
   },

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:d12f93c771167ed17b8893ed82c5e6aeb81d971f66c066b5af345bfe4b612c5e"
+            "sha256": "sha256:b42f0aca97fbf58cedf751fa2ff25cfa78f78ee361aa800d848eab1c0e2966be"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.1",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.1",
-    "sourceSha": "caf4e883d999a1f60e43e2e32a37c8c146e36270"
+    "sourceSha": "757c38383cd55075028d8f5ac70907aa888c47dd"
   },
   "claims": [
     {

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:d12f93c771167ed17b8893ed82c5e6aeb81d971f66c066b5af345bfe4b612c5e"
+            "sha256": "sha256:b42f0aca97fbf58cedf751fa2ff25cfa78f78ee361aa800d848eab1c0e2966be"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/docs/adr/KF-ADR-019f9f8a-9f40-7d6e-a4d2-5a334a9ab201.md
+++ b/docs/adr/KF-ADR-019f9f8a-9f40-7d6e-a4d2-5a334a9ab201.md
@@ -219,6 +219,15 @@ inspect, validate, and qualify operations produce inputs and evidence only;
 they do not install, activate, authorize, bind a listener, or grant credential
 or domain-action authority.
 
+The r30 terminal-qualification evidence repair supersedes r29 PR `#3175`
+after the protected base advanced through PR `#3173`. It keeps this ADR at
+`staged` and makes no new implementation claim: KFD-2 and KFD-3 release
+evidence are rebound to protected base
+`757c38383cd55075028d8f5ac70907aa888c47dd`, so the evidence source remains
+a real ancestor after GitHub merge-queue replay. The earlier r28 delivery
+remains retained as PR `#3162` and merge
+`8f5a87a6275b10b26c848d9710354cdc2588fed2`.
+
 The current r25 linear protected-delivery successor is replayed on protected
 base `445b2fd84ec7f613ccbfc3d5f06980a3b07f0690`. Its pre-binding product
 head is `245513a6a3d7f19e01030f6f395cbaed86e49435`. That protected base now


### PR DESCRIPTION
## Summary

- r30 successor to PR #3175 after PR #3173 advanced the protected base
- rebind KFD-2 and KFD-3 release evidence to protected base 757c38383cd55075028d8f5ac70907aa888c47dd
- retain a real evidence-source ancestor through GitHub merge-queue replay

Native Assignment `2026-08-09-kungfu-kfx-webhook-terminal-qualification` under initiative `2026-08-09-kungfu-kfx-webhook-agent-authoring`.

## Verification

- complete staged gate passed at 48315960a96e
- KFD Buildchain evidence and support matrix checks passed
- KFD source binding and source acceptance: 47/47
- portable Documentation Atlas bundle verification passed
- deterministic documentation gate passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["KF-ADR-019f9f8a-9f40-7d6e-a4d2-5a334a9ab201"],
  "summary": "Rebind webhook terminal qualification evidence after the protected base advanced",
  "verification": ["exact r30 staged gate at 48315960a96e", "KFD Buildchain and support-matrix checks", "source binding 47/47", "portable bundle and docs checks"]
}
-->

## Evolution Map impact

Evolution impact: extends

This is an evidence-binding repair for the existing KFX webhook terminal qualification and does not open a new authority transition.

## Checklist

- [x] Commits are signed off (DCO)
- [x] No credentials or secret material are persisted
- [x] This PR does not publish a release
