### PR TITLE
fix(action): refresh migration map digest

### DIFF
--- a/framework/action/manifest.json
+++ b/framework/action/manifest.json
@@ -40,7 +40,7 @@
     },
     {
       "path": "migration-map.json",
-      "sha256": "sha256:d3c43a6b5204fb3dbf0c4dcc88b135661214f2961f0495b3a7d1236a115cb047"
+      "sha256": "sha256:5903cdcf0c36cf87eb3feec4a8086b3f46826752974f8dd0a841e9b6e21e2769"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- refresh the checked-in Action package digest for `migration-map.json`
- restore fail-closed package verification for source and installed product builds
- keep runtime semantics unchanged; the existing package-integrity test is the regression gate
- replay the one-line repair on exact latest base `94ba9fbfb1bb436935935365c6a40627539cb638`

## Validation

- `./shifu test:action-kernel` — 34 Node tests (32 passed, 2 expected native-Core skips) and 5 Python tests passed
- source acceptance is also enforced by the protected PR engine at this exact head

## Context

The exact four-platform Full Build for merge `c389eb9f1ceb22598f5c4bcc0e72912563782e63` reached product packaging, then failed the installed Action smoke with `package-tampered` because `migration-map.json` had changed while its integrity-manifest digest remained stale.

This latest-base successor supersedes #3280, whose checks were bound to an older base event.

Evolution impact: none

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Refreshes the existing Action package integrity manifest without changing an architecture contract"
}
-->
