### PR TITLE
fix(release): bind Buildchain identity across merge groups

### DIFF
--- a/.github/workflows/affected-native-pr.yml
+++ b/.github/workflows/affected-native-pr.yml
@@ -76,11 +76,12 @@ jobs:
 
   source_acceptance:
     name: Candidate source acceptance
-    # Protected Buildchain merge #2872 admits exact proof reuse across a
-    # bounded, tree-equivalent base advance while retaining fail-closed replay.
-    uses: kungfu-systems/buildchain/.github/workflows/check.yml@8e9ce32ddd931fb294ab1a9a2a40e89ba743391a
+    # Protected Buildchain merge 675b4f2 admits exact proof reuse across a
+    # bounded, tree-equivalent base advance and preserves the merge-group base
+    # history required by the fail-closed source lifecycle.
+    uses: kungfu-systems/buildchain/.github/workflows/check.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105
     with:
-      buildchain-ref: 8e9ce32ddd931fb294ab1a9a2a40e89ba743391a
+      buildchain-ref: 675b4f2a51af7e5f2aac58011c7ede0313b2b105
       mode: source
       upload-artifacts: true
       source-proof-reuse: true

--- a/.github/workflows/aws-us-macos-burst-qualification.yml
+++ b/.github/workflows/aws-us-macos-burst-qualification.yml
@@ -48,9 +48,11 @@ jobs:
           (inputs.mode == 'full' && inputs.qualification-id == 'mac-full-01')
         )
       }}
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@9baf025baad5faa2d9c2339af06f73adbe4b84a0
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105
     with:
-      buildchain-ref: 9baf025baad5faa2d9c2339af06f73adbe4b84a0
+      buildchain-ref: 675b4f2a51af7e5f2aac58011c7ede0313b2b105
+      buildchain-contract-expected-channel: v3-alpha
+      buildchain-contract-expected-major: v3
       runner-preset: aws-us-ec2-macos-jit
       aws-ec2-macos-runner-label: ${{ inputs.runner-label }}
       setup-rust: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,7 +178,7 @@ jobs:
     if: ${{ always() && needs.preflight.result == 'success' && needs.windows-fast-sentinel.result == 'success' && needs.auditable-demo-fast-sentinel.result == 'success' && !inputs.fast-sentinels-only && fromJSON(inputs.macos-overflow-request-json || '{}').mode != 'control' }}
     # Execute one reviewed Buildchain revision for both the reusable workflow
     # shell and its runtime. Channel and major remain contract metadata only.
-    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@9baf025baad5faa2d9c2339af06f73adbe4b84a0
+    uses: kungfu-systems/buildchain/.github/workflows/.build.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105
     secrets:
       BUILDCHAIN_PROMOTION_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}
       BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN: ${{ secrets.BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN }}
@@ -187,7 +187,9 @@ jobs:
     with:
       # Privileged candidate builds never execute a movable channel or a
       # workflow_dispatch override. Channel and major are metadata only.
-      buildchain-ref: 9baf025baad5faa2d9c2339af06f73adbe4b84a0
+      buildchain-ref: 675b4f2a51af7e5f2aac58011c7ede0313b2b105
+      buildchain-contract-expected-channel: v3-alpha
+      buildchain-contract-expected-major: v3
       publish-source-ref: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').releaseCutSourceRef || '' }}
       publish-anchor-request-json: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').releaseCutSourceRef && toJSON(fromJSON(inputs.macos-overflow-request-json || '{}').releaseCutAnchorRequest) || '' }}
       runner-preset: custom

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -254,9 +254,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:a053c0325dbd7178df34ee7c8a2400e00fabe20ca35ca99066ad82df8827c9ea",
+          "definitionDigest": "sha256:210cf7b8616ecd1ddc00f3027662c0d3ad57807199ff41184fbf3b2aefd0b1d3",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@9baf025baad5faa2d9c2339af06f73adbe4b84a0"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105"],
           "steps": []
         }
       ]
@@ -328,9 +328,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:2393cc59a2cf6421a976ebeea6cc871a016df02a9a3f1b9273dfefebaa0ce9e3",
+          "definitionDigest": "sha256:ace627b308136dd4a51ff51a83c74422493db585b5089bcb5fc928af339dea61",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN","KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@9baf025baad5faa2d9c2339af06f73adbe4b84a0"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105"],
           "steps": []
         },
         {

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -146,9 +146,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:fbeab838677239d84dd323d0fc89e2de4088dc1e0296cefe87d3b784444e515e",
+          "definitionDigest": "sha256:15388c81a7d6cd1604b056f378bd45b58ed6bb190927c2c09e7993973ee51a44",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/check.yml@8e9ce32ddd931fb294ab1a9a2a40e89ba743391a"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/check.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105"],
           "steps": []
         },
         {

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -464,9 +464,11 @@
       "adapter": {
         "type": "buildchain-aws-macos-burst",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@9baf025baad5faa2d9c2339af06f73adbe4b84a0",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105",
         "with": {
-          "buildchain-ref": "9baf025baad5faa2d9c2339af06f73adbe4b84a0",
+          "buildchain-ref": "675b4f2a51af7e5f2aac58011c7ede0313b2b105",
+          "buildchain-contract-expected-channel": "v3-alpha",
+          "buildchain-contract-expected-major": "v3",
           "runner-preset": "aws-us-ec2-macos-jit",
           "aws-ec2-macos-runner-label": "${{ inputs.runner-label }}",
           "require-build": true,
@@ -505,7 +507,7 @@
       "adapter": {
         "type": "buildchain-heavy-build",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@9baf025baad5faa2d9c2339af06f73adbe4b84a0",
+        "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105",
         "job": {
       "needs": [
         "preflight",
@@ -520,7 +522,9 @@
           }
         },
         "with": {
-        "buildchain-ref": "9baf025baad5faa2d9c2339af06f73adbe4b84a0",
+        "buildchain-ref": "675b4f2a51af7e5f2aac58011c7ede0313b2b105",
+          "buildchain-contract-expected-channel": "v3-alpha",
+          "buildchain-contract-expected-major": "v3",
           "runner-preset": "custom",
       "platforms-json": "${{ fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'self-hosted' && '[{\"id\":\"macos-arm64\",\"name\":\"macOS ARM64 self-hosted primary\",\"platform\":\"macos\",\"runner\":\"[\\\"self-hosted\\\",\\\"macOS\\\",\\\"ARM64\\\",\\\"kungfu-build-v4-macos-arm64\\\"]\",\"capabilities\":[\"native-toolchain\",\"node\",\"product-artifacts\",\"rust\"]}]' || (fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'github-hosted' && '[{\"id\":\"macos-arm64\",\"name\":\"macOS ARM64 GitHub-hosted overflow\",\"platform\":\"macos\",\"runner\":\"[\\\"macos-15\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]}]' || (inputs.platforms-json || '[{\"id\":\"linux-x64\",\"name\":\"Linux x64\",\"platform\":\"linux\",\"runner\":\"[\\\"ubuntu-24.04\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"],\"environment\":{\"CC\":\"gcc-14\",\"CXX\":\"g++-14\"}},{\"id\":\"linux-arm64\",\"name\":\"Linux ARM64\",\"platform\":\"linux\",\"runner\":\"[\\\"ubuntu-24.04-arm\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]},{\"id\":\"macos-arm64\",\"name\":\"macOS ARM64\",\"platform\":\"macos\",\"runner\":\"[\\\"macos-15\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]},{\"id\":\"windows-x64\",\"name\":\"Windows x64\",\"platform\":\"windows\",\"runner\":\"[\\\"windows-2022\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]}]')) }}",
           "self-hosted-offline-fallback": false,

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -65,9 +65,9 @@
       "adapter": {
         "type": "buildchain-source",
         "kind": "job-uses",
-        "uses": "kungfu-systems/buildchain/.github/workflows/check.yml@8e9ce32ddd931fb294ab1a9a2a40e89ba743391a",
+        "uses": "kungfu-systems/buildchain/.github/workflows/check.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105",
         "with": {
-          "buildchain-ref": "8e9ce32ddd931fb294ab1a9a2a40e89ba743391a",
+          "buildchain-ref": "675b4f2a51af7e5f2aac58011c7ede0313b2b105",
           "mode": "source",
           "upload-artifacts": true,
           "source-proof-reuse": true,

--- a/docs/release-promotion-rehearsal.contract.json
+++ b/docs/release-promotion-rehearsal.contract.json
@@ -10,8 +10,8 @@
     "workflow_shell_resolved_sha": "a60957e3ffc8f9a02f0e9419deebc8d35a3f7198",
     "build_channel_ref": "v3-alpha",
     "build_major": "v3",
-    "build_workflow_shell_resolved_sha": "9baf025baad5faa2d9c2339af06f73adbe4b84a0",
-    "build_runtime_resolved_sha": "9baf025baad5faa2d9c2339af06f73adbe4b84a0",
+    "build_workflow_shell_resolved_sha": "675b4f2a51af7e5f2aac58011c7ede0313b2b105",
+    "build_runtime_resolved_sha": "675b4f2a51af7e5f2aac58011c7ede0313b2b105",
     "alpha": {
       "workflow_ref": "v3-alpha",
       "resolved_sha": "82701ca66f5366ade6ec694c9950d5d8d6db082d",

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -80,7 +80,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:e6a1091cafe27e20a4904aaeb2dc722f24978e136270fbff7c49df38e7b62e97"
+          "sourceRoot": "sha256:5555e74806d60b7dd3f528805aedf571ff35167b5c0ba578a9d194e4475c7769"
         },
         {
           "path": ".github/workflows/dev-post-merge-advisory.yml",
@@ -874,5 +874,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:efc430383cfb53541669afe3271f9e1d3c77469365bf19ddbc8b2358e8f9cca1"
+  "registryRoot": "sha256:40589805231f5a0533bfa239a60405a2f1d597925c6d4f58cf5883f3037ac638"
 }

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -118,7 +118,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:56fe6356f87e82f4c70fd993eed2b229b3408144b169aa8484c1307b9ec196a3"
+          "sourceRoot": "sha256:37524c81dd39c8b08315e7fe631f75b397a572a1d0894a15faa75b4b5a6da52e"
         },
         {
           "path": ".github/workflows/aws-us-windows-burst-qualification.yml",
@@ -136,7 +136,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:140984307dd4b63d38116e36afe6ba31436236b63d0964801e9b86f79e0b0685"
+          "sourceRoot": "sha256:c58e5621abf6fcf282054a08ae47fde24f2cc2ccd6146dab1e36946054b7aa26"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",
@@ -874,5 +874,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:fb0da7b8c112a93311b35d344806f5ea17fa0365d4faa1571951acbe3f80cff9"
+  "registryRoot": "sha256:efc430383cfb53541669afe3271f9e1d3c77469365bf19ddbc8b2358e8f9cca1"
 }

--- a/scripts/alpha-macos-overflow.test.mjs
+++ b/scripts/alpha-macos-overflow.test.mjs
@@ -482,7 +482,7 @@ test('workflow contract keeps candidates exact-source, independent, and publish-
   assert.doesNotMatch(workflow, /inputs\.buildchain-ref/u);
   assert.match(
     affectedNativeWorkflow,
-    /source_acceptance:[\s\S]*uses: kungfu-systems\/buildchain\/\.github\/workflows\/check\.yml@8e9ce32ddd931fb294ab1a9a2a40e89ba743391a[\s\S]*buildchain-ref: 8e9ce32ddd931fb294ab1a9a2a40e89ba743391a[\s\S]*source-proof-reuse: true[\s\S]*source-proof-policy-paths-json: '\["\.github\/workflows\/affected-native-pr\.yml"\]'[\s\S]*source-proof-closure-paths-json: '\["\.buildchain\/buildchain\.toml","shifu","scripts\/source-acceptance\.mjs","scripts\/require-shifu\.mjs"\]'[\s\S]*source-proof-dependency-paths-json: '\["package\.json","pnpm-lock\.yaml"\]'[\s\S]*source-proof-required-contexts-json: '\["Candidate source acceptance \/ check"\]'/u,
+    /source_acceptance:[\s\S]*uses: kungfu-systems\/buildchain\/\.github\/workflows\/check\.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105[\s\S]*buildchain-ref: 675b4f2a51af7e5f2aac58011c7ede0313b2b105[\s\S]*source-proof-reuse: true[\s\S]*source-proof-policy-paths-json: '\["\.github\/workflows\/affected-native-pr\.yml"\]'[\s\S]*source-proof-closure-paths-json: '\["\.buildchain\/buildchain\.toml","shifu","scripts\/source-acceptance\.mjs","scripts\/require-shifu\.mjs"\]'[\s\S]*source-proof-dependency-paths-json: '\["package\.json","pnpm-lock\.yaml"\]'[\s\S]*source-proof-required-contexts-json: '\["Candidate source acceptance \/ check"\]'/u,
   );
   assert.match(
     affectedNativeWorkflow,

--- a/scripts/alpha-macos-overflow.test.mjs
+++ b/scripts/alpha-macos-overflow.test.mjs
@@ -468,12 +468,17 @@ test('workflow contract keeps candidates exact-source, independent, and publish-
   );
   assert.match(
     workflow,
-    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@9baf025baad5faa2d9c2339af06f73adbe4b84a0/u,
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105/u,
   );
   assert.match(
     workflow,
-    /^\s+buildchain-ref: 9baf025baad5faa2d9c2339af06f73adbe4b84a0$/mu,
+    /^\s+buildchain-ref: 675b4f2a51af7e5f2aac58011c7ede0313b2b105$/mu,
   );
+  assert.match(
+    workflow,
+    /^\s+buildchain-contract-expected-channel: v3-alpha$/mu,
+  );
+  assert.match(workflow, /^\s+buildchain-contract-expected-major: v3$/mu);
   assert.doesNotMatch(workflow, /inputs\.buildchain-ref/u);
   assert.match(
     affectedNativeWorkflow,

--- a/scripts/alpha-promotion-preflight.test.mjs
+++ b/scripts/alpha-promotion-preflight.test.mjs
@@ -587,12 +587,12 @@ test('patrol, normal Alpha builds and sentinels keep one controller authority', 
   );
   assert.match(
     build,
-    /buildchain-ref: 9baf025baad5faa2d9c2339af06f73adbe4b84a0[\s\S]*publish-source-ref: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.releaseCutSourceRef \|\| '' \}\}[\s\S]*publish-anchor-request-json: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.releaseCutSourceRef && toJSON/u,
+    /buildchain-ref: 675b4f2a51af7e5f2aac58011c7ede0313b2b105[\s\S]*buildchain-contract-expected-channel: v3-alpha[\s\S]*buildchain-contract-expected-major: v3[\s\S]*publish-source-ref: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.releaseCutSourceRef \|\| '' \}\}[\s\S]*publish-anchor-request-json: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.releaseCutSourceRef && toJSON/u,
   );
   assert.doesNotMatch(build, /inputs\.buildchain-ref/u);
   assert.match(
     build,
-    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@9baf025baad5faa2d9c2339af06f73adbe4b84a0/u,
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105/u,
   );
   const preBuild = build.slice(0, build.indexOf('\n  build:'));
   assert.doesNotMatch(

--- a/scripts/verify-alpha-release-cut-lock.test.mjs
+++ b/scripts/verify-alpha-release-cut-lock.test.mjs
@@ -80,12 +80,14 @@ test('Alpha.2 r17 keeps its historical channel lock while builds execute one imm
   );
   assert.match(
     build,
-    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@9baf025baad5faa2d9c2339af06f73adbe4b84a0/u,
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/\.build\.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105/u,
   );
   assert.match(
     build,
-    /buildchain-ref: 9baf025baad5faa2d9c2339af06f73adbe4b84a0/u,
+    /buildchain-ref: 675b4f2a51af7e5f2aac58011c7ede0313b2b105/u,
   );
+  assert.match(build, /buildchain-contract-expected-channel: v3-alpha/u);
+  assert.match(build, /buildchain-contract-expected-major: v3/u);
   assert.doesNotMatch(build, /inputs\.buildchain-ref/u);
   assert.match(
     promotion,


### PR DESCRIPTION
## Summary

- consume the protected Buildchain `675b4f2a51af7e5f2aac58011c7ede0313b2b105` workflow shell and runtime in both production Build callers
- bind the reviewed `v3-alpha` channel and `v3` major as explicit contract metadata
- advance affected-native source acceptance to the same protected Buildchain revision so merge-group checkouts retain the protected base history
- refresh workflow-authority and publication-control projections and harden exact-binding tests

## Exact source

- base: `c0abdecb4b28c570596c97c311212af2608261f3`
- head: `ed7a759764703def90dd273de778183ec7c8554e`
- tree: `4116b0fde4ecf2c26ed51b86fa7d27eeacee0490`
- protected target: `dev/v4/v4.0`
- Buildchain protected dependency: `675b4f2a51af7e5f2aac58011c7ede0313b2b105` (PR #2916)

This supersedes PR #3258 without weakening authority. PR #3258 proved the immutable Buildchain identity locally and at exact-head source acceptance, but the active merge group exposed that its older reusable-workflow pin used a shallow checkout and could not resolve the protected source base. This successor uses the already protected Buildchain fix consistently for the caller and merge-group source gate.

## Validation

- `./shifu check:source`: passed; Python work-state 40/40, runtime upgrade 134/134, desktop adapter 73/73, TypeScript and Biome clean, final build-free source gate passed
- source contract suite: 1129 tests, 1118 passed, 11 expected skips, 0 failed
- `./shifu test:alpha-macos-overflow`: 14/14 passed
- `./shifu test:alpha-promotion-preflight`: 97/97 passed
- `./shifu release:promotion:rehearse`: `ok: true`, no tracked/ref/remote/credential side effects
- `./shifu test:release-publication-control-plane`: 11/11 passed
- exact-head Atlas work admission issued and verified with binding root `sha256:5aa045a093544252258f6e2ed964cfaaafb7bc02c6b7dcea1ebb5cc3566e754a`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix advances an already reviewed immutable Buildchain dependency and repairs its merge-group source checkout without changing an architecture contract or declaring a release promotion."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change consumes an already protected Buildchain revision and remains fail closed. It does not publish a release, activate a runtime, introduce credentials, or expand provider authority.

## Review and delivery

The source commit is authored and published by `dongkeren`. Independent exact-head review, approval, Warrant admission, merge queue, and merge remain assigned to `kungfu-origin`; no protection or required gate is bypassed.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
