### PR TITLE
fix(check): consume linear source replay runtime

### DIFF
--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.1",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.1",
-    "sourceSha": "8028d15898639438a9553ed9bcf92d08e6c47c90"
+    "sourceSha": "67d906d78d0b792ecb52201ba881c5196217cc81"
   },
   "claims": [
     {

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "8028d15898639438a9553ed9bcf92d08e6c47c90",
+    "sourceSha": "67d906d78d0b792ecb52201ba881c5196217cc81",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:688886d29ec7be1d63b4a7cf6d4c8354ce1e025a885d0b84af137e409df107df"
   },

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:ed5f533c9709565bc42a5ea5102d50f3de7c9e4e8b7f0bf426a6ebca0d5fdc26"
+            "sha256": "sha256:a24276aa3f47e84667142a676284dc9d423233185ff3ad1bc1e80a5542943b78"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/.github/workflows/affected-native-pr.yml
+++ b/.github/workflows/affected-native-pr.yml
@@ -76,11 +76,11 @@ jobs:
 
   source_acceptance:
     name: Candidate source acceptance
-    # Protected Buildchain merge #2815 admits only exact tree-equivalent
-    # linear merge-queue replays while retaining the legacy two-parent path.
-    uses: kungfu-systems/buildchain/.github/workflows/check.yml@0ef9b58e12f5982e374cc2669a3d55dd009992e5
+    # Protected Buildchain merge #2872 admits exact proof reuse across a
+    # bounded, tree-equivalent base advance while retaining fail-closed replay.
+    uses: kungfu-systems/buildchain/.github/workflows/check.yml@8e9ce32ddd931fb294ab1a9a2a40e89ba743391a
     with:
-      buildchain-ref: 0ef9b58e12f5982e374cc2669a3d55dd009992e5
+      buildchain-ref: 8e9ce32ddd931fb294ab1a9a2a40e89ba743391a
       mode: source
       upload-artifacts: true
       source-proof-reuse: true

--- a/.github/workflows/affected-native-pr.yml
+++ b/.github/workflows/affected-native-pr.yml
@@ -76,9 +76,11 @@ jobs:
 
   source_acceptance:
     name: Candidate source acceptance
-    uses: kungfu-systems/buildchain/.github/workflows/check.yml@fb0ad6d84f10a1f9b872a799e035232d82558bd0
+    # Protected Buildchain merge #2815 admits only exact tree-equivalent
+    # linear merge-queue replays while retaining the legacy two-parent path.
+    uses: kungfu-systems/buildchain/.github/workflows/check.yml@0ef9b58e12f5982e374cc2669a3d55dd009992e5
     with:
-      buildchain-ref: fb0ad6d84f10a1f9b872a799e035232d82558bd0
+      buildchain-ref: 0ef9b58e12f5982e374cc2669a3d55dd009992e5
       mode: source
       upload-artifacts: true
       source-proof-reuse: true

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.1",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.1",
-    "sourceSha": "8028d15898639438a9553ed9bcf92d08e6c47c90"
+    "sourceSha": "67d906d78d0b792ecb52201ba881c5196217cc81"
   },
   "claims": [
     {

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:ed5f533c9709565bc42a5ea5102d50f3de7c9e4e8b7f0bf426a6ebca0d5fdc26"
+            "sha256": "sha256:a24276aa3f47e84667142a676284dc9d423233185ff3ad1bc1e80a5542943b78"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -146,9 +146,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:2adfce66c7ed383b2cbe79dc4e554245c5d6244eae545776490864dee675ffeb",
+          "definitionDigest": "sha256:fbeab838677239d84dd323d0fc89e2de4088dc1e0296cefe87d3b784444e515e",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/check.yml@0ef9b58e12f5982e374cc2669a3d55dd009992e5"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/check.yml@8e9ce32ddd931fb294ab1a9a2a40e89ba743391a"],
           "steps": []
         },
         {

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -146,9 +146,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:0143fcf52f42df0daa42860bc1d9148af6a7f309c81022c42982f9807d47320c",
+          "definitionDigest": "sha256:2adfce66c7ed383b2cbe79dc4e554245c5d6244eae545776490864dee675ffeb",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/check.yml@fb0ad6d84f10a1f9b872a799e035232d82558bd0"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/check.yml@0ef9b58e12f5982e374cc2669a3d55dd009992e5"],
           "steps": []
         },
         {

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -65,9 +65,9 @@
       "adapter": {
         "type": "buildchain-source",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/check.yml@fb0ad6d84f10a1f9b872a799e035232d82558bd0",
+        "uses": "kungfu-systems/buildchain/.github/workflows/check.yml@0ef9b58e12f5982e374cc2669a3d55dd009992e5",
         "with": {
-          "buildchain-ref": "fb0ad6d84f10a1f9b872a799e035232d82558bd0",
+          "buildchain-ref": "0ef9b58e12f5982e374cc2669a3d55dd009992e5",
           "mode": "source",
           "upload-artifacts": true,
           "source-proof-reuse": true,

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -65,9 +65,9 @@
       "adapter": {
         "type": "buildchain-source",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/check.yml@0ef9b58e12f5982e374cc2669a3d55dd009992e5",
+        "uses": "kungfu-systems/buildchain/.github/workflows/check.yml@8e9ce32ddd931fb294ab1a9a2a40e89ba743391a",
         "with": {
-          "buildchain-ref": "0ef9b58e12f5982e374cc2669a3d55dd009992e5",
+          "buildchain-ref": "8e9ce32ddd931fb294ab1a9a2a40e89ba743391a",
           "mode": "source",
           "upload-artifacts": true,
           "source-proof-reuse": true,

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -80,7 +80,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:cdbe84e0179441724b13d8e8dbc78f84e2eb7f18582f69473372f49b2011dffd"
+          "sourceRoot": "sha256:8799b4aed59fa446111510e26544dc546dd78206ec2ec4a69de29959ff59d26e"
         },
         {
           "path": ".github/workflows/dev-post-merge-advisory.yml",
@@ -874,5 +874,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:1d35348fb9b5fdb6270556976511205c9998add0792dd686f16126ea379916e5"
+  "registryRoot": "sha256:4256916064a92fff9040b55111a2e4d052209c1ac62edd6fb202f44c5b96ddd6"
 }

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -80,7 +80,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:8799b4aed59fa446111510e26544dc546dd78206ec2ec4a69de29959ff59d26e"
+          "sourceRoot": "sha256:e6a1091cafe27e20a4904aaeb2dc722f24978e136270fbff7c49df38e7b62e97"
         },
         {
           "path": ".github/workflows/dev-post-merge-advisory.yml",
@@ -874,5 +874,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:4256916064a92fff9040b55111a2e4d052209c1ac62edd6fb202f44c5b96ddd6"
+  "registryRoot": "sha256:4de9f88caf86353d01e212e5cc361b84a9293c1bbcf5bc37c30bbbe1ee333c0d"
 }

--- a/scripts/alpha-macos-overflow.test.mjs
+++ b/scripts/alpha-macos-overflow.test.mjs
@@ -476,7 +476,7 @@ test('workflow contract keeps candidates exact-source, independent, and publish-
   );
   assert.match(
     affectedNativeWorkflow,
-    /source_acceptance:[\s\S]*uses: kungfu-systems\/buildchain\/\.github\/workflows\/check\.yml@0ef9b58e12f5982e374cc2669a3d55dd009992e5[\s\S]*buildchain-ref: 0ef9b58e12f5982e374cc2669a3d55dd009992e5[\s\S]*source-proof-reuse: true[\s\S]*source-proof-policy-paths-json: '\["\.github\/workflows\/affected-native-pr\.yml"\]'[\s\S]*source-proof-closure-paths-json: '\["\.buildchain\/buildchain\.toml","shifu","scripts\/source-acceptance\.mjs","scripts\/require-shifu\.mjs"\]'[\s\S]*source-proof-dependency-paths-json: '\["package\.json","pnpm-lock\.yaml"\]'[\s\S]*source-proof-required-contexts-json: '\["Candidate source acceptance \/ check"\]'/u,
+    /source_acceptance:[\s\S]*uses: kungfu-systems\/buildchain\/\.github\/workflows\/check\.yml@8e9ce32ddd931fb294ab1a9a2a40e89ba743391a[\s\S]*buildchain-ref: 8e9ce32ddd931fb294ab1a9a2a40e89ba743391a[\s\S]*source-proof-reuse: true[\s\S]*source-proof-policy-paths-json: '\["\.github\/workflows\/affected-native-pr\.yml"\]'[\s\S]*source-proof-closure-paths-json: '\["\.buildchain\/buildchain\.toml","shifu","scripts\/source-acceptance\.mjs","scripts\/require-shifu\.mjs"\]'[\s\S]*source-proof-dependency-paths-json: '\["package\.json","pnpm-lock\.yaml"\]'[\s\S]*source-proof-required-contexts-json: '\["Candidate source acceptance \/ check"\]'/u,
   );
   assert.match(
     affectedNativeWorkflow,

--- a/scripts/alpha-macos-overflow.test.mjs
+++ b/scripts/alpha-macos-overflow.test.mjs
@@ -476,7 +476,7 @@ test('workflow contract keeps candidates exact-source, independent, and publish-
   );
   assert.match(
     affectedNativeWorkflow,
-    /source_acceptance:[\s\S]*uses: kungfu-systems\/buildchain\/\.github\/workflows\/check\.yml@fb0ad6d84f10a1f9b872a799e035232d82558bd0[\s\S]*buildchain-ref: fb0ad6d84f10a1f9b872a799e035232d82558bd0[\s\S]*source-proof-reuse: true[\s\S]*source-proof-policy-paths-json: '\["\.github\/workflows\/affected-native-pr\.yml"\]'[\s\S]*source-proof-closure-paths-json: '\["\.buildchain\/buildchain\.toml","shifu","scripts\/source-acceptance\.mjs","scripts\/require-shifu\.mjs"\]'[\s\S]*source-proof-dependency-paths-json: '\["package\.json","pnpm-lock\.yaml"\]'[\s\S]*source-proof-required-contexts-json: '\["Candidate source acceptance \/ check"\]'/u,
+    /source_acceptance:[\s\S]*uses: kungfu-systems\/buildchain\/\.github\/workflows\/check\.yml@0ef9b58e12f5982e374cc2669a3d55dd009992e5[\s\S]*buildchain-ref: 0ef9b58e12f5982e374cc2669a3d55dd009992e5[\s\S]*source-proof-reuse: true[\s\S]*source-proof-policy-paths-json: '\["\.github\/workflows\/affected-native-pr\.yml"\]'[\s\S]*source-proof-closure-paths-json: '\["\.buildchain\/buildchain\.toml","shifu","scripts\/source-acceptance\.mjs","scripts\/require-shifu\.mjs"\]'[\s\S]*source-proof-dependency-paths-json: '\["package\.json","pnpm-lock\.yaml"\]'[\s\S]*source-proof-required-contexts-json: '\["Candidate source acceptance \/ check"\]'/u,
   );
   assert.match(
     affectedNativeWorkflow,


### PR DESCRIPTION
## Summary

- pin Candidate source acceptance to protected Buildchain merge #2872
- reuse exact PR source proof across a bounded, tree-equivalent dev base advance
- retain fail-closed linear replay and legacy two-parent verification
- refresh workflow, publication, and KFD authority projections

This is the current-base runtime follow-up to protected Kungfu merge #3182. The functional source-proof/native reuse path is already merged; this patch consumes the protected base-advance repair needed to prevent a qualified proof from falling back to the full source lifecycle after unrelated dev advancement.

## Exact delivery coordinates

- base: `dev/v4/v4.0` (resolved again by protected source qualification and Warrant)
- head: `aa30585dfe352b17921706e180c75150d89838fc`
- Buildchain runtime: `8e9ce32ddd931fb294ab1a9a2a40e89ba743391a` (protected merge #2872)

## Verification

- `./shifu check:source`: passed; Node 1148 tests with 0 failures, Python 40/40, runtime-upgrade 134/134, desktop 73/73
- commit staged gate: passed, including 75 dev-latency contract tests and 147 docs tests
- `node --test scripts/alpha-macos-overflow.test.mjs`: 14/14 passed
- `node --test scripts/affected-native-semantic-source.test.mjs`: 5/5 passed
- `./shifu kfd:buildchain:check`: passed
- `./shifu kfd:support-matrix:check`: passed
- `./shifu check:release-publication-control-plane`: passed
- `git diff --check`: passed

No required check, Warrant, exact-head/base predicate, or merge-queue authority is bypassed.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix updates an immutable Buildchain runtime pin to consume an already protected base-advance proof verifier; it does not alter an architecture contract or ADR record."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Generated evidence changes only retain exact source and workflow roots; no publication or channel movement occurs.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed

## Non-claims

Local validation does not prove merge-group reuse or the final parent latency SLO. Protected source CI, independent exact-head review, Delivery Warrant admission, and the merge-group canary remain authoritative.