### PR TITLE
fix(release): bind alpha channel identity

### DIFF
--- a/.github/workflows/aws-us-macos-burst-qualification.yml
+++ b/.github/workflows/aws-us-macos-burst-qualification.yml
@@ -51,7 +51,7 @@ jobs:
     uses: kungfu-systems/buildchain/.github/workflows/.build.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105
     with:
       buildchain-ref: 675b4f2a51af7e5f2aac58011c7ede0313b2b105
-      buildchain-contract-expected-channel: v3-alpha
+      buildchain-contract-expected-channel: alpha
       buildchain-contract-expected-major: v3
       runner-preset: aws-us-ec2-macos-jit
       aws-ec2-macos-runner-label: ${{ inputs.runner-label }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,7 +188,7 @@ jobs:
       # Privileged candidate builds never execute a movable channel or a
       # workflow_dispatch override. Channel and major are metadata only.
       buildchain-ref: 675b4f2a51af7e5f2aac58011c7ede0313b2b105
-      buildchain-contract-expected-channel: v3-alpha
+      buildchain-contract-expected-channel: alpha
       buildchain-contract-expected-major: v3
       publish-source-ref: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').releaseCutSourceRef || '' }}
       publish-anchor-request-json: ${{ fromJSON(inputs.macos-overflow-request-json || '{}').releaseCutSourceRef && toJSON(fromJSON(inputs.macos-overflow-request-json || '{}').releaseCutAnchorRequest) || '' }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -254,7 +254,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:210cf7b8616ecd1ddc00f3027662c0d3ad57807199ff41184fbf3b2aefd0b1d3",
+          "definitionDigest": "sha256:ea931acfdfd1b834638b707f769e880cd13bef72d36f0a5cd0caf8e276868735",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105"],
           "steps": []
@@ -328,7 +328,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:ace627b308136dd4a51ff51a83c74422493db585b5089bcb5fc928af339dea61",
+          "definitionDigest": "sha256:15b09f4cf46b1e4ce4c929f7d9565b0ec4ba3ba60d18ba7dddaeab311916cdee",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN","KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105"],
           "steps": []

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -467,7 +467,7 @@
         "uses": "kungfu-systems/buildchain/.github/workflows/.build.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105",
         "with": {
           "buildchain-ref": "675b4f2a51af7e5f2aac58011c7ede0313b2b105",
-          "buildchain-contract-expected-channel": "v3-alpha",
+          "buildchain-contract-expected-channel": "alpha",
           "buildchain-contract-expected-major": "v3",
           "runner-preset": "aws-us-ec2-macos-jit",
           "aws-ec2-macos-runner-label": "${{ inputs.runner-label }}",
@@ -523,7 +523,7 @@
         },
         "with": {
         "buildchain-ref": "675b4f2a51af7e5f2aac58011c7ede0313b2b105",
-          "buildchain-contract-expected-channel": "v3-alpha",
+          "buildchain-contract-expected-channel": "alpha",
           "buildchain-contract-expected-major": "v3",
           "runner-preset": "custom",
       "platforms-json": "${{ fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'self-hosted' && '[{\"id\":\"macos-arm64\",\"name\":\"macOS ARM64 self-hosted primary\",\"platform\":\"macos\",\"runner\":\"[\\\"self-hosted\\\",\\\"macOS\\\",\\\"ARM64\\\",\\\"kungfu-build-v4-macos-arm64\\\"]\",\"capabilities\":[\"native-toolchain\",\"node\",\"product-artifacts\",\"rust\"]}]' || (fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'github-hosted' && '[{\"id\":\"macos-arm64\",\"name\":\"macOS ARM64 GitHub-hosted overflow\",\"platform\":\"macos\",\"runner\":\"[\\\"macos-15\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]}]' || (inputs.platforms-json || '[{\"id\":\"linux-x64\",\"name\":\"Linux x64\",\"platform\":\"linux\",\"runner\":\"[\\\"ubuntu-24.04\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"],\"environment\":{\"CC\":\"gcc-14\",\"CXX\":\"g++-14\"}},{\"id\":\"linux-arm64\",\"name\":\"Linux ARM64\",\"platform\":\"linux\",\"runner\":\"[\\\"ubuntu-24.04-arm\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]},{\"id\":\"macos-arm64\",\"name\":\"macOS ARM64\",\"platform\":\"macos\",\"runner\":\"[\\\"macos-15\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]},{\"id\":\"windows-x64\",\"name\":\"Windows x64\",\"platform\":\"windows\",\"runner\":\"[\\\"windows-2022\\\"]\",\"capabilities\":[\"node\",\"native-toolchain\",\"product-artifacts\",\"rust\"]}]')) }}",

--- a/framework/release/publication-control-plane.mjs
+++ b/framework/release/publication-control-plane.mjs
@@ -127,11 +127,22 @@ export function validateBuildWorkflowAuthority(
   ];
   const buildchainRefLines =
     buildWorkflow.match(/^\s+buildchain-ref:\s*.+$/gmu) || [];
+  const expectedChannelLines =
+    buildWorkflow.match(/^\s+buildchain-contract-expected-channel:\s*.+$/gmu) ||
+    [];
+  const expectedMajorLines =
+    buildWorkflow.match(/^\s+buildchain-contract-expected-major:\s*.+$/gmu) ||
+    [];
   if (
     buildShellCalls.length !== 1 ||
     buildShellCalls[0][1] !== workflowShellSha ||
     buildchainRefLines.length !== 1 ||
     buildchainRefLines[0].trim() !== `buildchain-ref: ${runtimeSha}` ||
+    expectedChannelLines.length !== 1 ||
+    expectedChannelLines[0].trim() !==
+      'buildchain-contract-expected-channel: alpha' ||
+    expectedMajorLines.length !== 1 ||
+    expectedMajorLines[0].trim() !== 'buildchain-contract-expected-major: v3' ||
     buildWorkflow.includes('inputs.buildchain-ref') ||
     buildWorkflow.includes('kungfu-trader/workflows@v1')
   )

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -118,7 +118,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:37524c81dd39c8b08315e7fe631f75b397a572a1d0894a15faa75b4b5a6da52e"
+          "sourceRoot": "sha256:e8552047f420b6a69de4d8dcb1c15c3c3a31eb07a161f64b96d38da376b26794"
         },
         {
           "path": ".github/workflows/aws-us-windows-burst-qualification.yml",
@@ -136,7 +136,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:c58e5621abf6fcf282054a08ae47fde24f2cc2ccd6146dab1e36946054b7aa26"
+          "sourceRoot": "sha256:8f7b82e1e0ccdb919580ff88083867229d7d771523c66e4071434ae7cbd6be75"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",
@@ -877,5 +877,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:405d8ee4350e9fe4a82f48cd28c089542b808e686521ad2d9fca868e3398cdf6"
+  "registryRoot": "sha256:888025549022f1671397499b9f6982a1e83776b0f97a861e619fa78367a5561d"
 }

--- a/scripts/alpha-macos-overflow.test.mjs
+++ b/scripts/alpha-macos-overflow.test.mjs
@@ -474,10 +474,7 @@ test('workflow contract keeps candidates exact-source, independent, and publish-
     workflow,
     /^\s+buildchain-ref: 675b4f2a51af7e5f2aac58011c7ede0313b2b105$/mu,
   );
-  assert.match(
-    workflow,
-    /^\s+buildchain-contract-expected-channel: v3-alpha$/mu,
-  );
+  assert.match(workflow, /^\s+buildchain-contract-expected-channel: alpha$/mu);
   assert.match(workflow, /^\s+buildchain-contract-expected-major: v3$/mu);
   assert.doesNotMatch(workflow, /inputs\.buildchain-ref/u);
   assert.match(

--- a/scripts/alpha-promotion-preflight.test.mjs
+++ b/scripts/alpha-promotion-preflight.test.mjs
@@ -587,7 +587,7 @@ test('patrol, normal Alpha builds and sentinels keep one controller authority', 
   );
   assert.match(
     build,
-    /buildchain-ref: 675b4f2a51af7e5f2aac58011c7ede0313b2b105[\s\S]*buildchain-contract-expected-channel: v3-alpha[\s\S]*buildchain-contract-expected-major: v3[\s\S]*publish-source-ref: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.releaseCutSourceRef \|\| '' \}\}[\s\S]*publish-anchor-request-json: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.releaseCutSourceRef && toJSON/u,
+    /buildchain-ref: 675b4f2a51af7e5f2aac58011c7ede0313b2b105[\s\S]*buildchain-contract-expected-channel: alpha[\s\S]*buildchain-contract-expected-major: v3[\s\S]*publish-source-ref: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.releaseCutSourceRef \|\| '' \}\}[\s\S]*publish-anchor-request-json: \$\{\{ fromJSON\(inputs\.macos-overflow-request-json \|\| '\{\}'\)\.releaseCutSourceRef && toJSON/u,
   );
   assert.doesNotMatch(build, /inputs\.buildchain-ref/u);
   assert.match(

--- a/scripts/release-publication-control-plane.test.mjs
+++ b/scripts/release-publication-control-plane.test.mjs
@@ -110,6 +110,17 @@ test('build authority pins workflow and runtime bytes while recording channel id
     () =>
       validateBuildWorkflowAuthority(
         source.replace(
+          'buildchain-contract-expected-channel: alpha',
+          'buildchain-contract-expected-channel: v3-alpha',
+        ),
+        buildchainContract,
+      ),
+    /authority drift/u,
+  );
+  assert.throws(
+    () =>
+      validateBuildWorkflowAuthority(
+        source.replace(
           `buildchain-ref: ${shellSha}`,
           "buildchain-ref: ${{ inputs.buildchain-ref || 'v3-alpha' }}",
         ),

--- a/scripts/verify-alpha-release-cut-lock.test.mjs
+++ b/scripts/verify-alpha-release-cut-lock.test.mjs
@@ -86,7 +86,7 @@ test('Alpha.2 r17 keeps its historical channel lock while builds execute one imm
     build,
     /buildchain-ref: 675b4f2a51af7e5f2aac58011c7ede0313b2b105/u,
   );
-  assert.match(build, /buildchain-contract-expected-channel: v3-alpha/u);
+  assert.match(build, /buildchain-contract-expected-channel: alpha/u);
   assert.match(build, /buildchain-contract-expected-major: v3/u);
   assert.doesNotMatch(build, /inputs\.buildchain-ref/u);
   assert.match(


### PR DESCRIPTION
## Summary

Bind the privileged product build to the Buildchain `alpha` channel identity while retaining the separately pinned `v3` major and exact runtime SHA. This repairs the deterministic trust-gate rejection observed by the fresh KFX Full Build after PR #3256 merged.

## Related issue

Atlas goal `2026-08-09-kungfu-kfx-webhook-agent-authoring`.

## Changes

- change both privileged Buildchain callers from the invalid composite channel `v3-alpha` to the public `alpha` channel;
- keep the exact Buildchain runtime SHA and `v3` major unchanged;
- add publication-control-plane guards and a negative regression fixture for composite-channel drift;
- refresh the governed workflow authority and publication surface projections.

## Verification

- `./shifu check:source` (1129 passed, 0 failed, 11 skipped; Python 40 passed; runtime upgrade 134 passed; desktop update 73 passed; TypeScript, Biome, and zero-write gates passed)
- `./shifu test:alpha-macos-overflow` (14 passed)
- `./shifu test:alpha-promotion-preflight` (97 passed)
- `./shifu test:release-publication-control-plane` (11 passed)
- `./shifu check:release-publication-control-plane` (qualifying)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Corrects release workflow metadata to the existing public Buildchain channel vocabulary without changing an architecture contract"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [x] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change is limited to governed release-channel metadata. Exact runtime SHA, major identity, source lock, and publication-control-plane projections remain fail-closed and are covered by the checks above.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
