### PR TITLE
fix(product): preserve Alpha macOS update metadata

### DIFF
--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.3",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.3",
-    "sourceSha": "8bb7c178559b7208b4cc41f1374f82bf39c4e750"
+    "sourceSha": "c871acf686fbd17f9eb01529a5ad5669b92a2052"
   },
   "claims": [
     {

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "8bb7c178559b7208b4cc41f1374f82bf39c4e750",
+    "sourceSha": "c871acf686fbd17f9eb01529a5ad5669b92a2052",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:688886d29ec7be1d63b4a7cf6d4c8354ce1e025a885d0b84af137e409df107df"
   },

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:9514e703287606b444db073a88f341ec4b65da0d2a040afd02caf010258d551e"
+            "sha256": "sha256:f809e1728f1bfdd47d97a8b5d33633f7c52bcd901d7e025f489bdbe3360dfe37"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.3",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.3",
-    "sourceSha": "8bb7c178559b7208b4cc41f1374f82bf39c4e750"
+    "sourceSha": "c871acf686fbd17f9eb01529a5ad5669b92a2052"
   },
   "claims": [
     {

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:9514e703287606b444db073a88f341ec4b65da0d2a040afd02caf010258d551e"
+            "sha256": "sha256:f809e1728f1bfdd47d97a8b5d33633f7c52bcd901d7e025f489bdbe3360dfe37"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/product/scripts/finalize-macos-release-artifacts.test.mjs
+++ b/product/scripts/finalize-macos-release-artifacts.test.mjs
@@ -39,7 +39,7 @@ function json(root, relative, value) {
   return write(root, relative, `${JSON.stringify(value, null, 2)}\n`);
 }
 
-function signingFixture() {
+function signingFixture({ updateMetadata = 'latest-mac.yml' } = {}) {
   const root = fs.mkdtempSync(
     path.join(os.tmpdir(), 'kungfu-macos-release-finalization-'),
   );
@@ -78,7 +78,7 @@ function signingFixture() {
     write(root, artifact.path, artifact.bytes);
   write(
     root,
-    'product/release/desktop/latest-mac.yml',
+    `product/release/desktop/${updateMetadata}`,
     'version: 4.0.0-alpha.2\npath: retained-updater.zip\n',
   );
   json(root, 'product/release/desktop/update-info.json', { retained: true });
@@ -235,6 +235,57 @@ test('finalization is idempotent for the same signed source and artifact bytes',
     assert.equal(fs.readFileSync(first.receiptFile).compare(receiptBytes), 0);
   } finally {
     cleanup(fixture);
+  }
+});
+
+test('finalization preserves Alpha channel macOS update metadata', async () => {
+  const fixture = signingFixture({ updateMetadata: 'alpha-mac.yml' });
+  try {
+    const result = await finalizeMacosReleaseArtifacts(options(fixture.root));
+    assert.equal(result.reused, false);
+    assert.ok(
+      result.receipt.preservedMetadata.some(
+        ({ path: retainedPath }) =>
+          retainedPath === 'product/release/desktop/alpha-mac.yml',
+      ),
+    );
+    assert.equal(
+      fs.existsSync(
+        path.join(fixture.root, 'product/release/desktop/alpha-mac.yml'),
+      ),
+      true,
+    );
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test('finalization rejects missing or ambiguous macOS update metadata before deletion', async () => {
+  for (const variant of ['missing', 'ambiguous']) {
+    const fixture = signingFixture();
+    try {
+      if (variant === 'missing')
+        fs.rmSync(
+          path.join(fixture.root, 'product/release/desktop/latest-mac.yml'),
+        );
+      else
+        write(
+          fixture.root,
+          'product/release/desktop/alpha-mac.yml',
+          'version: 4.0.0-alpha.2\npath: retained-updater.zip\n',
+        );
+      await assert.rejects(
+        finalizeMacosReleaseArtifacts(options(fixture.root)),
+        /expected one electron-builder macOS update metadata file/u,
+      );
+      for (const artifact of fixture.intermediateArtifacts)
+        assert.equal(
+          fs.existsSync(path.join(fixture.root, artifact.path)),
+          true,
+        );
+    } finally {
+      cleanup(fixture);
+    }
   }
 });
 

--- a/product/scripts/upgrade-manifest.mjs
+++ b/product/scripts/upgrade-manifest.mjs
@@ -763,7 +763,11 @@ export async function finalizeMacosReleaseArtifacts({
       archives.filter((name) => name.endsWith('.zip')).length === 1,
     `expected one electron-builder DMG and ZIP, found: ${archives.join(', ') || 'none'}`,
   );
-  releaseAssert(names.includes('latest-mac.yml'), 'latest-mac.yml is missing');
+  const updateMetadata = names.filter((name) => name.endsWith('-mac.yml'));
+  releaseAssert(
+    updateMetadata.length === 1,
+    `expected one electron-builder macOS update metadata file, found: ${updateMetadata.join(', ') || 'none'}`,
+  );
   const removed = [];
   for (const name of [...archives, ...blockmaps].sort()) {
     removed.push(


### PR DESCRIPTION
## Summary

- accept exactly one channel-specific electron-builder macOS update metadata file during signed artifact finalization
- preserve Alpha `alpha-mac.yml` while retaining stable `latest-mac.yml` compatibility
- fail closed before deleting intermediate archives when metadata is missing or ambiguous
- refresh KFD release evidence after linearizing onto the current protected dev base

Repairs the finalization-only failure from Full Product Build 31927955617 after all four platform product jobs, including Windows x64, had succeeded. Supersedes non-linear PR #3197.

Native Assignment `2026-08-09-kungfu-kfx-webhook-terminal-qualification` under initiative `2026-08-09-kungfu-kfx-webhook-agent-authoring`.

## Verification

- complete staged gate passed at `38f2024374`
- `./shifu test:cli-surface-qualification`: 90/90 passed on the original repair
- Project Cut queue admission qualified against protected dev `5acee65ef4`
- KFD evidence and support-matrix checks passed after exact-head regeneration
- regression coverage includes Alpha metadata preservation plus missing/ambiguous fail-closed cases

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Bounded bugfix to accept the channel-specific electron-builder macOS metadata filename without changing release, signing, updater, or publication authority"
}
-->

## Evolution Map impact

Evolution impact: none

This is a bounded release-finalization repair. It preserves existing channel authority and does not add a new publication or signing authority.

## Checklist

- [x] Commits are signed off (DCO)
- [x] No credentials or secret material are persisted
- [x] This PR does not publish a release