### PR TITLE
docs(check): define source-proof base-advance canary

### DIFF
--- a/docs/qualification/gates/README.md
+++ b/docs/qualification/gates/README.md
@@ -122,6 +122,16 @@ require both `Candidate source acceptance / check` and the stable
 `affected-native / linux` aggregate. A ruleset change without the matching
 baseline transition therefore fails closed before samples are collected.
 
+The hosted source-proof canary must exercise a real, disjoint protected-base
+advance rather than replaying the pull request against its original base. First
+qualify the target pull-request head, then merge an independently reviewed
+predecessor that does not change the target's source-proof predicates, and only
+then admit the unchanged target head to the merge queue. The merge-group source
+job qualifies the canary only when its rooted receipt reports proof reuse and
+finishes in under 60 seconds without entering the install or check lifecycle.
+Any head mutation, merge conflict, predicate drift, missing receipt, or full
+qualification fallback invalidates that attempt and requires a fresh canary.
+
 The report uses the current source planner to classify samples as `native`,
 `non-native`, or `unknown`, and reports nearest-rank P50/P95 for every stratum.
 Planner failures remain unknown instead of becoming non-native. For each native


### PR DESCRIPTION
## Summary

- define the hosted source-proof canary as a real disjoint protected-base advance
- require the target head to remain unchanged between PR qualification and merge-group admission
- reject head mutation, conflicts, predicate drift, missing proof, full fallback, or a source job at or above 60 seconds

This documentation-only predecessor is intentionally disjoint from the child-4 runtime patch. It will qualify first but remain without `state/ready` until the unchanged runtime successor has its own exact-head source proof. Merging this predecessor then provides the real base advance used by the protected source-proof reuse canary.

## Verification

- `./shifu docs:check`: passed
- `./shifu docs:prose:required`: passed
- managed staged pre-commit gates: passed
- `git diff --check`: passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded documentation change records the existing dev-gate canary procedure and does not alter an architecture contract or ADR record."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed

## Non-claims

This PR only creates the disjoint protected-base transition. It does not itself prove source-proof reuse or the final latency SLO; the unchanged runtime successor merge-group receipt and under-60-second required job remain authoritative.