### PR TITLE
fix(release): consume immutable Buildchain identity

### DIFF
--- a/.github/workflows/aws-us-macos-burst-qualification.yml
+++ b/.github/workflows/aws-us-macos-burst-qualification.yml
@@ -48,9 +48,11 @@ jobs:
           (inputs.mode == 'full' && inputs.qualification-id == 'mac-full-01')
         )
       }}
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@9baf025baad5faa2d9c2339af06f73adbe4b84a0
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105
     with:
-      buildchain-ref: 9baf025baad5faa2d9c2339af06f73adbe4b84a0
+      buildchain-ref: 675b4f2a51af7e5f2aac58011c7ede0313b2b105
+      buildchain-contract-expected-channel: v3-alpha
+      buildchain-contract-expected-major: v3
       runner-preset: aws-us-ec2-macos-jit
       aws-ec2-macos-runner-label: ${{ inputs.runner-label }}
       setup-rust: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,7 +178,7 @@ jobs:
     if: ${{ always() && needs.preflight.result == 'success' && needs.windows-fast-sentinel.result == 'success' && needs.auditable-demo-fast-sentinel.result == 'success' && !inputs.fast-sentinels-only && fromJSON(inputs.macos-overflow-request-json || '{}').mode != 'control' }}
     # Execute one reviewed Buildchain revision for both the reusable workflow
     # shell and its runtime. Channel and major remain contract metadata only.
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@9baf025baad5faa2d9c2339af06f73adbe4b84a0
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105
     secrets:
       BUILDCHAIN_PROMOTION_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}
       BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN }}
@@ -187,7 +187,9 @@ jobs:
     with:
       # Privileged candidate builds never execute a movable channel or a
       # workflow_dispatch override. Channel and major are metadata only.
-      buildchain-ref: 9baf025baad5faa2d9c2339af06f73adbe4b84a0
+      buildchain-ref: 675b4f2a51af7e5f2aac58011c7ede0313b2b105
+      buildchain-contract-expected-channel: v3-alpha
+      buildchain-contract-expected-major: v3
       publish-source-ref: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').releaseCutSourceRef || '' }}
       publish-anchor-request-json: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').releaseCutSourceRef && toJSON(fromJSON(inputs.macos-overflow-request-json || '{}').releaseCutAnchorRequest) || '' }}
       runner-preset: custom

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -254,9 +254,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:a053c0325dbd7178df34ee7c8a2400e00fabe20ca35ca99066ad82df8827c9ea",
+          "definitionDigest": "sha256:210cf7b8616ecd1ddc00f3027662c0d3ad57807199ff41184fbf3b2aefd0b1d3",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@9baf025baad5faa2d9c2339af06f73adbe4b84a0"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105"],
           "steps": []
         }
       ]
@@ -328,9 +328,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:2393cc59a2cf6421a976ebeea6cc871a016df02a9a3f1b9273dfefebaa0ce9e3",
+          "definitionDigest": "sha256:ace627b308136dd4a51ff51a83c74422493db585b5089bcb5fc928af339dea61",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN","KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@9baf025baad5faa2d9c2339af06f73adbe4b84a0"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105"],
           "steps": []
         },
         {

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -464,9 +464,11 @@
       "adapter": {
         "type": "buildchain-aws-macos-burst",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@9baf025baad5faa2d9c2339af06f73adbe4b84a0",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105",
         "with": {
-          "buildchain-ref": "9baf025baad5faa2d9c2339af06f73adbe4b84a0",
+          "buildchain-ref": "675b4f2a51af7e5f2aac58011c7ede0313b2b105",
+          "buildchain-contract-expected-channel": "v3-alpha",
+          "buildchain-contract-expected-major": "v3",
           "runner-preset": "aws-us-ec2-macos-jit",
           "aws-ec2-macos-runner-label": "${{ inputs.runner-label }}",
           "require-build": true,
@@ -505,7 +507,7 @@
       "adapter": {
         "type": "buildchain-heavy-build",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@9baf025baad5faa2d9c2339af06f73adbe4b84a0",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105",
         "job": {
       "needs": [
         "preflight",
@@ -520,7 +522,9 @@
           }
         },
         "with": {
-        "buildchain-ref": "9baf025baad5faa2d9c2339af06f73adbe4b84a0",
+        "buildchain-ref": "675b4f2a51af7e5f2aac58011c7ede0313b2b105",
+          "buildchain-contract-expected-channel": "v3-alpha",
+          "buildchain-contract-expected-major": "v3",
           "runner-preset": "custom",
       "platforms-json": "${{ fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'self-hosted' && '[{\"id\":\"macos-arm64\",\"name\":\"macOS ARM64 self-hosted primary\",\"platform\":\"macos\",\"runner\":\"[\\\"self-hosted\\\",\\\"macOS\\\",\\\"ARM64\\\",\\\"kungfu-build-v4-macos-arm64\\\"]\",\"capabilities\":[\"native-toolchain\",\"node\",\"product-artifacts\",\"rust\"]}]' || (fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'github-hosted' && '[{\"id\":\"macos-arm64\",\"name\":\"macOS ARM64 GitHub-hosted overflow\",\"platform\":\"macos\",\"runner\":\"[\\\"macos-15\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]}]' || (inputs.platforms-json || '[{\"id\":\"linux-x64\",\"name\":\"Linux x64\",\"platform\":\"linux\",\"runner\":\"[\\\"ubuntu-24.04\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"],\"environment\":{\"CC\":\"gcc-14\",\"CXX\":\"g++-14\"}},{\"id\":\"linux-arm64\",\"name\":\"Linux ARM64\",\"platform\":\"linux\",\"runner\":\"[\\\"ubuntu-24.04-arm\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]},{\"id\":\"macos-arm64\",\"name\":\"macOS ARM64\",\"platform\":\"macos\",\"runner\":\"[\\\"macos-15\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]},{\"id\":\"windows-x64\",\"name\":\"Windows x64\",\"platform\":\"windows\",\"runner\":\"[\\\"windows-2022\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]}]')) }}",
           "self-hosted-offline-fallback": false,

--- a/docs/release-promotion-rehearsal.contract.json
+++ b/docs/release-promotion-rehearsal.contract.json
@@ -10,8 +10,8 @@
     "workflow_shell_resolved_sha": "a60957e3ffc8f9a02f0e9419deebc8d35a3f7198",
     "build_channel_ref": "v3-alpha",
     "build_major": "v3",
-    "build_workflow_shell_resolved_sha": "9baf025baad5faa2d9c2339af06f73adbe4b84a0",
-    "build_runtime_resolved_sha": "9baf025baad5faa2d9c2339af06f73adbe4b84a0",
+    "build_workflow_shell_resolved_sha": "675b4f2a51af7e5f2aac58011c7ede0313b2b105",
+    "build_runtime_resolved_sha": "675b4f2a51af7e5f2aac58011c7ede0313b2b105",
     "alpha": {
       "workflow_ref": "v3-alpha",
       "resolved_sha": "82701ca66f5366ade6ec694c9950d5d8d6db082d",

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -118,7 +118,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:56fe6356f87e82f4c70fd993eed2b229b3408144b169aa8484c1307b9ec196a3"
+          "sourceRoot": "sha256:37524c81dd39c8b08315e7fe631f75b397a572a1d0894a15faa75b4b5a6da52e"
         },
         {
           "path": ".github/workflows/aws-us-windows-burst-qualification.yml",
@@ -136,7 +136,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:140984307dd4b63d38116e36afe6ba31436236b63d0964801e9b86f79e0b0685"
+          "sourceRoot": "sha256:c58e5621abf6fcf282054a08ae47fde24f2cc2ccd6146dab1e36946054b7aa26"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",
@@ -874,5 +874,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:fb0da7b8c112a93311b35d344806f5ea17fa0365d4faa1571951acbe3f80cff9"
+  "registryRoot": "sha256:efc430383cfb53541669afe3271f9e1d3c77469365bf19ddbc8b2358e8f9cca1"
 }

--- a/scripts/alpha-macos-overflow.test.mjs
+++ b/scripts/alpha-macos-overflow.test.mjs
@@ -468,12 +468,17 @@ test('workflow contract keeps candidates exact-source, independent, and publish-
   );
   assert.match(
     workflow,
-    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@9baf025baad5faa2d9c2339af06f73adbe4b84a0/u,
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105/u,
   );
   assert.match(
     workflow,
-    /^\s+buildchain-ref: 9baf025baad5faa2d9c2339af06f73adbe4b84a0$/mu,
+    /^\s+buildchain-ref: 675b4f2a51af7e5f2aac58011c7ede0313b2b105$/mu,
   );
+  assert.match(
+    workflow,
+    /^\s+buildchain-contract-expected-channel: v3-alpha$/mu,
+  );
+  assert.match(workflow, /^\s+buildchain-contract-expected-major: v3$/mu);
   assert.doesNotMatch(workflow, /inputs\.buildchain-ref/u);
   assert.match(
     affectedNativeWorkflow,

--- a/scripts/alpha-promotion-preflight.test.mjs
+++ b/scripts/alpha-promotion-preflight.test.mjs
@@ -587,12 +587,12 @@ test('patrol, normal Alpha builds and sentinels keep one controller authority', 
   );
   assert.match(
     build,
-    /buildchain-ref: 9baf025baad5faa2d9c2339af06f73adbe4b84a0[\s\S]*publish-source-ref: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.releaseCutSourceRef \|\| '' \}\}[\s\S]*publish-anchor-request-json: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.releaseCutSourceRef && toJSON/u,
+    /buildchain-ref: 675b4f2a51af7e5f2aac58011c7ede0313b2b105[\s\S]*buildchain-contract-expected-channel: v3-alpha[\s\S]*buildchain-contract-expected-major: v3[\s\S]*publish-source-ref: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.releaseCutSourceRef \|\| '' \}\}[\s\S]*publish-anchor-request-json: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.releaseCutSourceRef && toJSON/u,
   );
   assert.doesNotMatch(build, /inputs\.buildchain-ref/u);
   assert.match(
     build,
-    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@9baf025baad5faa2d9c2339af06f73adbe4b84a0/u,
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105/u,
   );
   const preBuild = build.slice(0, build.indexOf('\n  build:'));
   assert.doesNotMatch(

--- a/scripts/verify-alpha-release-cut-lock.test.mjs
+++ b/scripts/verify-alpha-release-cut-lock.test.mjs
@@ -80,12 +80,14 @@ test('Alpha.2 r17 keeps its historical channel lock while builds execute one imm
   );
   assert.match(
     build,
-    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@9baf025baad5faa2d9c2339af06f73adbe4b84a0/u,
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105/u,
   );
   assert.match(
     build,
-    /buildchain-ref: 9baf025baad5faa2d9c2339af06f73adbe4b84a0/u,
+    /buildchain-ref: 675b4f2a51af7e5f2aac58011c7ede0313b2b105/u,
   );
+  assert.match(build, /buildchain-contract-expected-channel: v3-alpha/u);
+  assert.match(build, /buildchain-contract-expected-major: v3/u);
   assert.doesNotMatch(build, /inputs\.buildchain-ref/u);
   assert.match(
     promotion,


### PR DESCRIPTION
## Summary

- consume the protected Buildchain `675b4f2a51af7e5f2aac58011c7ede0313b2b105` workflow shell and runtime in both production Build callers
- bind the reviewed `v3-alpha` channel and `v3` major as explicit contract metadata
- refresh workflow-authority and publication-control projections and harden exact-binding tests

## Exact source

- base: `c0abdecb4b28c570596c97c311212af2608261f3`
- head: `7676160dde766f0fe56d4c37992933a3c2411706`
- tree: `ed3fa152dba16affa288420467b26fc5b0e38d83`
- protected target: `dev/v4/v4.0`
- Buildchain protected dependency: `675b4f2a51af7e5f2aac58011c7ede0313b2b105` (PR #2916)

This is the minimal successor after PR #3251 merged. Its post-merge exact-source Build correctly exposed that the previous Buildchain revision could not prove expected channel/major metadata; Buildchain PR #2916 repaired that fail-closed contract without weakening authority.

## Validation

- `./shifu check:source`: 1129 tests, 1118 passed, 11 expected skips, 0 failed
- `./shifu test:alpha-macos-overflow`: 14/14 passed
- `./shifu test:alpha-promotion-preflight`: 97/97 passed
- `./shifu release:promotion:rehearse`: `ok: true`, no tracked/ref/remote/credential side effects
- publication control-plane check: qualifying
- exact-head Atlas work admission issued and verified with binding root `sha256:68f6997e0ac82f3e4ebfdeab09494950fd0f9e8bfe9c2e1137efba1b3f81c537`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix advances an already reviewed immutable Buildchain dependency and strengthens its existing identity assertions without changing an architecture contract or declaring a release promotion."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change consumes an already protected Buildchain revision and remains fail closed. It does not publish a release, activate a runtime, introduce credentials, or expand provider authority.

## Review and delivery

The source commit is authored and published by `dongkeren`. Independent exact-head review, approval, Warrant admission, merge queue, and merge remain assigned to `kungfu-origin`; no protection or required gate is bypassed.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
