### PR TITLE
fix(tui): remove inherited node mode from child env

### DIFF
--- a/framework/tui/src/terminal-lifecycle.test.ts
+++ b/framework/tui/src/terminal-lifecycle.test.ts
@@ -41,6 +41,8 @@ test('child CLI retains installed authority without recursive libnode selection'
 
   assert.equal(child.KUNGFU_AS_VARIANT, undefined);
   assert.equal(child.KUNGFU_NODE_VARIANT_ENTRY, undefined);
+  assert.equal(Object.hasOwn(child, 'KUNGFU_AS_VARIANT'), false);
+  assert.equal(Object.hasOwn(child, 'KUNGFU_NODE_VARIANT_ENTRY'), false);
   assert.equal(child.KUNGFU_INSTALL_SOURCE, 'archive');
   assert.equal(child.KUNGFU_DIR, '/product/runtime');
   assert.equal(

--- a/framework/tui/src/terminal-lifecycle.ts
+++ b/framework/tui/src/terminal-lifecycle.ts
@@ -119,11 +119,11 @@ export function tuiChildCliEnvironment(
   // libnode. Keep the installed runtime and KFX authority roots because the
   // child CLI needs them to prove that its native binding belongs to the exact
   // Release Manifest selected by the product launcher.
-  child.KUNGFU_AS_VARIANT = undefined;
+  Reflect.deleteProperty(child, 'KUNGFU_AS_VARIANT');
   // The trunk pins the active embedded-Node entry while the TUI is running.
   // That pin belongs only to this process: a child CLI must be free to select
   // its own Agent Session entry instead of recursively entering tui.mjs.
-  child.KUNGFU_NODE_VARIANT_ENTRY = undefined;
+  Reflect.deleteProperty(child, 'KUNGFU_NODE_VARIANT_ENTRY');
   return child;
 }
 


### PR DESCRIPTION
## Summary

Prevent the packaged Windows TUI from forwarding own environment properties whose values are undefined into child_process.spawn. The child CLI boundary now physically removes the embedded-Node mode selectors before launching the installed CLI, avoiding the repeatable Windows spawn EINVAL seen in Full Build run 31967448263.

## Related issue

Follow-up to the Windows failure in Full Build run 31967448263 after #3232 merged.

## Changes

- remove KUNGFU_AS_VARIANT and KUNGFU_NODE_VARIANT_ENTRY with Reflect.deleteProperty at the child CLI boundary
- assert that both keys are absent rather than merely resolving to undefined

## Verification

- ./shifu --filter @kungfu-tech/tui exec tsx --test src/terminal-lifecycle.test.ts (14/14)
- ./shifu test:cli-surface-qualification (91/91)
- ./shifu check:source (1114 passed, 11 skipped, 0 failed; full gate passed)
- exact Biome check for both changed files

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix changes only environment sanitization at an existing TUI child-process boundary and does not alter an architecture contract"
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
