### PR TITLE
fix(storage): decouple range filters from retired sources

### DIFF
--- a/framework/core/src/python/kungfu/cli/commands/storage.py
+++ b/framework/core/src/python/kungfu/cli/commands/storage.py
@@ -29,7 +29,7 @@ def _require_source(source_id):
 
 
 def _range_filter(since, from_time, until):
-    from kungfu.sources.store import build_range_filter
+    from kungfu.storage import build_range_filter
 
     try:
         return build_range_filter(since=since, from_time=from_time, until=until)

--- a/framework/core/src/python/kungfu/storage/__init__.py
+++ b/framework/core/src/python/kungfu/storage/__init__.py
@@ -1,2 +1,49 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+
+def _iso(stamp: datetime) -> str:
+    if stamp.tzinfo is None:
+        stamp = stamp.replace(tzinfo=timezone.utc)
+    return stamp.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_relative(value: str, *, now: datetime) -> datetime | None:
+    text = value.strip().lower()
+    if len(text) < 2 or not text[:-1].isdigit():
+        return None
+    amount = int(text[:-1])
+    unit = text[-1]
+    if unit == "d":
+        delta = timedelta(days=amount)
+    elif unit == "h":
+        delta = timedelta(hours=amount)
+    elif unit == "m":
+        delta = timedelta(minutes=amount)
+    elif unit == "s":
+        delta = timedelta(seconds=amount)
+    else:
+        return None
+    return now - delta
+
+
+def build_range_filter(
+    *,
+    since: str | None = None,
+    from_time: str | None = None,
+    until: str | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any] | None:
+    if since and from_time:
+        raise ValueError("use either --since or --from, not both")
+    result: dict[str, Any] = {}
+    if since:
+        relative = _parse_relative(since, now=now or datetime.now(timezone.utc))
+        result["since"] = _iso(relative) if relative is not None else since
+    if from_time:
+        result["since"] = from_time
+    if until:
+        result["until"] = until
+    return result or None

--- a/framework/core/tests/python/test_query_cli.py
+++ b/framework/core/tests/python/test_query_cli.py
@@ -24,6 +24,56 @@ def test_storage_layout_lazy_context_keeps_all_runtime_paths(tmp_path):
     assert layout["runtime_dir"] == str(home / "runtime")
 
 
+def test_storage_query_does_not_depend_on_retired_source_compatibility(tmp_path):
+    result = CliRunner().invoke(
+        kfc,
+        [
+            "--home",
+            str(tmp_path / "home"),
+            "storage",
+            "query",
+            "--table",
+            "episodes",
+            "--scope",
+            "all",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["row_count"] == 0
+
+
+def test_storage_query_preserves_explicit_range_filter(tmp_path, monkeypatch):
+    captured = {}
+
+    def capture_query(runtime_dir, **request):
+        captured.update(request)
+        return {"ok": True, "row_count": 0, "rows": []}
+
+    monkeypatch.setattr(storage_service, "query_projection", capture_query)
+    result = CliRunner().invoke(
+        kfc,
+        [
+            "--home",
+            str(tmp_path / "home"),
+            "storage",
+            "query",
+            "--from",
+            "2026-08-17T00:00:00Z",
+            "--until",
+            "2026-08-18T00:00:00Z",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["range_filter"] == {
+        "since": "2026-08-17T00:00:00Z",
+        "until": "2026-08-18T00:00:00Z",
+    }
+
+
 def test_facts_cli_exposes_the_libkungfu_owned_contract(tmp_path):
     result = CliRunner().invoke(
         kfc, ["--home", str(tmp_path / "home"), "facts", "capabilities"]


### PR DESCRIPTION
Repair installed storage query startup by moving range filters under kungfu.storage; focused regression tests and full source qualification pass.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Restore storage query startup ownership without changing an architecture contract"
}
-->

## Evolution Map impact

Evolution impact: none