### PR TITLE
fix(release): use semantic Buildchain channel

### DIFF
--- a/.github/workflows/aws-us-macos-burst-qualification.yml
+++ b/.github/workflows/aws-us-macos-burst-qualification.yml
@@ -51,7 +51,7 @@ jobs:
     uses: kungfu-systems/buildchain/.github/workflows/.build.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105
     with:
       buildchain-ref: 675b4f2a51af7e5f2aac58011c7ede0313b2b105
-      buildchain-contract-expected-channel: v3-alpha
+      buildchain-contract-expected-channel: alpha
       buildchain-contract-expected-major: v3
       runner-preset: aws-us-ec2-macos-jit
       aws-ec2-macos-runner-label: ${{ inputs.runner-label }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,7 +188,7 @@ jobs:
       # Privileged candidate builds never execute a movable channel or a
       # workflow_dispatch override. Channel and major are metadata only.
       buildchain-ref: 675b4f2a51af7e5f2aac58011c7ede0313b2b105
-      buildchain-contract-expected-channel: v3-alpha
+      buildchain-contract-expected-channel: alpha
       buildchain-contract-expected-major: v3
       publish-source-ref: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').releaseCutSourceRef || '' }}
       publish-anchor-request-json: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').releaseCutSourceRef && toJSON(fromJSON(inputs.macos-overflow-request-json || '{}').releaseCutAnchorRequest) || '' }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -254,7 +254,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:210cf7b8616ecd1ddc00f3027662c0d3ad57807199ff41184fbf3b2aefd0b1d3",
+          "definitionDigest": "sha256:ea931acfdfd1b834638b707f769e880cd13bef72d36f0a5cd0caf8e276868735",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105"],
           "steps": []
@@ -328,7 +328,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:ace627b308136dd4a51ff51a83c74422493db585b5089bcb5fc928af339dea61",
+          "definitionDigest": "sha256:15b09f4cf46b1e4ce4c929f7d9565b0ec4ba3ba60d18ba7dddaeab311916cdee",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN","KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105"],
           "steps": []

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -467,7 +467,7 @@
         "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105",
         "with": {
           "buildchain-ref": "675b4f2a51af7e5f2aac58011c7ede0313b2b105",
-          "buildchain-contract-expected-channel": "v3-alpha",
+          "buildchain-contract-expected-channel": "alpha",
           "buildchain-contract-expected-major": "v3",
           "runner-preset": "aws-us-ec2-macos-jit",
           "aws-ec2-macos-runner-label": "${{ inputs.runner-label }}",
@@ -523,7 +523,7 @@
         },
         "with": {
         "buildchain-ref": "675b4f2a51af7e5f2aac58011c7ede0313b2b105",
-          "buildchain-contract-expected-channel": "v3-alpha",
+          "buildchain-contract-expected-channel": "alpha",
           "buildchain-contract-expected-major": "v3",
           "runner-preset": "custom",
       "platforms-json": "${{ fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'self-hosted' && '[{\"id\":\"macos-arm64\",\"name\":\"macOS ARM64 self-hosted primary\",\"platform\":\"macos\",\"runner\":\"[\\\"self-hosted\\\",\\\"macOS\\\",\\\"ARM64\\\",\\\"kungfu-build-v4-macos-arm64\\\"]\",\"capabilities\":[\"native-toolchain\",\"node\",\"product-artifacts\",\"rust\"]}]' || (fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'github-hosted' && '[{\"id\":\"macos-arm64\",\"name\":\"macOS ARM64 GitHub-hosted overflow\",\"platform\":\"macos\",\"runner\":\"[\\\"macos-15\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]}]' || (inputs.platforms-json || '[{\"id\":\"linux-x64\",\"name\":\"Linux x64\",\"platform\":\"linux\",\"runner\":\"[\\\"ubuntu-24.04\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"],\"environment\":{\"CC\":\"gcc-14\",\"CXX\":\"g++-14\"}},{\"id\":\"linux-arm64\",\"name\":\"Linux ARM64\",\"platform\":\"linux\",\"runner\":\"[\\\"ubuntu-24.04-arm\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]},{\"id\":\"macos-arm64\",\"name\":\"macOS ARM64\",\"platform\":\"macos\",\"runner\":\"[\\\"macos-15\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]},{\"id\":\"windows-x64\",\"name\":\"Windows x64\",\"platform\":\"windows\",\"runner\":\"[\\\"windows-2022\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]}]')) }}",

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -118,7 +118,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:37524c81dd39c8b08315e7fe631f75b397a572a1d0894a15faa75b4b5a6da52e"
+          "sourceRoot": "sha256:e8552047f420b6a69de4d8dcb1c15c3c3a31eb07a161f64b96d38da376b26794"
         },
         {
           "path": ".github/workflows/aws-us-windows-burst-qualification.yml",
@@ -136,7 +136,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:c58e5621abf6fcf282054a08ae47fde24f2cc2ccd6146dab1e36946054b7aa26"
+          "sourceRoot": "sha256:8f7b82e1e0ccdb919580ff88083867229d7d771523c66e4071434ae7cbd6be75"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",
@@ -877,5 +877,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:405d8ee4350e9fe4a82f48cd28c089542b808e686521ad2d9fca868e3398cdf6"
+  "registryRoot": "sha256:888025549022f1671397499b9f6982a1e83776b0f97a861e619fa78367a5561d"
 }

--- a/scripts/alpha-macos-overflow.test.mjs
+++ b/scripts/alpha-macos-overflow.test.mjs
@@ -474,10 +474,7 @@ test('workflow contract keeps candidates exact-source, independent, and publish-
     workflow,
     /^\s+buildchain-ref: 675b4f2a51af7e5f2aac58011c7ede0313b2b105$/mu,
   );
-  assert.match(
-    workflow,
-    /^\s+buildchain-contract-expected-channel: v3-alpha$/mu,
-  );
+  assert.match(workflow, /^\s+buildchain-contract-expected-channel: alpha$/mu);
   assert.match(workflow, /^\s+buildchain-contract-expected-major: v3$/mu);
   assert.doesNotMatch(workflow, /inputs\.buildchain-ref/u);
   assert.match(

--- a/scripts/alpha-promotion-preflight.test.mjs
+++ b/scripts/alpha-promotion-preflight.test.mjs
@@ -587,7 +587,7 @@ test('patrol, normal Alpha builds and sentinels keep one controller authority', 
   );
   assert.match(
     build,
-    /buildchain-ref: 675b4f2a51af7e5f2aac58011c7ede0313b2b105[\s\S]*buildchain-contract-expected-channel: v3-alpha[\s\S]*buildchain-contract-expected-major: v3[\s\S]*publish-source-ref: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.releaseCutSourceRef \|\| '' \}\}[\s\S]*publish-anchor-request-json: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.releaseCutSourceRef && toJSON/u,
+    /buildchain-ref: 675b4f2a51af7e5f2aac58011c7ede0313b2b105[\s\S]*buildchain-contract-expected-channel: alpha[\s\S]*buildchain-contract-expected-major: v3[\s\S]*publish-source-ref: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.releaseCutSourceRef \|\| '' \}\}[\s\S]*publish-anchor-request-json: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.releaseCutSourceRef && toJSON/u,
   );
   assert.doesNotMatch(build, /inputs\.buildchain-ref/u);
   assert.match(

--- a/scripts/verify-alpha-release-cut-lock.test.mjs
+++ b/scripts/verify-alpha-release-cut-lock.test.mjs
@@ -86,7 +86,7 @@ test('Alpha.2 r17 keeps its historical channel lock while builds execute one imm
     build,
     /buildchain-ref: 675b4f2a51af7e5f2aac58011c7ede0313b2b105/u,
   );
-  assert.match(build, /buildchain-contract-expected-channel: v3-alpha/u);
+  assert.match(build, /buildchain-contract-expected-channel: alpha/u);
   assert.match(build, /buildchain-contract-expected-major: v3/u);
   assert.doesNotMatch(build, /inputs\.buildchain-ref/u);
   assert.match(


### PR DESCRIPTION
Follow-up correction for goal `2026-07-29-kungfu-terminal-review-remediation` after the exact post-merge Build run exposed a semantic channel mismatch.

Exact candidate:
- protected base: `04c804c31b89aaf31d0763416cda15d29e5cc4f0`
- head: `7136278ad5937f2f29813c7d0d3e60b384c0a7a9`
- tree: `61de83d0d64ade28155d6b6898a8be44bb0efdad`
- scope: 8 files, 12 insertions, 15 deletions

Post-merge Build run `32032986273` rejected the immutable Buildchain contract at Trust gate because the caller supplied ref label `v3-alpha` where the pinned Buildchain validator requires semantic channel `alpha`. The immutable workflow/runtime SHA and contract lock remain unchanged. This patch corrects only the semantic channel input in both Build callers, refreshes the generated workflow and publication authority roots, and updates the exact contract tests.

Local qualification:
- pinned Buildchain `675b4f2a51af7e5f2aac58011c7ede0313b2b105` validator: `alpha` -> `channel-bound`; prior `v3-alpha` -> `channel-binding-mismatch`
- `./shifu check:source`: passed
- Node tests: 1132 total, 1121 pass, 11 expected skips, 0 fail
- Agent Work Python: 40/40; runtime upgrade: 134/134; desktop update: 73/73
- TypeScript, Biome, release publication control plane, KFD 195/195, and staged commit gates: passed
- zero-write tracked root: `sha256:7a9ef04603187f34a91cd9729ddf782091dcf5a4cd8b4579955b45c4aabbb660`
- zero-write untracked root empty: `sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This follow-up corrects the semantic channel value consumed by an already reviewed immutable Buildchain validator. It does not change architecture authority, the immutable runtime, the contract lock, or any public release decision."
}
-->

This PR follows merged PR #3270 and the exact failed post-merge Build run. It requires fresh exact-head Core evidence, independent `kungfu-origin` review, non-preemptive Delivery Warrant admission, merge queue completion, a new exact-SHA post-merge qualification set, and a fresh terminal-review attestation.
