### PR TITLE
fix(governance): fail source admission before passport expiry

### DIFF
--- a/docs/architecture/incubation-passport-governance.md
+++ b/docs/architecture/incubation-passport-governance.md
@@ -65,8 +65,15 @@ Run:
 The checker scans every tracked `.fbs` and `.bfbs`, resolves registered schema
 owners, validates all referenced paths, checks Root protocol conformance, and
 rejects overdue runtime incubation. The baseline is an exact set: a new issue,
-an expired waiver, or a stale entry all fail. This keeps current debt visible
-without granting an open-ended exception to future files.
+a stale entry, or an entry within the contract's 30-day expiry lead window all
+fail. A near-expiry failure names the owner and removal condition, forcing an
+explicit renewal, retirement, or removal decision before merge instead of
+letting a previously green protected head decay after the expiry date.
+
+`scripts/check-incubation-passport.mjs --today YYYY-MM-DD` is the disposable
+clock used by regression fixtures. The fixtures cover a current date, the
+near-expiry lead boundary, the expiry date, and the post-expiry date without
+changing the machine clock or extending a waiver.
 
 ## Current boundary
 

--- a/framework/incubation/incubation-passport.contract.json
+++ b/framework/incubation/incubation-passport.contract.json
@@ -14,7 +14,8 @@
     "identityProtocol": "Any object that mints a durable Root or identity preimage provides two independent implementation languages and shared golden vectors before admission.",
     "admissionReceipt": "An admitted native owner emits a fail-closed kungfu.incubation-passport.admission-receipt/v1 binding candidate, Assignment, source tree, fixtures, implementation languages, platform evidence, exact schema bytes, and no-rewrite evidence.",
     "deadline": "An incubating runtime object past its declared deadline is a gate failure.",
-    "history": "Registration and admission are additive. They never migrate, reinterpret, recalculate, or alias sealed evidence."
+    "history": "Registration and admission are additive. They never migrate, reinterpret, recalculate, or alias sealed evidence.",
+    "baselineLifecycle": "An accepted issue fails source admission before its expiry date enters the configured lead window; the failure names the owner and removal condition so renewal, retirement, or removal is decided before merge."
   },
   "baselinePolicy": {
     "mode": "exact-known-issues",
@@ -27,6 +28,8 @@
     ],
     "newIssue": "fail",
     "staleEntry": "fail",
-    "expiredEntry": "fail"
+    "expiredEntry": "fail",
+    "nearExpiryEntry": "fail-with-owner-and-removal-condition",
+    "expiryLeadDays": 30
   }
 }

--- a/framework/incubation/schema/incubation-passport-contract-v1.schema.json
+++ b/framework/incubation/schema/incubation-passport-contract-v1.schema.json
@@ -35,7 +35,8 @@
         "identityProtocol",
         "admissionReceipt",
         "deadline",
-        "history"
+        "history",
+        "baselineLifecycle"
       ],
       "properties": {
         "birthDecision": { "type": "string", "minLength": 1 },
@@ -44,7 +45,8 @@
         "identityProtocol": { "type": "string", "minLength": 1 },
         "admissionReceipt": { "type": "string", "minLength": 1 },
         "deadline": { "type": "string", "minLength": 1 },
-        "history": { "type": "string", "minLength": 1 }
+        "history": { "type": "string", "minLength": 1 },
+        "baselineLifecycle": { "type": "string", "minLength": 1 }
       }
     },
     "baselinePolicy": {
@@ -55,7 +57,9 @@
         "requiredFields",
         "newIssue",
         "staleEntry",
-        "expiredEntry"
+        "expiredEntry",
+        "nearExpiryEntry",
+        "expiryLeadDays"
       ],
       "properties": {
         "mode": { "const": "exact-known-issues" },
@@ -71,7 +75,11 @@
         },
         "newIssue": { "const": "fail" },
         "staleEntry": { "const": "fail" },
-        "expiredEntry": { "const": "fail" }
+        "expiredEntry": { "const": "fail" },
+        "nearExpiryEntry": {
+          "const": "fail-with-owner-and-removal-condition"
+        },
+        "expiryLeadDays": { "type": "integer", "minimum": 1 }
       }
     }
   }

--- a/scripts/check-incubation-passport.mjs
+++ b/scripts/check-incubation-passport.mjs
@@ -43,6 +43,14 @@ function utcDate() {
   return new Date().toISOString().slice(0, 10);
 }
 
+function utcDay(date) {
+  if (!/^\d{4}-\d{2}-\d{2}$/u.test(date || '')) return null;
+  const value = Date.parse(`${date}T00:00:00Z`);
+  if (Number.isNaN(value)) return null;
+  if (new Date(value).toISOString().slice(0, 10) !== date) return null;
+  return Math.floor(value / 86_400_000);
+}
+
 function issue(key, detail) {
   return { key, detail };
 }
@@ -915,17 +923,24 @@ export function collectIssues({
   return issues.sort((left, right) => left.key.localeCompare(right.key));
 }
 
-export function compareBaseline(issues, baseline, today = utcDate()) {
+export function compareBaseline(
+  issues,
+  baseline,
+  today = utcDate(),
+  expiryLeadDays = 30,
+) {
   const currentByKey = new Map(issues.map((entry) => [entry.key, entry]));
   const baselineByKey = new Map();
   const malformedBaseline = [];
+  const todayDay = utcDay(today);
   for (const entry of baseline.issues || []) {
     if (
       !entry.key ||
       !entry.owner ||
       !entry.rationale ||
       !entry.expiresOn ||
-      !entry.removalCondition
+      !entry.removalCondition ||
+      utcDay(entry.expiresOn) === null
     ) {
       malformedBaseline.push(entry.key || '<missing-key>');
       continue;
@@ -933,6 +948,16 @@ export function compareBaseline(issues, baseline, today = utcDate()) {
     if (baselineByKey.has(entry.key)) malformedBaseline.push(entry.key);
     baselineByKey.set(entry.key, entry);
   }
+
+  const expiringBaseline = [...baselineByKey.values()].filter((entry) => {
+    const expiryDay = utcDay(entry.expiresOn);
+    return (
+      todayDay !== null &&
+      expiryDay !== null &&
+      expiryDay >= todayDay &&
+      expiryDay - todayDay <= expiryLeadDays
+    );
+  });
 
   return {
     newIssues: issues.filter((entry) => !baselineByKey.has(entry.key)),
@@ -942,6 +967,7 @@ export function compareBaseline(issues, baseline, today = utcDate()) {
     expiredBaseline: [...baselineByKey.values()].filter(
       (entry) => entry.expiresOn < today,
     ),
+    expiringBaseline,
     malformedBaseline,
   };
 }
@@ -970,6 +996,11 @@ export async function validateRepository(root = ROOT, today = utcDate()) {
   const authority = loadJson(root, contract.schemaAuthority);
 
   const structuralErrors = [];
+  if (utcDay(today) === null) {
+    structuralErrors.push(
+      `today must be a real UTC date, got ${today || '<missing>'}`,
+    );
+  }
   const Ajv2020 = await loadAjv2020();
   let schemaValidation = 'skipped';
   if (Ajv2020) {
@@ -1010,17 +1041,20 @@ export async function validateRepository(root = ROOT, today = utcDate()) {
     schemas: trackedSchemas(root),
     today,
   });
-  const comparison = compareBaseline(issues, baseline, today);
+  const expiryLeadDays = contract.baselinePolicy.expiryLeadDays;
+  const comparison = compareBaseline(issues, baseline, today, expiryLeadDays);
   const ok =
     structuralErrors.length === 0 &&
     comparison.newIssues.length === 0 &&
     comparison.staleBaseline.length === 0 &&
     comparison.expiredBaseline.length === 0 &&
+    comparison.expiringBaseline.length === 0 &&
     comparison.malformedBaseline.length === 0;
   return {
     schema: 'kungfu.incubation-passport.check/v1',
     ok,
     today,
+    expiryLeadDays,
     currentIssueCount: issues.length,
     acceptedIssueCount: issues.length - comparison.newIssues.length,
     schemaValidation,
@@ -1039,6 +1073,11 @@ function renderFailure(result) {
     lines.push(`  stale-baseline: ${entry.key}`);
   for (const entry of result.expiredBaseline)
     lines.push(`  expired-baseline: ${entry.key} (${entry.expiresOn})`);
+  for (const entry of result.expiringBaseline)
+    lines.push(
+      `  near-expiry-baseline: ${entry.key} (${entry.expiresOn}; ` +
+        `owner=${entry.owner}; continuation=${entry.removalCondition})`,
+    );
   for (const entry of result.malformedBaseline)
     lines.push(`  malformed-baseline: ${entry}`);
   return lines.join('\n');
@@ -1051,8 +1090,10 @@ if (invoked) {
   const json = process.argv.includes('--json');
   const todayIndex = process.argv.indexOf('--today');
   const today = todayIndex >= 0 ? process.argv[todayIndex + 1] : utcDate();
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(today || '')) {
-    console.error('[incubation-passport] --today requires YYYY-MM-DD');
+  if (utcDay(today) === null) {
+    console.error(
+      '[incubation-passport] --today requires a real YYYY-MM-DD UTC date',
+    );
     process.exit(2);
   }
   const result = await validateRepository(ROOT, today);

--- a/scripts/check-incubation-passport.test.mjs
+++ b/scripts/check-incubation-passport.test.mjs
@@ -59,6 +59,40 @@ test('repository matches the exact known-issue baseline', async () => {
   assert.equal(result.acceptedIssueCount, 5);
 });
 
+test('repository baseline lifecycle fails before expiry with an actionable continuation', async () => {
+  const results = new Map();
+  for (const fixture of FIXTURES.clockCases) {
+    const result = await validateRepository(ROOT, fixture.today);
+    results.set(fixture.name, result);
+    assert.equal(result.ok, fixture.expectedOk, fixture.name);
+    assert.equal(
+      result.expiringBaseline.length,
+      fixture.expectedExpiring,
+      fixture.name,
+    );
+    assert.equal(
+      result.expiredBaseline.length,
+      fixture.expectedExpired,
+      fixture.name,
+    );
+  }
+
+  const nearExpiry = results.get('near-expiry');
+  assert.ok(
+    nearExpiry.expiringBaseline.every(
+      (entry) => entry.owner && entry.removalCondition,
+    ),
+  );
+});
+
+test('repository baseline lifecycle fails closed for an impossible clock date', async () => {
+  const result = await validateRepository(ROOT, '2026-02-31');
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.structuralErrors.some((entry) => entry.includes('real UTC date')),
+  );
+});
+
 test('admitted native receipt rejects stale and incomplete evidence', () => {
   const registry = JSON.parse(
     fs.readFileSync(
@@ -267,5 +301,6 @@ test('baseline comparison rejects new, stale, expired, and malformed entries', (
     comparison.expiredBaseline.map((entry) => entry.key),
     ['known'],
   );
+  assert.deepEqual(comparison.expiringBaseline, []);
   assert.deepEqual(comparison.malformedBaseline, ['malformed']);
 });

--- a/tests/fixtures/incubation-passport/cases.json
+++ b/tests/fixtures/incubation-passport/cases.json
@@ -13,5 +13,35 @@
       "name": "overdue runtime incubation",
       "expectedIssue": "overdue-runtime-incubation:example.runtime"
     }
+  ],
+  "clockCases": [
+    {
+      "name": "current",
+      "today": "2026-11-30",
+      "expectedOk": true,
+      "expectedExpiring": 0,
+      "expectedExpired": 0
+    },
+    {
+      "name": "near-expiry",
+      "today": "2026-12-01",
+      "expectedOk": false,
+      "expectedExpiring": 5,
+      "expectedExpired": 0
+    },
+    {
+      "name": "expiry-boundary",
+      "today": "2026-12-31",
+      "expectedOk": false,
+      "expectedExpiring": 5,
+      "expectedExpired": 0
+    },
+    {
+      "name": "post-boundary",
+      "today": "2027-01-01",
+      "expectedOk": false,
+      "expectedExpiring": 0,
+      "expectedExpired": 5
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- fail source admission when an accepted incubation-passport issue enters the contract-defined 30-day expiry lead window
- report the exact owner and removal condition so renewal, retirement, or removal is decided before merge
- keep the existing passport contract as the single authority; no second registry, scheduler, or date extension

## Related issue

Native Assignment: `2026-08-18-kungfu-time-stable-source-admission`

## Changes

- add a fail-closed baseline lifecycle policy and schema fields
- validate real UTC dates and reject impossible disposable-clock input
- add current, near-expiry, expiry-boundary, post-boundary, and invalid-date regression coverage
- document the pre-merge lifecycle behavior

## Verification

- `./shifu check:source` passed with zero writes on exact head `7190b1cd88713f15558a1672a298eb70497ccf76`
- `node --test scripts/check-incubation-passport.test.mjs` passed 8/8
- Biome and `git diff --check` passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Tighten the existing incubation-passport source-admission lifecycle without changing architecture authority or widening product behavior"
}
-->

## Evolution Map impact

Evolution impact: extends

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed

Parent goal: `2026-08-18-kungfu-mainline-quality-convergence`
