### PR TITLE
fix(qualification): align retired profile fixtures

### DIFF
--- a/framework/core/tests/python/test_fact_kernel_integrity.py
+++ b/framework/core/tests/python/test_fact_kernel_integrity.py
@@ -30,13 +30,16 @@ def _source(profile: str, source_id: str) -> dict:
 def _fixture(runtime_dir: Path) -> dict:
     document = {
         "sources": [
-            _source("mission-go", "mission:fixture/go:integrity"),
+            _source(
+                "initiative-assignment",
+                "initiative:fixture/assignment:integrity",
+            ),
             _source("xinfa-atlas", "atlas:fixture"),
         ],
         "relations": [
             {
                 "relation_type": "uses-context",
-                "source_id": "mission:fixture/go:integrity",
+                "source_id": "initiative:fixture/assignment:integrity",
                 "target_id": "atlas:fixture",
                 "attributes": {"inheriting": False},
             }

--- a/framework/core/tests/python/test_fact_profile_shadow.py
+++ b/framework/core/tests/python/test_fact_profile_shadow.py
@@ -56,7 +56,7 @@ def _document():
             {
                 "relation_type": "explicitly-authorizes",
                 "source_id": "warrant:fact-kernel-review",
-                "target_id": "mission:technical-stewardship/go:fact-kernel",
+                "target_id": "initiative:technical-stewardship/assignment:fact-kernel",
                 "attributes": {"scope": "fixture-only", "inheriting": False},
             },
         ],
@@ -101,7 +101,11 @@ def test_shadow_comparison_reports_typed_gaps_without_selecting_authority(tmp_pa
 
     missing = deepcopy(document)
     missing["sources"].append(
-        _source("mission-go", "mission:missing/go:missing", {"status": "missing"})
+        _source(
+            "initiative-assignment",
+            "initiative:missing/assignment:missing",
+            {"status": "missing"},
+        )
     )
     missing_result = storage_service.fact_profile_shadow_compare(missing, actual)
     assert missing_result["counts"]["missing"] == 1

--- a/framework/spec/generated/registry.json
+++ b/framework/spec/generated/registry.json
@@ -6,7 +6,7 @@
       "protocol_id": "kungfu.fact-cut-kernel.contract/v1",
       "source": "framework/fact/kungfu-fact-cut-kernel.contract.json",
       "source_role": "fact-object-cut-and-admission-semantics",
-      "source_root": "sha256:63736a25cac825216749f971d672ab8e5ab98d2015bd1d50bc91ddf68775f8b1",
+      "source_root": "sha256:3072bfb66115e6fad01d0426ebc6633cf22d4fe06b9c81905fdadcfd2ac003dd",
       "version_axis": "Fact record schema and Cut protocol"
     },
     {
@@ -15,7 +15,7 @@
       "protocol_id": "kungfu.fact-root.canonical/v2",
       "source": "framework/fact/kungfu-fact-cut-kernel.contract.json",
       "source_role": "portable-canonical-Fact-root-preimage",
-      "source_root": "sha256:63736a25cac825216749f971d672ab8e5ab98d2015bd1d50bc91ddf68775f8b1",
+      "source_root": "sha256:3072bfb66115e6fad01d0426ebc6633cf22d4fe06b9c81905fdadcfd2ac003dd",
       "version_axis": "Fact root canonicalization protocol"
     },
     {
@@ -78,7 +78,7 @@
       "protocol_id": "kungfu.layered-api-encoding-boundary.contract/v1",
       "source": "framework/core/architecture/layered-api-encoding-boundary.contract.json",
       "source_role": "Hana-POD-versus-FlatBuffers-payload-schema-ownership",
-      "source_root": "sha256:44f182fa7def13375d074ba525b57e1dd93f8529366ee4a1a172fd93528f956f",
+      "source_root": "sha256:5d57d352c43d5ab8cfcef545437d68ad4150109494d98ac3874ffda7da6071eb",
       "version_axis": "payload schema owner and protocol-selected encoding"
     },
     {
@@ -121,7 +121,7 @@
       },
       {
         "path": "framework/fact/kungfu-fact-cut-kernel.contract.json",
-        "root": "sha256:63736a25cac825216749f971d672ab8e5ab98d2015bd1d50bc91ddf68775f8b1"
+        "root": "sha256:3072bfb66115e6fad01d0426ebc6633cf22d4fe06b9c81905fdadcfd2ac003dd"
       },
       {
         "path": "framework/episode/kungfu-episode-invariants.contract.json",
@@ -149,7 +149,7 @@
       },
       {
         "path": "framework/core/architecture/layered-api-encoding-boundary.contract.json",
-        "root": "sha256:44f182fa7def13375d074ba525b57e1dd93f8529366ee4a1a172fd93528f956f"
+        "root": "sha256:5d57d352c43d5ab8cfcef545437d68ad4150109494d98ac3874ffda7da6071eb"
       },
       {
         "path": "framework/spec/schema/manifest.schema.json",


### PR DESCRIPTION
## Summary

Repair the two verification defects exposed by Full Product Build run 32185858229 after the KFX runtime activation delivery.

## Related issue

Follow-up to protected delivery PR #3309 and Full Product Build run 32185858229.

## Changes

- Refresh the generated Spec registry roots from the checked-in authority generator.
- Replace retired mission-go fixture coordinates with initiative-assignment coordinates.
- Repair the remaining profile-shadow relation endpoint and missing-source fixture.

## Verification

- ./shifu check:source (1144 Node tests, 40 Python tests, 134 runtime tests, 73 desktop tests; exit 0)
- ./shifu test:fact-profile-shadow (3 passed)
- ./shifu test:fact-kernel-integrity (5 passed)
- ./shifu invariant:verify -- --domain fact --level source,native,runtime --json (7 verified)
- ./shifu --filter @kungfu-tech/spec generate:check (8 generated artifacts current)
- Project Cut composition qualified with no changed Cut paths

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded qualification repair restores generated authority and migrated fixture parity without changing an architecture contract"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The generated Spec registry participates in release verification; deterministic regeneration and the full source gate verify the exact refreshed roots.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable; fixture and generated authority repair only)
