### PR TITLE
fix(check): consume linear source replay runtime

### DIFF
--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.3",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.3",
-    "sourceSha": "00430dfac025664f9dc61cbb66c405dd29b3411f"
+    "sourceSha": "274cc22c8dbbe013decf0273ea49a93a4c27d7d4"
   },
   "claims": [
     {

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "00430dfac025664f9dc61cbb66c405dd29b3411f",
+    "sourceSha": "274cc22c8dbbe013decf0273ea49a93a4c27d7d4",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:766dd8a4f3848a5d60440ead27d60e4400b0630e54d610e977933d580511c8f6"
   },

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:72eedc8a284ccd3720d36698c58a7b024d76194692267a034409552a5df40ac2"
+            "sha256": "sha256:a65e19235b31c9236cd5ef77ee06f74b6df4d9b6c2a5ca07d7e45ea571c4530c"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/.github/workflows/affected-native-pr.yml
+++ b/.github/workflows/affected-native-pr.yml
@@ -76,9 +76,11 @@ jobs:
 
   source_acceptance:
     name: Candidate source acceptance
-    uses: kungfu-systems/buildchain/.github/workflows/check.yml@fb0ad6d84f10a1f9b872a799e035232d82558bd0
+    # Protected Buildchain merge #2872 admits exact proof reuse across a
+    # bounded, tree-equivalent base advance while retaining fail-closed replay.
+    uses: kungfu-systems/buildchain/.github/workflows/check.yml@8e9ce32ddd931fb294ab1a9a2a40e89ba743391a
     with:
-      buildchain-ref: fb0ad6d84f10a1f9b872a799e035232d82558bd0
+      buildchain-ref: 8e9ce32ddd931fb294ab1a9a2a40e89ba743391a
       mode: source
       upload-artifacts: true
       source-proof-reuse: true

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.3",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.3",
-    "sourceSha": "00430dfac025664f9dc61cbb66c405dd29b3411f"
+    "sourceSha": "274cc22c8dbbe013decf0273ea49a93a4c27d7d4"
   },
   "claims": [
     {

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:72eedc8a284ccd3720d36698c58a7b024d76194692267a034409552a5df40ac2"
+            "sha256": "sha256:a65e19235b31c9236cd5ef77ee06f74b6df4d9b6c2a5ca07d7e45ea571c4530c"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -146,9 +146,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:0143fcf52f42df0daa42860bc1d9148af6a7f309c81022c42982f9807d47320c",
+          "definitionDigest": "sha256:fbeab838677239d84dd323d0fc89e2de4088dc1e0296cefe87d3b784444e515e",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/check.yml@fb0ad6d84f10a1f9b872a799e035232d82558bd0"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/check.yml@8e9ce32ddd931fb294ab1a9a2a40e89ba743391a"],
           "steps": []
         },
         {

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -65,9 +65,9 @@
       "adapter": {
         "type": "buildchain-source",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/check.yml@fb0ad6d84f10a1f9b872a799e035232d82558bd0",
+        "uses": "kungfu-systems/buildchain/.github/workflows/check.yml@8e9ce32ddd931fb294ab1a9a2a40e89ba743391a",
         "with": {
-          "buildchain-ref": "fb0ad6d84f10a1f9b872a799e035232d82558bd0",
+          "buildchain-ref": "8e9ce32ddd931fb294ab1a9a2a40e89ba743391a",
           "mode": "source",
           "upload-artifacts": true,
           "source-proof-reuse": true,

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -80,7 +80,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:cdbe84e0179441724b13d8e8dbc78f84e2eb7f18582f69473372f49b2011dffd"
+          "sourceRoot": "sha256:e6a1091cafe27e20a4904aaeb2dc722f24978e136270fbff7c49df38e7b62e97"
         },
         {
           "path": ".github/workflows/dev-post-merge-advisory.yml",
@@ -874,5 +874,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:7eaeacd0eeb7adb13016f5b782525f2bcc810352486dd81afb566ce3453798e0"
+  "registryRoot": "sha256:5d9e792b041bd4cd0ed69d1af54f7ffa37690f78ec492758b87601bb7b679057"
 }

--- a/scripts/alpha-macos-overflow.test.mjs
+++ b/scripts/alpha-macos-overflow.test.mjs
@@ -476,7 +476,7 @@ test('workflow contract keeps candidates exact-source, independent, and publish-
   );
   assert.match(
     affectedNativeWorkflow,
-    /source_acceptance:[\s\S]*uses: kungfu-systems\/buildchain\/\.github\/workflows\/check\.yml@fb0ad6d84f10a1f9b872a799e035232d82558bd0[\s\S]*buildchain-ref: fb0ad6d84f10a1f9b872a799e035232d82558bd0[\s\S]*source-proof-reuse: true[\s\S]*source-proof-policy-paths-json: '\["\.github\/workflows\/affected-native-pr\.yml"\]'[\s\S]*source-proof-closure-paths-json: '\["\.buildchain\/buildchain\.toml","shifu","scripts\/source-acceptance\.mjs","scripts\/require-shifu\.mjs"\]'[\s\S]*source-proof-dependency-paths-json: '\["package\.json","pnpm-lock\.yaml"\]'[\s\S]*source-proof-required-contexts-json: '\["Candidate source acceptance \/ check"\]'/u,
+    /source_acceptance:[\s\S]*uses: kungfu-systems\/buildchain\/\.github\/workflows\/check\.yml@8e9ce32ddd931fb294ab1a9a2a40e89ba743391a[\s\S]*buildchain-ref: 8e9ce32ddd931fb294ab1a9a2a40e89ba743391a[\s\S]*source-proof-reuse: true[\s\S]*source-proof-policy-paths-json: '\["\.github\/workflows\/affected-native-pr\.yml"\]'[\s\S]*source-proof-closure-paths-json: '\["\.buildchain\/buildchain\.toml","shifu","scripts\/source-acceptance\.mjs","scripts\/require-shifu\.mjs"\]'[\s\S]*source-proof-dependency-paths-json: '\["package\.json","pnpm-lock\.yaml"\]'[\s\S]*source-proof-required-contexts-json: '\["Candidate source acceptance \/ check"\]'/u,
   );
   assert.match(
     affectedNativeWorkflow,


### PR DESCRIPTION
## Summary

- supersede stale/conflicting #3229 with a fresh linear successor on the current protected base
- pin Candidate source acceptance to protected Buildchain merge #2872
- reuse exact PR source proof across a bounded, tree-equivalent dev base advance
- retain fail-closed linear replay and legacy two-parent verification
- refresh workflow, publication, and KFD authority projections against the new source identity

This successor is based on protected dev `1879b61d757c650f2bc8c68baa4f451ad2294097` after prerequisite #3232 merged. #3229 remains immutable historical evidence; its approval, source CI, Warrant state, and exact-head claims are not reused.

## Native Work

- Assignment: `2026-08-12-kungfu-merge-group-source-proof-reuse`
- fresh Atlas work-admission binding: `sha256:885c77dff8c29007be87c4c531cff06afbd23256ffb4ed33ca5a37803ba5c4b5`
- orchestration boundary: stage-ready, pending protected delivery

## Exact delivery coordinates

- base at qualification: `1879b61d757c650f2bc8c68baa4f451ad2294097`
- head: `784f9e76e4253dc11d41394ea0465e2df7364e61`
- Buildchain runtime: `8e9ce32ddd931fb294ab1a9a2a40e89ba743391a` (protected merge #2872)

## Verification

- complete managed staged pre-commit gates passed
- Buildchain KFD evidence and support-matrix fixed-point checks passed
- alpha macOS overflow tests: 14/14 passed
- workflow/publication focused tests: 12/12 passed
- Gate catalog focused tests: 24/24 passed
- exact diff from protected base is limited to 10 intended files
- `git diff --check`: passed
- fresh exact-head Atlas work admission: verified

Protected source CI, independent exact-head review, Delivery Warrant qualification, merge-group proof reuse, protected merge, release qualification, publication, and runtime activation remain authoritative and pending.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix updates an immutable Buildchain runtime pin and bounded source-proof replay policy without changing an architecture contract or ADR record."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Generated evidence changes only retain exact source and workflow roots; no publication, release cut, channel movement, or runtime activation occurs.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed