### PR TITLE
fix(kfx): refresh authoring contract roots

### DIFF
--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.3",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.3",
-    "sourceSha": "f7b3176dd02080da16eaf66abb64e8dbe23a0a43"
+    "sourceSha": "00430dfac025664f9dc61cbb66c405dd29b3411f"
   },
   "claims": [
     {

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "f7b3176dd02080da16eaf66abb64e8dbe23a0a43",
+    "sourceSha": "00430dfac025664f9dc61cbb66c405dd29b3411f",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:766dd8a4f3848a5d60440ead27d60e4400b0630e54d610e977933d580511c8f6"
   },

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:75575478efb2fc4020cb1c3ec41d9059fc818cd074c55ef4aa91e0d7ff353176"
+            "sha256": "sha256:72eedc8a284ccd3720d36698c58a7b024d76194692267a034409552a5df40ac2"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.3",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.3",
-    "sourceSha": "f7b3176dd02080da16eaf66abb64e8dbe23a0a43"
+    "sourceSha": "00430dfac025664f9dc61cbb66c405dd29b3411f"
   },
   "claims": [
     {

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:75575478efb2fc4020cb1c3ec41d9059fc818cd074c55ef4aa91e0d7ff353176"
+            "sha256": "sha256:72eedc8a284ccd3720d36698c58a7b024d76194692267a034409552a5df40ac2"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/framework/core/src/python/kungfu/kfx_authoring_assets/contract.json
+++ b/framework/core/src/python/kungfu/kfx_authoring_assets/contract.json
@@ -28,7 +28,7 @@
       "service-webhook-host.mjs": "460cb9938c8c0596d160fbcd61eb42bcfd9838cf8d154553b2544321af340a11",
       "types.d.ts": "1d063701b8e57c21899fb741d2adaee3cd36fcb0895ccf6f71eb1ef8e6bf5a65"
     },
-    "root": "sha256:422a4c00c8f42a5aacc0cca8ed80c96ed433bd0e9f56a9ed297f60719264e842"
+    "root": "sha256:cf8e0fde840b21408ff4fc8308d26b4a184306bd85ebd68c20a8ed998ce35d8f"
   },
   "schemas": {
     "packageManifest": "kungfu.kfx.manifest/v1",
@@ -158,5 +158,5 @@
       "bytes": 4338
     }
   ],
-  "contractRoot": "sha256:819ae3f7ebd4934cadb28ee5b37f346e1feeb8d4fb1de35d290d75c35ed8c62f"
+  "contractRoot": "sha256:2ede5c87eca5f4433a276722705882df6d70ab54cd45b1232b3a58d076340569"
 }

--- a/framework/core/tests/python/test_kfx_authoring.py
+++ b/framework/core/tests/python/test_kfx_authoring.py
@@ -25,9 +25,13 @@ def scaffold(tmp_path: Path, key: str = "ordinary-webhook") -> Path:
 
 def test_capabilities_bind_exact_installed_sdk_and_authority_boundary():
     capabilities = kfx_authoring.capabilities()
+    repository_root = Path(__file__).resolve().parents[4]
+    kfx_package = json.loads(
+        (repository_root / "framework/kfx/package.json").read_text(encoding="utf-8")
+    )
 
     assert capabilities["status"] == "available"
-    assert capabilities["productVersion"] == "4.0.0-alpha.1"
+    assert capabilities["productVersion"] == kfx_package["version"]
     assert capabilities["sdk"]["source"].endswith("service-authz.ts")
     assert capabilities["sdk"]["root"].startswith("sha256:")
     assert capabilities["lifecycle"][:6] == [

--- a/framework/site/src/kfx-site-bundle.source.json
+++ b/framework/site/src/kfx-site-bundle.source.json
@@ -89,6 +89,14 @@
       "nonClaim": "Scaffold, build, and qualification commands do not install or activate a package."
     },
     {
+      "id": "installed-authoring-contract",
+      "path": "framework/core/src/python/kungfu/kfx_authoring_assets/contract.json",
+      "role": "machine-contract",
+      "maturity": "pre-release",
+      "status": "implemented",
+      "nonClaim": "A version-matched authoring contract describes inert authoring assets; it does not install or activate an extension."
+    },
+    {
       "id": "cli-surface-catalog",
       "path": "framework/core/src/python/kungfu/agent/cli_surface.catalog.json",
       "role": "cli-catalog",
@@ -170,7 +178,7 @@
       "summary": "The 4.0.0-alpha.3 KFX manifest declares package identity, facets, requested capabilities, and host inputs; retained qualification covers package, install, activation, upgrade, rollback, and removal for the maintained webhook suite.",
       "maturity": "pre-release",
       "status": "implemented",
-      "sourceIds": ["kfx-contract", "extensions-guide", "github-webhook-qualification"],
+      "sourceIds": ["kfx-contract", "extensions-guide", "installed-authoring-contract", "github-webhook-qualification"],
       "nonClaim": "A conforming manifest remains inert until native admission."
     },
     {
@@ -179,7 +187,7 @@
       "summary": "On the 4.0.0-alpha.3 development line, a pinned Fact cut, Work, Warrant, policy, exact roots, and CAS guard every accepted package, install, activation, upgrade, rollback, and removal mutation.",
       "maturity": "pre-release",
       "status": "staged",
-      "sourceIds": ["kfx-domain-profile", "kfx-topology", "github-webhook-qualification"],
+      "sourceIds": ["kfx-domain-profile", "kfx-topology", "installed-authoring-contract", "github-webhook-qualification"],
       "nonClaim": "Filesystem discovery and package metadata are observations, not registry authority."
     },
     {
@@ -188,7 +196,7 @@
       "summary": "On the 4.0.0-alpha.3 development line, packages request capabilities while Core policy and an explicit exact grant select the allowed subset for one host and preserve that separation across rollback.",
       "maturity": "pre-release",
       "status": "implemented",
-      "sourceIds": ["kfx-contract", "capability-ownership", "kfx-topology", "github-webhook-qualification"],
+      "sourceIds": ["kfx-contract", "capability-ownership", "kfx-topology", "installed-authoring-contract", "github-webhook-qualification"],
       "nonClaim": "Declaration, KFD success, or package origin does not grant a capability."
     },
     {
@@ -206,7 +214,7 @@
       "summary": "The installed 4.0.0-alpha.3-matched kit supports scaffold, inspect, validate, build, offline qualify, package, install, activate, upgrade, rollback, and remove steps.",
       "maturity": "pre-release",
       "status": "experimental",
-      "sourceIds": ["installed-agent-index", "installed-authoring-brief", "github-webhook-suite-readme"],
+      "sourceIds": ["installed-agent-index", "installed-authoring-brief", "installed-authoring-contract", "github-webhook-suite-readme"],
       "nonClaim": "Authoring output remains inert; lifecycle commands require their declared native admission and do not expose a public listener by themselves."
     },
     {
@@ -215,7 +223,7 @@
       "summary": "The 4.0.0-alpha.3 runtime SDK projection and public CLI catalog expose version-matched authoring, lifecycle, and native inspection routes.",
       "maturity": "pre-release",
       "status": "implemented",
-      "sourceIds": ["installed-authoring-brief", "cli-surface-catalog", "kfx-contract", "github-webhook-suite-readme"],
+      "sourceIds": ["installed-authoring-brief", "installed-authoring-contract", "cli-surface-catalog", "kfx-contract", "github-webhook-suite-readme"],
       "nonClaim": "A visible CLI route does not change its declared mutation or approval policy."
     },
     {
@@ -242,7 +250,7 @@
       "summary": "For the 4.0.0-alpha.3 development line, identity-neutral terminal evidence and the maintained webhook Profile cover installed-product package, lifecycle, rollback, removal, and local reference-suite qualification.",
       "maturity": "pre-release",
       "status": "qualified",
-      "sourceIds": ["kfx-terminal-qualification", "github-webhook-qualification", "github-webhook-suite-readme"],
+      "sourceIds": ["kfx-terminal-qualification", "installed-authoring-contract", "github-webhook-qualification", "github-webhook-suite-readme"],
       "nonClaim": "Current retained evidence does not establish stable compatibility, downstream Site adoption, or completion of the optional real GitHub/AWS China canary."
     }
   ],

--- a/framework/site/src/kfx-site-impact.contract.json
+++ b/framework/site/src/kfx-site-impact.contract.json
@@ -184,6 +184,21 @@
       "disposition": "proof-eligible"
     },
     {
+      "id": "python-kfx-authoring-tests",
+      "selectors": [
+        {
+          "kind": "exact",
+          "value": "framework/core/tests/python/test_kfx_authoring.py"
+        }
+      ],
+      "facets": [
+        "agent-first-authoring",
+        "sdk-cli",
+        "qualification-status"
+      ],
+      "disposition": "proof-eligible"
+    },
+    {
       "id": "root-kfx-test-fixtures",
       "selectors": [
         {

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -815,6 +815,22 @@ function checkInvariantSystem() {
   ]);
 }
 
+function checkKfxAuthoringKit(files = [], { force = false } = {}) {
+  const touched = files.some(
+    (file) =>
+      file === 'framework/api/package.json' ||
+      file === 'framework/kfx/package.json' ||
+      file === 'framework/api/src/capability/service-authz.ts' ||
+      file === 'scripts/generate-kfx-authoring-kit.mjs' ||
+      file.startsWith('framework/core/src/python/kungfu/kfx_authoring_assets/'),
+  );
+  if (!force && !touched) return;
+  run('installed KFX authoring kit generated-root check', 'node', [
+    path.join('scripts', 'generate-kfx-authoring-kit.mjs'),
+    '--check',
+  ]);
+}
+
 function checkStaged() {
   checkNoBashStaged();
   checkTestManifest();
@@ -877,6 +893,7 @@ function checkStaged() {
   checkBiomeFiles('staged', files);
   checkRustFiles('staged', files);
   checkBuildchainKfdEvidence(files);
+  checkKfxAuthoringKit(files);
   checkLibwasmCargoCache(files);
   checkXinfaCrate(files);
 
@@ -949,6 +966,7 @@ function checkChanged() {
   checkBiomeFiles('changed', files);
   checkRustFiles('changed', files);
   checkBuildchainKfdEvidence(files);
+  checkKfxAuthoringKit(files);
   checkLibwasmCargoCache(files);
   checkXinfaCrate(files);
   checkShared();
@@ -972,6 +990,7 @@ function checkAll() {
   run('repo lint + format check', 'pnpm', ['run', 'lint']);
   checkRustFiles('all', [], { force: true });
   checkBuildchainKfdEvidence([], { force: true });
+  checkKfxAuthoringKit([], { force: true });
   checkLibwasmCargoCache([], { force: true });
   checkXinfaCrate([], { force: true });
   checkShared();


### PR DESCRIPTION
## Summary

Refresh generated KFX authoring contract roots after the Alpha.3 version bump, bind the installed authoring contract into Site impact authority, and add an early source gate so future drift fails before product packaging.

## Verification

- generator current
- Python authoring tests 6/6
- capabilities test 1/1
- CLI surface qualification 91/91
- Site impact tests 14/14
- Site suite 26/26
- full staged hooks
- KFD and support matrix
- Project Cut qualified: candidate a14da67c1dbb8a5ece37bd2653ff0958b3758f38, tree 6739cc142784d0ed07ae8b5034ebae28c33408aa

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This repair refreshes generated evidence and impact bindings without changing an architecture contract"
}
-->

Evolution impact: none

## Governance risk check

This PR updates release evidence and provenance surfaces; validation is listed above.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed

Supersedes #3230 with a linear replay on protected base c207f2e4ed8882ccb403265dc23aecec4086c085. The r36 branch and PR remain immutable delivery-attempt evidence.
