### PR TITLE
fix(release): pass explicit Work to signed CLI smoke

### DIFF
--- a/product/scripts/finalize-signed-cli-qualification.test.mjs
+++ b/product/scripts/finalize-signed-cli-qualification.test.mjs
@@ -385,7 +385,10 @@ test('post-sign Codex planning is credential-free and selects only the fixture p
     source,
     /'starter-create',[\s\S]*?'--expected-plan-root',[\s\S]*?'--execute',[\s\S]*?'--json'/u,
   );
-  assert.match(source, /'run',[\s\S]*?'codex',[\s\S]*?'--plan'/u);
+  assert.match(
+    source,
+    /'run',[\s\S]*?'codex',[\s\S]*?projectPlan\.initialWork\.title,[\s\S]*?'--workspace',[\s\S]*?'--plan'/u,
+  );
   assert.match(source, /realCodexRequired: false/u);
   assert.match(source, /providerCredentialsRead: false/u);
 });

--- a/product/scripts/verify-cli-surface-qualification.mjs
+++ b/product/scripts/verify-cli-surface-qualification.mjs
@@ -471,6 +471,10 @@ function verifyCodexPlanWithoutCodex({
     'Agent Work Starter plan',
   );
   assert(projectPlan.planRoot, 'Agent Work Starter plan omitted planRoot');
+  assert(
+    projectPlan.initialWork?.title,
+    'Agent Work Starter plan omitted initial Work title',
+  );
   runKungfu(
     kungfu,
     [
@@ -490,15 +494,23 @@ function verifyCodexPlanWithoutCodex({
   const plan = parseJsonOutput(
     runKungfu(
       kungfu,
-      ['run', 'codex', '--workspace', project, '--plan', '--json'],
+      [
+        'run',
+        'codex',
+        projectPlan.initialWork.title,
+        '--workspace',
+        project,
+        '--plan',
+        '--json',
+      ],
       { cwd: temporaryRoot, env },
     ).stdout,
-    'kungfu run codex --plan',
+    'kungfu run codex <task> --plan',
   );
   assert(
     /^sha256:[0-9a-f]{64}$/u.test(plan.planRoot || '') &&
       plan.agent?.provider === 'codex',
-    'kungfu run codex --plan did not bind the fixture provider and exact plan',
+    'kungfu run codex <task> --plan did not bind the fixture provider and exact plan',
   );
   return {
     fixtureOnly: true,


### PR DESCRIPTION
## Summary

Repair the deterministic macOS post-sign CLI finalization failure observed in Full Product Build run 32200025709, job 95931119003. The signed CLI smoke now starts the reviewed Starter plan with its exact captured Work title instead of relying on the removed no-task fallback.

## Related issue

Follow-up release qualification for `2026-08-09-kungfu-kfx-webhook-agent-authoring`.

## Changes

- Assert that the deterministic Starter project plan exposes `initialWork.title`.
- Pass that exact title as the positional task to `kungfu run codex --workspace project --plan --json`.
- Extend the signed CLI qualification regression test to enforce the explicit-task invocation.

## Verification

- `./shifu test:cli-surface-qualification` (95/95)
- `./shifu check:source` (1144 Node tests: 1133 passed, 11 skipped; 40 Python; 134 upgrade; 73 desktop; build-free source gate passed)
- `./shifu check:staged`
- Commit hook repeated the staged gate successfully

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded release qualification repair updates a post-sign smoke invocation to the current explicit-task Work start contract without changing architecture"
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This changes only a credential-free, plan-only post-sign smoke invocation. The reviewed deterministic Starter fixture remains the provider, and the checks above validate its exact Work contract.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable: no product or public contract behavior changed)
