### PR TITLE
fix(runtime): recover invalid pending Assignment commands

### DIFF
--- a/docs/adr/KF-ADR-019fe996-1912-7144-8fa5-3fceaa416365.md
+++ b/docs/adr/KF-ADR-019fe996-1912-7144-8fa5-3fceaa416365.md
@@ -6,7 +6,7 @@ decision_status: accepted
 implementation_status: implemented
 review_state: self-reviewed
 sensitivity: public
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/2869, https://github.com/kungfu-systems/kungfu/pull/2908, https://github.com/kungfu-systems/kungfu/pull/2979, https://github.com/kungfu-systems/kungfu/pull/3291, https://github.com/kungfu-systems/kungfu/pull/3308]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/2869, https://github.com/kungfu-systems/kungfu/pull/2908, https://github.com/kungfu-systems/kungfu/pull/2979, https://github.com/kungfu-systems/kungfu/pull/3291, https://github.com/kungfu-systems/kungfu/pull/3311]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/2869
 qualification_refs: [scripts/check-temporal-relation-contract.test.mjs, framework/core/tests/python/test_temporal_relation.py, tests/fixtures/temporal-relation-contract/cases.json, framework/core/src/python/kungfu/storage/fact_root_canonical.py, scripts/check-release-provenance-object.test.mjs, framework/core/src/python/kungfu/release_provenance/__init__.py, framework/core/tests/python/test_release_provenance.py, tests/fixtures/release-provenance-object/cases.json, framework/release/kungfu-release-provenance.contract.json, framework/core/tests/python/test_temporal_release_admission.py, framework/core/tests/python/test_temporal_provenance_cutover.py, scripts/verify-kungfu-release-admission.test.mjs, docs/qualification/evidence/kungfu-temporal-release-admission-facts.json, docs/qualification/evidence/kungfu-temporal-provenance-cutover.json, framework/release/kungfu-durable-provenance-authority.contract.json, scripts/check-durable-provenance-authority.test.mjs, scripts/qualify-durable-provenance-authority.py, docs/qualification/evidence/durable-provenance-authority/v1/report.json, docs/qualification/evidence/durable-provenance-authority/v1/authority-bundle.json]
 sources: [local-files, user-consensus]
@@ -25,7 +25,7 @@ ai_provenance: GPT-5 via Codex on 2026-08-10, 2026-08-12, 2026-08-15, and 2026-0
 - Temporal admission cutover: PR #2979 at functional commit `685ad133c7fd390dbf4accee89fdf8113482c2dd` makes historical and current allowances active only through closed fact proofs; the retained digest list is a generated rollback projection, not authority
 - Durable authority cutover: PR #3291 makes the release-provenance Fact/Cut durability profile default-enabled and production-eligible, retains exact Alpha history and clean-host replay evidence, and leaves Git/GitHub coordinates as non-authoritative projections without performing publication
 - Protected-delivery repair: a dequeued source identity is never reused; the replacement revision must recompute its Project Cut replay proof against the exact protected base while preserving the qualified Fact and qualification roots
-- Runtime recovery repair: PR #3308 rejects unsupported assessment executors before persisting pending state and deterministically clears already-retained invalid commands without invoking or mutating Work Control authority
+- Runtime recovery repair: PR #3311 rejects unsupported assessment executors before persisting pending state and deterministically clears already-retained invalid commands without invoking or mutating Work Control authority
 - Date: 2026-08-10
 - Category: Fact kernel / temporal relations / proof-carrying query
 - Related: [KF-ADR-019f86da-4f90-7c45-8d95-3745dcbbff1c](KF-ADR-019f86da-4f90-7c45-8d95-3745dcbbff1c.md),

--- a/docs/adr/KF-ADR-019fe996-1912-7144-8fa5-3fceaa416365.md
+++ b/docs/adr/KF-ADR-019fe996-1912-7144-8fa5-3fceaa416365.md
@@ -6,7 +6,7 @@ decision_status: accepted
 implementation_status: implemented
 review_state: self-reviewed
 sensitivity: public
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/2869, https://github.com/kungfu-systems/kungfu/pull/2908, https://github.com/kungfu-systems/kungfu/pull/2979, https://github.com/kungfu-systems/kungfu/pull/3291]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/2869, https://github.com/kungfu-systems/kungfu/pull/2908, https://github.com/kungfu-systems/kungfu/pull/2979, https://github.com/kungfu-systems/kungfu/pull/3291, https://github.com/kungfu-systems/kungfu/pull/3308]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/2869
 qualification_refs: [scripts/check-temporal-relation-contract.test.mjs, framework/core/tests/python/test_temporal_relation.py, tests/fixtures/temporal-relation-contract/cases.json, framework/core/src/python/kungfu/storage/fact_root_canonical.py, scripts/check-release-provenance-object.test.mjs, framework/core/src/python/kungfu/release_provenance/__init__.py, framework/core/tests/python/test_release_provenance.py, tests/fixtures/release-provenance-object/cases.json, framework/release/kungfu-release-provenance.contract.json, framework/core/tests/python/test_temporal_release_admission.py, framework/core/tests/python/test_temporal_provenance_cutover.py, scripts/verify-kungfu-release-admission.test.mjs, docs/qualification/evidence/kungfu-temporal-release-admission-facts.json, docs/qualification/evidence/kungfu-temporal-provenance-cutover.json, framework/release/kungfu-durable-provenance-authority.contract.json, scripts/check-durable-provenance-authority.test.mjs, scripts/qualify-durable-provenance-authority.py, docs/qualification/evidence/durable-provenance-authority/v1/report.json, docs/qualification/evidence/durable-provenance-authority/v1/authority-bundle.json]
 sources: [local-files, user-consensus]
@@ -25,6 +25,7 @@ ai_provenance: GPT-5 via Codex on 2026-08-10, 2026-08-12, 2026-08-15, and 2026-0
 - Temporal admission cutover: PR #2979 at functional commit `685ad133c7fd390dbf4accee89fdf8113482c2dd` makes historical and current allowances active only through closed fact proofs; the retained digest list is a generated rollback projection, not authority
 - Durable authority cutover: PR #3291 makes the release-provenance Fact/Cut durability profile default-enabled and production-eligible, retains exact Alpha history and clean-host replay evidence, and leaves Git/GitHub coordinates as non-authoritative projections without performing publication
 - Protected-delivery repair: a dequeued source identity is never reused; the replacement revision must recompute its Project Cut replay proof against the exact protected base while preserving the qualified Fact and qualification roots
+- Runtime recovery repair: PR #3308 rejects unsupported assessment executors before persisting pending state and deterministically clears already-retained invalid commands without invoking or mutating Work Control authority
 - Date: 2026-08-10
 - Category: Fact kernel / temporal relations / proof-carrying query
 - Related: [KF-ADR-019f86da-4f90-7c45-8d95-3745dcbbff1c](KF-ADR-019f86da-4f90-7c45-8d95-3745dcbbff1c.md),

--- a/framework/core/src/python/kungfu/assignment_runtime/authority.py
+++ b/framework/core/src/python/kungfu/assignment_runtime/authority.py
@@ -144,6 +144,41 @@ class LocalRuntimeError(RuntimeError):
         self.diagnostics = list(diagnostics or [])
 
 
+def _validate_command_arguments(command: Mapping[str, Any]) -> None:
+    arguments = command.get("arguments")
+    if not isinstance(arguments, Mapping):
+        return
+    executor_profile = str(arguments.get("executorProfile") or "")
+    if executor_profile and executor_profile not in _ASSESSMENT_EXECUTOR_PROFILES:
+        raise LocalRuntimeError(
+            "invalid-command",
+            "Assessment executor profile must be inline, thread, or process",
+            details={"field": "executorProfile"},
+        )
+
+
+def _interrupted_command_rejection(
+    pending: Mapping[str, Any], error: LocalRuntimeError
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    command = dict(pending["command"])
+    details = {
+        "commandId": str(command.get("commandId") or ""),
+        "commandRoot": str(pending.get("commandRoot") or ""),
+        "errorCode": error.code,
+    }
+    diagnostic = {
+        "code": "interrupted-command-rejected",
+        "message": (
+            "An interrupted command failed deterministic validation before "
+            "authority execution"
+        ),
+        "severity": "warning",
+        "recovery": [],
+        "details": {**details, **dict(error.details)},
+    }
+    return diagnostic, details
+
+
 class AssignmentAuthority(Protocol):
     """Private adapter boundary to the one native transition authority."""
 

--- a/framework/core/src/python/kungfu/assignment_runtime/authority.py
+++ b/framework/core/src/python/kungfu/assignment_runtime/authority.py
@@ -76,6 +76,7 @@ _COMMAND_OPERATIONS = {
     "initiative.bundle.import": "import-initiative",
 }
 _LEASE_COMMANDS = {"assignment.claim", "assignment.stage"}
+_ASSESSMENT_EXECUTOR_PROFILES = {"inline", "thread", "process"}
 _PROCESS_WRITERS: set[str] = set()
 _PROCESS_WRITERS_GUARD = threading.Lock()
 

--- a/framework/core/src/python/kungfu/assignment_runtime/local.py
+++ b/framework/core/src/python/kungfu/assignment_runtime/local.py
@@ -26,7 +26,6 @@ from .authority import (
     SNAPSHOT_SCHEMA,
     STATE_SCHEMA,
     STREAM_ID,
-    _ASSESSMENT_EXECUTOR_PROFILES,
     _COMMAND_OPERATIONS,
     _ERROR_RETRYABLE,
     _LEASE_COMMANDS,
@@ -37,8 +36,10 @@ from .authority import (
     WorkControlAuthority,
     _contains_forbidden_argument,
     _copy_json,
+    _interrupted_command_rejection,
     _root,
     _stable,
+    _validate_command_arguments,
 )
 
 
@@ -308,7 +309,7 @@ class EmbeddedLocalAssignmentRuntime:
             return
         command = dict(pending["command"])
         try:
-            self._validate_command_arguments(command)
+            _validate_command_arguments(command)
         except LocalRuntimeError as error:
             if error.code != "invalid-command":
                 raise
@@ -343,39 +344,16 @@ class EmbeddedLocalAssignmentRuntime:
     def _reject_pending_before_authority(
         self, pending: Mapping[str, Any], error: LocalRuntimeError
     ) -> None:
-        command = dict(pending["command"])
         revision = dict(
             pending.get("beforeRevision") or self._state.get("revision") or {}
         )
-        diagnostic = {
-            "code": "interrupted-command-rejected",
-            "message": (
-                "An interrupted command failed deterministic validation before "
-                "authority execution"
-            ),
-            "severity": "warning",
-            "recovery": [],
-            "details": {
-                "commandId": str(command.get("commandId") or ""),
-                "commandRoot": str(pending.get("commandRoot") or ""),
-                "errorCode": error.code,
-                **dict(error.details),
-            },
-        }
+        diagnostic, event_details = _interrupted_command_rejection(pending, error)
         diagnostics = list(self._state.get("diagnostics") or [])
         if diagnostic not in diagnostics:
             diagnostics.append(diagnostic)
         self._state["diagnostics"] = diagnostics
         self._state["pending"] = None
-        self._append_event(
-            "command-rejected",
-            revision,
-            {
-                "commandId": str(command.get("commandId") or ""),
-                "commandRoot": str(pending.get("commandRoot") or ""),
-                "errorCode": error.code,
-            },
-        )
+        self._append_event("command-rejected", revision, event_details)
         self._save_state()
 
     def handle(self, request: Mapping[str, Any]) -> dict[str, Any]:
@@ -627,7 +605,7 @@ class EmbeddedLocalAssignmentRuntime:
                 "Caller attempted to name or mutate backend implementation state",
                 details={"field": forbidden},
             )
-        self._validate_command_arguments(command)
+        _validate_command_arguments(command)
         attempt = command.get("attempt")
         lease = command.get("lease")
         warrant = command.get("warrant")
@@ -680,19 +658,6 @@ class EmbeddedLocalAssignmentRuntime:
                 raise LocalRuntimeError(
                     "warrant-invalid", "Command Warrant scope is insufficient"
                 )
-
-    @staticmethod
-    def _validate_command_arguments(command: Mapping[str, Any]) -> None:
-        arguments = command.get("arguments")
-        if not isinstance(arguments, Mapping):
-            return
-        executor_profile = str(arguments.get("executorProfile") or "")
-        if executor_profile and executor_profile not in _ASSESSMENT_EXECUTOR_PROFILES:
-            raise LocalRuntimeError(
-                "invalid-command",
-                "Assessment executor profile must be inline, thread, or process",
-                details={"field": "executorProfile"},
-            )
 
     def _submit(
         self, request: Mapping[str, Any], selected: list[str]

--- a/framework/core/src/python/kungfu/assignment_runtime/local.py
+++ b/framework/core/src/python/kungfu/assignment_runtime/local.py
@@ -26,6 +26,7 @@ from .authority import (
     SNAPSHOT_SCHEMA,
     STATE_SCHEMA,
     STREAM_ID,
+    _ASSESSMENT_EXECUTOR_PROFILES,
     _COMMAND_OPERATIONS,
     _ERROR_RETRYABLE,
     _LEASE_COMMANDS,
@@ -305,6 +306,14 @@ class EmbeddedLocalAssignmentRuntime:
         pending = self._state.get("pending")
         if not isinstance(pending, Mapping):
             return
+        command = dict(pending["command"])
+        try:
+            self._validate_command_arguments(command)
+        except LocalRuntimeError as error:
+            if error.code != "invalid-command":
+                raise
+            self._reject_pending_before_authority(pending, error)
+            return
         if isinstance(pending.get("authorityResult"), Mapping):
             snapshot, revision = self._observe_snapshot(record_event=False)
             self._finalize_pending(dict(pending), snapshot, revision, recovered=True)
@@ -329,6 +338,44 @@ class EmbeddedLocalAssignmentRuntime:
         if diagnostic not in diagnostics:
             diagnostics.append(diagnostic)
         self._state["diagnostics"] = diagnostics
+        self._save_state()
+
+    def _reject_pending_before_authority(
+        self, pending: Mapping[str, Any], error: LocalRuntimeError
+    ) -> None:
+        command = dict(pending["command"])
+        revision = dict(
+            pending.get("beforeRevision") or self._state.get("revision") or {}
+        )
+        diagnostic = {
+            "code": "interrupted-command-rejected",
+            "message": (
+                "An interrupted command failed deterministic validation before "
+                "authority execution"
+            ),
+            "severity": "warning",
+            "recovery": [],
+            "details": {
+                "commandId": str(command.get("commandId") or ""),
+                "commandRoot": str(pending.get("commandRoot") or ""),
+                "errorCode": error.code,
+                **dict(error.details),
+            },
+        }
+        diagnostics = list(self._state.get("diagnostics") or [])
+        if diagnostic not in diagnostics:
+            diagnostics.append(diagnostic)
+        self._state["diagnostics"] = diagnostics
+        self._state["pending"] = None
+        self._append_event(
+            "command-rejected",
+            revision,
+            {
+                "commandId": str(command.get("commandId") or ""),
+                "commandRoot": str(pending.get("commandRoot") or ""),
+                "errorCode": error.code,
+            },
+        )
         self._save_state()
 
     def handle(self, request: Mapping[str, Any]) -> dict[str, Any]:
@@ -580,6 +627,7 @@ class EmbeddedLocalAssignmentRuntime:
                 "Caller attempted to name or mutate backend implementation state",
                 details={"field": forbidden},
             )
+        self._validate_command_arguments(command)
         attempt = command.get("attempt")
         lease = command.get("lease")
         warrant = command.get("warrant")
@@ -632,6 +680,19 @@ class EmbeddedLocalAssignmentRuntime:
                 raise LocalRuntimeError(
                     "warrant-invalid", "Command Warrant scope is insufficient"
                 )
+
+    @staticmethod
+    def _validate_command_arguments(command: Mapping[str, Any]) -> None:
+        arguments = command.get("arguments")
+        if not isinstance(arguments, Mapping):
+            return
+        executor_profile = str(arguments.get("executorProfile") or "")
+        if executor_profile and executor_profile not in _ASSESSMENT_EXECUTOR_PROFILES:
+            raise LocalRuntimeError(
+                "invalid-command",
+                "Assessment executor profile must be inline, thread, or process",
+                details={"field": "executorProfile"},
+            )
 
     def _submit(
         self, request: Mapping[str, Any], selected: list[str]

--- a/framework/core/tests/python/test_assignment_runtime.py
+++ b/framework/core/tests/python/test_assignment_runtime.py
@@ -1017,6 +1017,86 @@ def test_restart_deterministically_recovers_durable_interrupted_commands(
         recovered.close()
 
 
+def test_invalid_assessment_executor_is_rejected_before_pending_write(tmp_path):
+    runtime_dir = tmp_path / "invalid-executor" / ".kungfu" / "runtime"
+    authority = FakeAuthority(runtime_dir)
+    with EmbeddedLocalAssignmentRuntime(
+        runtime_dir,
+        realm_id=REALM["realmId"],
+        generation=REALM["generation"],
+        authority=authority,
+        contract=ASSIGNMENT_RUNTIME_CONTRACT,
+        request_schema=ENVELOPE_SCHEMA,
+    ) as runtime:
+        snapshot = _handle(
+            runtime, _request("assignment.snapshot", "assignment.snapshot.read")
+        )
+        command = _command(
+            snapshot["revision"],
+            command_type="assignment.completion.review",
+        )
+        command["arguments"] = {"executorProfile": "github-protected-review"}
+        rejected = _handle(
+            runtime,
+            _request(
+                "command.submit",
+                "assignment.command.submit",
+                payload=command,
+            ),
+        )
+
+        assert rejected["error"]["code"] == "invalid-command"
+        assert runtime._state["pending"] is None
+        assert authority._read()["effects"] == []
+
+
+def test_restart_rejects_legacy_invalid_executor_pending_before_authority(tmp_path):
+    runtime_dir = tmp_path / "legacy-invalid-executor" / ".kungfu" / "runtime"
+    authority = FakeAuthority(runtime_dir)
+    runtime = EmbeddedLocalAssignmentRuntime(
+        runtime_dir,
+        realm_id=REALM["realmId"],
+        generation=REALM["generation"],
+        authority=authority,
+        contract=ASSIGNMENT_RUNTIME_CONTRACT,
+        request_schema=ENVELOPE_SCHEMA,
+    ).start()
+    snapshot = _handle(
+        runtime, _request("assignment.snapshot", "assignment.snapshot.read")
+    )
+    command = _command(
+        snapshot["revision"],
+        command_type="assignment.completion.review",
+    )
+    command["arguments"] = {"executorProfile": "github-protected-review"}
+    runtime._state["pending"] = {
+        "commandRoot": _root(command),
+        "command": command,
+        "beforeRevision": snapshot["revision"],
+        "requestId": "legacy.invalid.executor",
+    }
+    runtime._save_state()
+    runtime.close()
+
+    recovered = EmbeddedLocalAssignmentRuntime(
+        runtime_dir,
+        realm_id=REALM["realmId"],
+        generation=REALM["generation"],
+        authority=authority,
+        contract=ASSIGNMENT_RUNTIME_CONTRACT,
+        request_schema=ENVELOPE_SCHEMA,
+    ).start()
+    try:
+        assert recovered._state["pending"] is None
+        assert authority._read()["effects"] == []
+        assert recovered._state["events"][-1]["kind"] == "command-rejected"
+        assert recovered._state["diagnostics"][-1]["code"] == (
+            "interrupted-command-rejected"
+        )
+    finally:
+        recovered.close()
+
+
 def test_interrupted_authority_write_without_result_is_fail_visible(tmp_path):
     runtime_dir = tmp_path / "ambiguous-crash" / ".kungfu" / "runtime"
     authority = FakeAuthority(runtime_dir)


### PR DESCRIPTION
<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "implemented",
  "adrs": [
    "KF-ADR-019fe996-1912-7144-8fa5-3fceaa416365"
  ],
  "summary": "Recover deterministic invalid Assignment Runtime assessment commands without invoking Work Control authority, so the durable-provenance cutover can complete through the public native lifecycle.",
  "verification": [
    "./shifu test:assignment-runtime"
  ]
}
-->

Follow-up to #3305 for the same durable-provenance cutover Assignment.

The public completion review admitted an unsupported executor profile before the Assignment Runtime had validated it. The Work Control call then failed deterministically, leaving a pending command that every restart retried and permanently fencing public status and lifecycle commands.

This patch validates assessment executor profiles before persisting pending state. It also handles already-retained invalid-executor pending commands by recording a warning and command-rejected event, clearing the local pending envelope, and never invoking or mutating Work Control authority.

Verification: ./shifu test:assignment-runtime (35 JS/GUI contract checks, 29 Python Assignment Runtime and coordination tests, 2 targeted runtime-service tests).