### PR TITLE
fix(check): consume linear source replay runtime

### DIFF
--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.3",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.3",
-    "sourceSha": "221d0e1ab2edc3cc899bd6ba72fa1744a4336d36"
+    "sourceSha": "5f69795fcbcd21a347955dd79edb4ba9d7a8c984"
   },
   "claims": [
     {

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "221d0e1ab2edc3cc899bd6ba72fa1744a4336d36",
+    "sourceSha": "5f69795fcbcd21a347955dd79edb4ba9d7a8c984",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:766dd8a4f3848a5d60440ead27d60e4400b0630e54d610e977933d580511c8f6"
   },

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:af392cb353df2f87f5cb553aee38a1706a8df23992e50ca96c63fd38ef3e8dff"
+            "sha256": "sha256:41aa28973b39223558509b5f4c2fc919327bdfcb519f0926b5b3c6acf8a28bf9"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/.github/workflows/affected-native-pr.yml
+++ b/.github/workflows/affected-native-pr.yml
@@ -76,9 +76,11 @@ jobs:
 
   source_acceptance:
     name: Candidate source acceptance
-    uses: kungfu-systems/buildchain/.github/workflows/check.yml@fb0ad6d84f10a1f9b872a799e035232d82558bd0
+    # Protected Buildchain merge #2872 admits exact proof reuse across a
+    # bounded, tree-equivalent base advance while retaining fail-closed replay.
+    uses: kungfu-systems/buildchain/.github/workflows/check.yml@8e9ce32ddd931fb294ab1a9a2a40e89ba743391a
     with:
-      buildchain-ref: fb0ad6d84f10a1f9b872a799e035232d82558bd0
+      buildchain-ref: 8e9ce32ddd931fb294ab1a9a2a40e89ba743391a
       mode: source
       upload-artifacts: true
       source-proof-reuse: true

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.3",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.3",
-    "sourceSha": "221d0e1ab2edc3cc899bd6ba72fa1744a4336d36"
+    "sourceSha": "5f69795fcbcd21a347955dd79edb4ba9d7a8c984"
   },
   "claims": [
     {

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:af392cb353df2f87f5cb553aee38a1706a8df23992e50ca96c63fd38ef3e8dff"
+            "sha256": "sha256:41aa28973b39223558509b5f4c2fc919327bdfcb519f0926b5b3c6acf8a28bf9"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -146,9 +146,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:0143fcf52f42df0daa42860bc1d9148af6a7f309c81022c42982f9807d47320c",
+          "definitionDigest": "sha256:fbeab838677239d84dd323d0fc89e2de4088dc1e0296cefe87d3b784444e515e",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/check.yml@fb0ad6d84f10a1f9b872a799e035232d82558bd0"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/check.yml@8e9ce32ddd931fb294ab1a9a2a40e89ba743391a"],
           "steps": []
         },
         {

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -65,9 +65,9 @@
       "adapter": {
         "type": "buildchain-source",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/check.yml@fb0ad6d84f10a1f9b872a799e035232d82558bd0",
+        "uses": "kungfu-systems/buildchain/.github/workflows/check.yml@8e9ce32ddd931fb294ab1a9a2a40e89ba743391a",
         "with": {
-          "buildchain-ref": "fb0ad6d84f10a1f9b872a799e035232d82558bd0",
+          "buildchain-ref": "8e9ce32ddd931fb294ab1a9a2a40e89ba743391a",
           "mode": "source",
           "upload-artifacts": true,
           "source-proof-reuse": true,

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -80,7 +80,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:cdbe84e0179441724b13d8e8dbc78f84e2eb7f18582f69473372f49b2011dffd"
+          "sourceRoot": "sha256:e6a1091cafe27e20a4904aaeb2dc722f24978e136270fbff7c49df38e7b62e97"
         },
         {
           "path": ".github/workflows/dev-post-merge-advisory.yml",
@@ -874,5 +874,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:91dccffea430dc91c46f008b942885ff036ba038c19101f455991501f4bdef1c"
+  "registryRoot": "sha256:8ad34e714bc1fb5233f61962d3c188d3fe85d132cf0c5171b14ac56076f85db6"
 }

--- a/scripts/alpha-macos-overflow.test.mjs
+++ b/scripts/alpha-macos-overflow.test.mjs
@@ -476,7 +476,7 @@ test('workflow contract keeps candidates exact-source, independent, and publish-
   );
   assert.match(
     affectedNativeWorkflow,
-    /source_acceptance:[\s\S]*uses: kungfu-systems\/buildchain\/\.github\/workflows\/check\.yml@fb0ad6d84f10a1f9b872a799e035232d82558bd0[\s\S]*buildchain-ref: fb0ad6d84f10a1f9b872a799e035232d82558bd0[\s\S]*source-proof-reuse: true[\s\S]*source-proof-policy-paths-json: '\["\.github\/workflows\/affected-native-pr\.yml"\]'[\s\S]*source-proof-closure-paths-json: '\["\.buildchain\/buildchain\.toml","shifu","scripts\/source-acceptance\.mjs","scripts\/require-shifu\.mjs"\]'[\s\S]*source-proof-dependency-paths-json: '\["package\.json","pnpm-lock\.yaml"\]'[\s\S]*source-proof-required-contexts-json: '\["Candidate source acceptance \/ check"\]'/u,
+    /source_acceptance:[\s\S]*uses: kungfu-systems\/buildchain\/\.github\/workflows\/check\.yml@8e9ce32ddd931fb294ab1a9a2a40e89ba743391a[\s\S]*buildchain-ref: 8e9ce32ddd931fb294ab1a9a2a40e89ba743391a[\s\S]*source-proof-reuse: true[\s\S]*source-proof-policy-paths-json: '\["\.github\/workflows\/affected-native-pr\.yml"\]'[\s\S]*source-proof-closure-paths-json: '\["\.buildchain\/buildchain\.toml","shifu","scripts\/source-acceptance\.mjs","scripts\/require-shifu\.mjs"\]'[\s\S]*source-proof-dependency-paths-json: '\["package\.json","pnpm-lock\.yaml"\]'[\s\S]*source-proof-required-contexts-json: '\["Candidate source acceptance \/ check"\]'/u,
   );
   assert.match(
     affectedNativeWorkflow,


### PR DESCRIPTION
## Summary

- supersede conflicting #3202 with a current-protected-base linear successor
- pin Candidate source acceptance to protected Buildchain merge #2872
- reuse exact PR source proof across a bounded, tree-equivalent dev base advance
- retain fail-closed linear replay and legacy two-parent verification
- refresh workflow, publication, and KFD authority projections after the rebase

This is the current-base runtime follow-up to protected Kungfu merge #3182. The functional source-proof/native reuse path is already merged; this patch consumes the protected base-advance repair needed to prevent a qualified proof from falling back to the full source lifecycle after unrelated dev advancement.

## Exact delivery coordinates

- base at forward-port: `4ecf535ae609cfda5b2dfe923e706b1211adc2ef`
- head: `ef8a5a9a2712f20db3fb0c8b96570e34489dc20e`
- Buildchain runtime: `8e9ce32ddd931fb294ab1a9a2a40e89ba743391a` (protected merge #2872)

## Verification

- 31 focused dev-delivery and overflow tests passed
- workflow authority closed-world verification passed
- 38-gate / 7-profile gate catalog alignment passed
- workflow authority serialization test passed
- managed staged pre-commit gates passed for both commits
- `git diff --check`: passed

No required check, Warrant, exact-head/base predicate, or merge-queue authority is bypassed.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix updates an immutable Buildchain runtime pin to consume an already protected base-advance proof verifier; it does not alter an architecture contract or ADR record."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Generated evidence changes only retain exact source and workflow roots; no publication or channel movement occurs.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed

## Non-claims

Local validation does not prove merge-group reuse or the final parent latency SLO. Protected source CI, independent exact-head review, Delivery Warrant admission, and the merge-group canary remain authoritative.
