### PR TITLE
fix(work): resolve packaged profile root

### DIFF
--- a/framework/core/src/python/kungfu/assignment_runtime/__init__.py
+++ b/framework/core/src/python/kungfu/assignment_runtime/__init__.py
@@ -97,12 +97,16 @@ def profile_source() -> Path:
 
     roots: list[str | Path] = [
         Path(value).expanduser()
-        for value in os.environ.get("KF_EXTENSION_PATH", "").split(os.pathsep)
+        for value in [
+            os.environ.get("KF_BUNDLED_EXTENSION_ROOT", ""),
+            *os.environ.get("KF_EXTENSION_PATH", "").split(os.pathsep),
+        ]
         if value
     ]
     if not roots:
         raise ValueError(
-            "KF_EXTENSION_PATH does not name an installed Work Control Profile"
+            "KF_BUNDLED_EXTENSION_ROOT or KF_EXTENSION_PATH does not name an "
+            "installed Work Control Profile"
         )
     discovered = profile_sdk.discover_source("kungfu.work-control", search_roots=roots)
     return Path(discovered["source"])

--- a/framework/core/tests/python/test_assignment_runtime.py
+++ b/framework/core/tests/python/test_assignment_runtime.py
@@ -6,6 +6,7 @@ import copy
 import hashlib
 import importlib.util
 import json
+import os
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
 from io import StringIO
@@ -15,6 +16,7 @@ from typing import Any
 import pytest
 from jsonschema import Draft202012Validator
 
+from kungfu import profile_sdk
 from kungfu.assignment_runtime import (
     EVENT_SCHEMA,
     SNAPSHOT_SCHEMA,
@@ -23,6 +25,7 @@ from kungfu.assignment_runtime import (
     LocalAssignmentRuntimeApplication,
     LocalRuntimeError,
     WorkControlAuthority,
+    profile_source,
     serve,
 )
 from kungfu.canonical_json import canonical_json_text
@@ -51,6 +54,50 @@ VALIDATE_ENVELOPE = Draft202012Validator(ENVELOPE_SCHEMA)
 REALM = {"realmId": "home-test", "realmKind": "local", "generation": "gen-1"}
 ROOT_A = "sha256:" + "a" * 64
 ROOT_B = "sha256:" + "b" * 64
+
+
+def test_profile_source_resolves_installed_bundled_root(monkeypatch, tmp_path):
+    bundled = tmp_path / "installed" / "extensions"
+    source = bundled / "work-control"
+    observed = []
+    monkeypatch.setenv("KF_BUNDLED_EXTENSION_ROOT", str(bundled))
+    monkeypatch.delenv("KF_EXTENSION_PATH", raising=False)
+    monkeypatch.setattr(
+        profile_sdk,
+        "discover_source",
+        lambda profile_id, *, search_roots: (
+            observed.append((profile_id, search_roots)) or {"source": str(source)}
+        ),
+    )
+
+    assert profile_source() == source
+    assert observed == [("kungfu.work-control", [bundled])]
+
+
+def test_profile_source_prefers_bundled_root_before_dev_overrides(
+    monkeypatch, tmp_path
+):
+    bundled = tmp_path / "installed" / "extensions"
+    dev_one = tmp_path / "dev-one"
+    dev_two = tmp_path / "dev-two"
+    observed = []
+    monkeypatch.setenv("KF_BUNDLED_EXTENSION_ROOT", str(bundled))
+    monkeypatch.setenv(
+        "KF_EXTENSION_PATH", os.pathsep.join([str(dev_one), str(dev_two)])
+    )
+    monkeypatch.setattr(
+        profile_sdk,
+        "discover_source",
+        lambda profile_id, *, search_roots: (
+            observed.append((profile_id, search_roots))
+            or {"source": str(bundled / "work-control")}
+        ),
+    )
+
+    assert profile_source() == bundled / "work-control"
+    assert observed == [
+        ("kungfu.work-control", [bundled, dev_one, dev_two]),
+    ]
 
 
 def _root(value: Any) -> str:


### PR DESCRIPTION
## Summary

- resolve the installed Work Control Profile from `KF_BUNDLED_EXTENSION_ROOT`
- keep bundled extensions ahead of development override roots
- retain the existing fail-closed discovery behavior when neither root is configured

## Validation

- `./shifu test:assignment-runtime`
- `./shifu test:cli-surface-qualification`
- `./shifu check:source`
- DCO and staged repository gates

## Delivery context

Full Product Build 32068987913 reached the packaged macOS lifecycle and exposed the installed-product admission failure: the launcher supplied `KF_BUNDLED_EXTENSION_ROOT`, while the Assignment runtime read only `KF_EXTENSION_PATH`. This change closes that exact environment-boundary mismatch.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Corrects installed Work Control Profile discovery to consume the existing bundled extension root without changing an architecture contract"
}
-->

## Evolution Map impact

Evolution impact: none
