### PR TITLE
fix(product): accept zero-residue v3 CLI retirement

### DIFF
--- a/product/scripts/cli-surface-qualification.mjs
+++ b/product/scripts/cli-surface-qualification.mjs
@@ -349,12 +349,11 @@ export function qualifyCliSurface({
       ),
     );
     assert(
-      legacyWorkControlRows.length > 0 &&
-        legacyWorkControlRows.every(
-          (row) =>
-            row.visibility === 'hidden-internal' &&
-            (row.kfd3_api_ids || []).length === 0,
-        ),
+      legacyWorkControlRows.every(
+        (row) =>
+          row.visibility === 'hidden-internal' &&
+          (row.kfd3_api_ids || []).length === 0,
+      ),
       'installed v3 compatibility reader is discoverable or owns a KFD identity',
     );
     run(['sdk', '--help'], 'kungfu sdk --help');

--- a/product/scripts/cli-surface-qualification.test.mjs
+++ b/product/scripts/cli-surface-qualification.test.mjs
@@ -59,6 +59,13 @@ function catalog(changes = {}) {
         availability: { state: 'available' },
       },
       {
+        canonical_path: 'kungfu dogfood',
+        aliases: [],
+        owner: 'profile-kfx',
+        maturity: 'stable',
+        availability: { state: 'available' },
+      },
+      {
         canonical_path: 'kungfu profile mission-control',
         aliases: [],
         owner: 'profile-kfx',
@@ -224,6 +231,55 @@ test('qualification accepts presentation-only alignment drift in bare help', () 
     },
   });
   assert.equal(report.qualified, true);
+});
+
+test('qualification accepts complete removal of the v3 compatibility reader', () => {
+  const zeroResidueCatalog = catalog();
+  zeroResidueCatalog.surfaces = zeroResidueCatalog.surfaces.filter(
+    (row) => !row.canonical_path.startsWith('kungfu profile mission-control'),
+  );
+  const report = qualifyCliSurface({
+    cli: '/fixture/kungfu',
+    expectedCatalog: zeroResidueCatalog,
+    runCommand: runner(zeroResidueCatalog),
+  });
+  assert.equal(report.qualified, true);
+});
+
+test('qualification rejects discoverable v3 compatibility residue', () => {
+  const discoverableCatalog = catalog();
+  discoverableCatalog.surfaces = discoverableCatalog.surfaces.map((row) =>
+    row.canonical_path.startsWith('kungfu profile mission-control')
+      ? { ...row, visibility: 'public' }
+      : row,
+  );
+  assert.throws(
+    () =>
+      qualifyCliSurface({
+        cli: '/fixture/kungfu',
+        expectedCatalog: discoverableCatalog,
+        runCommand: runner(discoverableCatalog),
+      }),
+    /installed CLI retained removed path kungfu profile mission-control/u,
+  );
+});
+
+test('qualification rejects v3 compatibility residue with a KFD identity', () => {
+  const kfdOwningCatalog = catalog();
+  kfdOwningCatalog.surfaces = kfdOwningCatalog.surfaces.map((row) =>
+    row.canonical_path.startsWith('kungfu profile mission-control')
+      ? { ...row, kfd3_api_ids: ['kungfu.legacy.mission-control'] }
+      : row,
+  );
+  assert.throws(
+    () =>
+      qualifyCliSurface({
+        cli: '/fixture/kungfu',
+        expectedCatalog: kfdOwningCatalog,
+        runCommand: runner(kfdOwningCatalog),
+      }),
+    /installed v3 compatibility reader is discoverable or owns a KFD identity/u,
+  );
 });
 
 test('verification binds the qualification to the exact archive digest', () => {


### PR DESCRIPTION
## Summary

Allow installed-product CLI qualification to accept complete removal of the retired v3 Work Control compatibility reader while continuing to reject any discoverable or KFD-owning residue.

## Related issue

Follow-up to the exact-head Full Build failure on `dev/v4/v4.0`.

## Changes

- Treat an empty legacy Work Control surface set as the desired zero-residue state.
- Preserve fail-closed checks for public legacy paths and legacy rows that still own KFD identities.
- Add regression coverage for complete retirement and both residue failure modes.

## Verification

- `./shifu test:cli-surface-qualification` (95/95 passed)
- `./shifu check:source` (passed)
- repository pre-commit staged gate (passed)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Correct packaged-product qualification for an already-settled v3 compatibility-reader retirement without changing architecture authority"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change is limited to fail-closed installed-product qualification and is covered by focused residue tests plus the full source gate.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required; qualification semantics now match the settled zero-residue catalog)
