### PR TITLE
fix(storage): decouple range filters from retired sources

### DIFF
--- a/framework/core/src/python/kungfu/cli/commands/storage.py
+++ b/framework/core/src/python/kungfu/cli/commands/storage.py
@@ -29,7 +29,7 @@ def _require_source(source_id):
 
 
 def _range_filter(since, from_time, until):
-    from kungfu.sources.store import build_range_filter
+    from kungfu.storage import build_range_filter
 
     try:
         return build_range_filter(since=since, from_time=from_time, until=until)

--- a/framework/core/src/python/kungfu/storage/__init__.py
+++ b/framework/core/src/python/kungfu/storage/__init__.py
@@ -1,2 +1,49 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+
+def _iso(stamp: datetime) -> str:
+    if stamp.tzinfo is None:
+        stamp = stamp.replace(tzinfo=timezone.utc)
+    return stamp.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_relative(value: str, *, now: datetime) -> datetime | None:
+    text = value.strip().lower()
+    if len(text) < 2 or not text[:-1].isdigit():
+        return None
+    amount = int(text[:-1])
+    unit = text[-1]
+    if unit == "d":
+        delta = timedelta(days=amount)
+    elif unit == "h":
+        delta = timedelta(hours=amount)
+    elif unit == "m":
+        delta = timedelta(minutes=amount)
+    elif unit == "s":
+        delta = timedelta(seconds=amount)
+    else:
+        return None
+    return now - delta
+
+
+def build_range_filter(
+    *,
+    since: str | None = None,
+    from_time: str | None = None,
+    until: str | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any] | None:
+    if since and from_time:
+        raise ValueError("use either --since or --from, not both")
+    result: dict[str, Any] = {}
+    if since:
+        relative = _parse_relative(since, now=now or datetime.now(timezone.utc))
+        result["since"] = _iso(relative) if relative is not None else since
+    if from_time:
+        result["since"] = from_time
+    if until:
+        result["until"] = until
+    return result or None

--- a/framework/core/tests/python/test_query_cli.py
+++ b/framework/core/tests/python/test_query_cli.py
@@ -24,6 +24,56 @@ def test_storage_layout_lazy_context_keeps_all_runtime_paths(tmp_path):
     assert layout["runtime_dir"] == str(home / "runtime")
 
 
+def test_storage_query_does_not_depend_on_retired_source_compatibility(tmp_path):
+    result = CliRunner().invoke(
+        kfc,
+        [
+            "--home",
+            str(tmp_path / "home"),
+            "storage",
+            "query",
+            "--table",
+            "episodes",
+            "--scope",
+            "all",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["row_count"] == 0
+
+
+def test_storage_query_preserves_explicit_range_filter(tmp_path, monkeypatch):
+    captured = {}
+
+    def capture_query(runtime_dir, **request):
+        captured.update(request)
+        return {"ok": True, "row_count": 0, "rows": []}
+
+    monkeypatch.setattr(storage_service, "query_projection", capture_query)
+    result = CliRunner().invoke(
+        kfc,
+        [
+            "--home",
+            str(tmp_path / "home"),
+            "storage",
+            "query",
+            "--from",
+            "2026-08-17T00:00:00Z",
+            "--until",
+            "2026-08-18T00:00:00Z",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["range_filter"] == {
+        "since": "2026-08-17T00:00:00Z",
+        "until": "2026-08-18T00:00:00Z",
+    }
+
+
 def test_facts_cli_exposes_the_libkungfu_owned_contract(tmp_path):
     result = CliRunner().invoke(
         kfc, ["--home", str(tmp_path / "home"), "facts", "capabilities"]


### PR DESCRIPTION
## Summary

- move storage range parsing under the current `kungfu.storage` owner
- stop installed `storage query` from importing the retired `kungfu.sources` package
- cover empty installed query startup and explicit `--from`/`--until` forwarding

## Validation

- `./shifu build:core`
- focused Python tests: 15 passed
- Ruff format/lint
- Python structure gate: 0 issues
- `./shifu check:source`
- `./shifu docs final-ready --since ba8b01b17e6a040665067f7037ae5d1967be9cf0 --budget 65536 --json` (pass)
- `./shifu core:affected` (`profile=full`, `tier=github-hosted-linux-native-pr`)

## Context

Exact four-platform Full Build 32094321430 proved packaging/install itself now succeeds, then all retained platforms failed the installed KFX lifecycle because `storage.py` imported `build_range_filter` from the retired `kungfu.sources` namespace. This change repairs that installed boundary without restoring the retired package.