### PR TITLE
fix(product): preserve Alpha macOS update metadata

### DIFF
--- a/product/scripts/finalize-macos-release-artifacts.test.mjs
+++ b/product/scripts/finalize-macos-release-artifacts.test.mjs
@@ -39,7 +39,7 @@ function json(root, relative, value) {
   return write(root, relative, `${JSON.stringify(value, null, 2)}\n`);
 }
 
-function signingFixture() {
+function signingFixture({ updateMetadata = 'latest-mac.yml' } = {}) {
   const root = fs.mkdtempSync(
     path.join(os.tmpdir(), 'kungfu-macos-release-finalization-'),
   );
@@ -78,7 +78,7 @@ function signingFixture() {
     write(root, artifact.path, artifact.bytes);
   write(
     root,
-    'product/release/desktop/latest-mac.yml',
+    `product/release/desktop/${updateMetadata}`,
     'version: 4.0.0-alpha.2\npath: retained-updater.zip\n',
   );
   json(root, 'product/release/desktop/update-info.json', { retained: true });
@@ -235,6 +235,57 @@ test('finalization is idempotent for the same signed source and artifact bytes',
     assert.equal(fs.readFileSync(first.receiptFile).compare(receiptBytes), 0);
   } finally {
     cleanup(fixture);
+  }
+});
+
+test('finalization preserves Alpha channel macOS update metadata', async () => {
+  const fixture = signingFixture({ updateMetadata: 'alpha-mac.yml' });
+  try {
+    const result = await finalizeMacosReleaseArtifacts(options(fixture.root));
+    assert.equal(result.reused, false);
+    assert.ok(
+      result.receipt.preservedMetadata.some(
+        ({ path: retainedPath }) =>
+          retainedPath === 'product/release/desktop/alpha-mac.yml',
+      ),
+    );
+    assert.equal(
+      fs.existsSync(
+        path.join(fixture.root, 'product/release/desktop/alpha-mac.yml'),
+      ),
+      true,
+    );
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test('finalization rejects missing or ambiguous macOS update metadata before deletion', async () => {
+  for (const variant of ['missing', 'ambiguous']) {
+    const fixture = signingFixture();
+    try {
+      if (variant === 'missing')
+        fs.rmSync(
+          path.join(fixture.root, 'product/release/desktop/latest-mac.yml'),
+        );
+      else
+        write(
+          fixture.root,
+          'product/release/desktop/alpha-mac.yml',
+          'version: 4.0.0-alpha.2\npath: retained-updater.zip\n',
+        );
+      await assert.rejects(
+        finalizeMacosReleaseArtifacts(options(fixture.root)),
+        /expected one electron-builder macOS update metadata file/u,
+      );
+      for (const artifact of fixture.intermediateArtifacts)
+        assert.equal(
+          fs.existsSync(path.join(fixture.root, artifact.path)),
+          true,
+        );
+    } finally {
+      cleanup(fixture);
+    }
   }
 });
 

--- a/product/scripts/upgrade-manifest.mjs
+++ b/product/scripts/upgrade-manifest.mjs
@@ -763,7 +763,11 @@ export async function finalizeMacosReleaseArtifacts({
       archives.filter((name) => name.endsWith('.zip')).length === 1,
     `expected one electron-builder DMG and ZIP, found: ${archives.join(', ') || 'none'}`,
   );
-  releaseAssert(names.includes('latest-mac.yml'), 'latest-mac.yml is missing');
+  const updateMetadata = names.filter((name) => name.endsWith('-mac.yml'));
+  releaseAssert(
+    updateMetadata.length === 1,
+    `expected one electron-builder macOS update metadata file, found: ${updateMetadata.join(', ') || 'none'}`,
+  );
   const removed = [];
   for (const name of [...archives, ...blockmaps].sort()) {
     removed.push(


### PR DESCRIPTION
## Summary

- accept exactly one channel-specific electron-builder macOS update metadata file during signed artifact finalization
- preserve Alpha `alpha-mac.yml` while retaining stable `latest-mac.yml` compatibility
- fail closed before deleting intermediate archives when metadata is missing or ambiguous

Repairs the finalization-only failure from Full Product Build 31927955617 after all four platform product jobs, including Windows x64, had succeeded.

Native Assignment `2026-08-09-kungfu-kfx-webhook-terminal-qualification` under initiative `2026-08-09-kungfu-kfx-webhook-agent-authoring`.

## Verification

- complete staged gate passed at `ce4b8eb5bf`
- `./shifu test:cli-surface-qualification`: 90/90 passed
- regression coverage includes Alpha metadata preservation plus missing/ambiguous fail-closed cases

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Bounded bugfix to accept the channel-specific electron-builder macOS metadata filename without changing release, signing, updater, or publication authority"
}
-->

## Evolution Map impact

Evolution impact: none

This is a bounded release-finalization repair. It preserves existing channel authority and does not add a new publication or signing authority.

## Checklist

- [x] Commits are signed off (DCO)
- [x] No credentials or secret material are persisted
- [x] This PR does not publish a release
