### PR TITLE
fix(ci): advance qualification patrol runtime

### DIFF
--- a/.github/workflows/dev-qualification-patrol.yml
+++ b/.github/workflows/dev-qualification-patrol.yml
@@ -32,16 +32,16 @@ permissions:
 
 jobs:
   patrol:
-    uses: kungfu-systems/buildchain/.github/workflows/dev-qualification-patrol.yml@49da2cd118b04d502fd90deaa57acaf83b0eaed7
+    uses: kungfu-systems/buildchain/.github/workflows/dev-qualification-patrol.yml@f0121c60ed34853343950af1e2ebf8bc984d0482
     with:
-      buildchain-ref: ${{ inputs.buildchain-ref || '49da2cd118b04d502fd90deaa57acaf83b0eaed7' }}
+      buildchain-ref: ${{ inputs.buildchain-ref || 'f0121c60ed34853343950af1e2ebf8bc984d0482' }}
       source-branch: ${{ github.event.repository.default_branch }}
       dev-workflow-path: .github/workflows/dev-verify-patrol.yml
       preflight-workflow-path: .github/workflows/alpha-promotion-preflight.yml
       priority-workflows-json: >-
         [".github/workflows/build.yml",".github/workflows/release-new-version.yml",".github/workflows/release-shifu.yml"]
       dispatch-inputs-json: >-
-        {"buildchain-ref":"${{ inputs.buildchain-ref || '49da2cd118b04d502fd90deaa57acaf83b0eaed7' }}"}
+        {"buildchain-ref":"${{ inputs.buildchain-ref || 'f0121c60ed34853343950af1e2ebf8bc984d0482' }}"}
       max-attempts: 2
       mutation-authorized: ${{ github.event_name != 'workflow_dispatch' }}
       dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || false }}

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -658,9 +658,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:57a029cf8190b4df23acdab9ba2607199f768e86544ea020c57a29dd22ca41be",
+          "definitionDigest": "sha256:e39ffe84e14d91819e292c1c4e2c2b52a6cdbb8c956d1eebe90c82ff18ec4978",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-qualification-patrol.yml@49da2cd118b04d502fd90deaa57acaf83b0eaed7"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-qualification-patrol.yml@f0121c60ed34853343950af1e2ebf8bc984d0482"],
           "steps": []
         }
       ]

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -215,7 +215,7 @@
             "product-alpha",
             "product-stable"
           ],
-          "sourceRoot": "sha256:a94f7b5c47883a70231ab1ca9b202cf0e7c15089d163410e0888b937c57d2c1f"
+          "sourceRoot": "sha256:2c43ef28613d7823bb48abddf730267f45a877934326c9a580c015f2c69cb708"
         },
         {
           "path": ".github/workflows/stable-candidate-patrol.yml",
@@ -877,5 +877,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:3ebbbca40296e1e19468acf4f060831cca43d217bca7f3a0f894b0a98901fbdb"
+  "registryRoot": "sha256:09de55e35f9ec14c2fa5bcfc90440268f0194a7a4cde4d86a809faff38da7387"
 }


### PR DESCRIPTION
## Summary

- advance the dev qualification patrol caller to the protected Buildchain pagination repair
- keep workflow authority and release publication roots aligned with the exact caller source
- preserve fail-closed active-workflow discovery without changing PR 3301 or its head

## Related issue

Native Assignment: `2026-08-18-kungfu-exact-head-ci-greenline`

Buildchain dependency: `kungfu-systems/buildchain#2939`, protected merge `f0121c60ed34853343950af1e2ebf8bc984d0482`

## Changes

- replace the three patrol Buildchain selectors with the protected merge SHA
- refresh the workflow authority record with the official generator
- refresh the publication surface root with the official generator

## Verification

- `node --test scripts/dev-alpha-candidate-patrol.test.mjs` passed 4/4
- `./shifu check:source` passed with 0 failures on exact head `465de6009f5c6023d769a59d9af50eebced4e241`
- the unbypassed pre-commit and pre-push hooks passed
- the commit contains exactly the three expected provenance/runtime pointer files

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Advance an existing CI caller to an already protected Buildchain repair without changing architecture authority or product behavior"
}
-->

## Evolution Map impact

Evolution impact: preserves

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed

Parent goal: `2026-08-18-kungfu-mainline-quality-convergence`
