### PR TITLE
docs(readme): lead with the recovery proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,41 +12,39 @@ same Work across Codex, Claude, OpenCode, Amp, or your own execution surface.
 > **Kungfu UNGFU™** · Never Guess. Facts Unfold. [Why this signature
 > exists](docs/concepts/why-kungfu.md).
 
-> **Exploring the source? Start with your Agent.** Agents should read
-> [`AGENTS.md`](AGENTS.md) before explaining or evaluating Kungfu. Ask for the
-> smallest mental model your question needs; Kungfu's internal vocabulary is
-> machine-readable implementation structure, not a syllabus you need to learn.
+## See one Work survive failure
 
-Paste this into your Agent:
-
-```text
-Inspect https://github.com/kungfu-systems/kungfu.
-Read AGENTS.md first. Explain what Kungfu does and evaluate its architecture.
-Give me only the smallest mental model I need; do not make me learn the
-repository's full ontology.
-```
-
-## Start where you already work
-
-First, [install Kungfu and make the `kungfu` command available on your
-`PATH`](docs/guides/installing-cli.md), then choose the entry that matches how
-you already work.
-
-**Try Kungfu before connecting a real Agent.** The built-in deterministic Mock
-Agent lets you experience Project and Work onboarding without provider
-credentials. To see why durable Work matters across failure and recovery, run:
+Kungfu is currently Alpha. On macOS or Linux, install the CLI with the reviewed
+per-user installer:
 
 ```sh
+curl -fsSL https://kungfu.tech/install.sh | sh
+```
+
+It does not use `sudo` or edit your shell profile. Follow the exact `PATH` step
+it prints, then open a project and run the deterministic recovery story:
+
+```sh
+cd your-project
 KUNGFU_MOCK_AGENT_SCENARIO=recovery-story kungfu
 ```
 
-Start the same Work through three consecutive Attempts: a disconnect, a crash,
-then a recovered delivery. For a quicker onboarding check that crosses a
-question, an approval, and a ready-for-review result in one Attempt, run:
+The built-in Mock Agent needs no provider credentials. It starts the same Work
+through three consecutive Attempts: a disconnect, a crash, then a recovered
+delivery. Because the scenario is deterministic, it tests Kungfu's local
+continuity and recovery path rather than a particular model.
+
+For a quicker onboarding check that crosses a question, an approval, and a
+ready-for-review result in one Attempt, run:
 
 ```sh
 KUNGFU_MOCK_AGENT_SCENARIO=multi-step kungfu
 ```
+
+See the [installation guide](docs/guides/installing-cli.md) for Windows,
+higher-assurance installation, explicit version pinning, and troubleshooting.
+
+## Keep the Agent interface you already use
 
 The Mock Agent covers Work creation and execution. Regular onboarding still
 needs a supported real Agent for independent review, so this is not yet an
@@ -173,6 +171,16 @@ From a source checkout, give your Agent the task you actually want to complete:
 
 ```text
 Read `AGENTS.md`. I want to <task>. Use the repository's verified task-context route. Before editing, explain only the concepts, current implementation owners, authority boundaries, and qualification path this task requires.
+```
+
+If you are exploring or evaluating the repository rather than changing it,
+paste this into your Agent:
+
+```text
+Inspect https://github.com/kungfu-systems/kungfu.
+Read AGENTS.md first. Explain what Kungfu does and evaluate its architecture.
+Give me only the smallest mental model I need; do not make me learn the
+repository's full ontology.
 ```
 
 For a whole-system explanation, start with the [Evolution

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ same Work across Codex, Claude, OpenCode, Amp, or your own execution surface.
 
 ## See one Work survive failure
 
-Kungfu is currently Alpha. On macOS or Linux, install the CLI with the reviewed
-per-user installer:
+Kungfu is currently Alpha. On macOS or Linux, install Kungfu and make the `kungfu` command available with the reviewed per-user installer:
 
 ```sh
 curl -fsSL https://kungfu.tech/install.sh | sh


### PR DESCRIPTION
## Summary

Make the public README first screen action-first for new GitHub visitors without changing product or release authority.

## Related issue

None.

## Changes

- Put the Alpha status, reviewed per-user installer, and deterministic recovery story directly after the product promise.
- Keep the native Agent launch and sidecar workflow ahead of repository-internal concepts.
- Move the source-exploration prompt to the contribution section where it remains available to technical readers.

## Verification

- `./shifu docs:check`
- `./shifu docs:prose:required`
- `./shifu docs final-ready --since origin/dev/v4/v4.0 --budget 66560 --json` (Human/Agent parity matched; no violations; mixed review required)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This documentation-only reorder changes no architecture contract or release authority"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The README now exposes the existing public installer earlier. Its command and boundaries are sourced from the existing installation guide; no publication state, release evidence, package, or deployment mechanism changes.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed