### PR TITLE
fix(ci): hydrate merge-group source history

### DIFF
--- a/scripts/check-kfd7-library-boundary.test.mjs
+++ b/scripts/check-kfd7-library-boundary.test.mjs
@@ -12,6 +12,7 @@ import {
   assertInstalledBootstrapExports,
   extractKfApiExportSymbols,
 } from './libkungfu-bootstrap-admission.mjs';
+import { sourceMergeBase } from './source-acceptance.mjs';
 
 const read = (path) => fs.readFileSync(path, 'utf8');
 const readJson = (path) => JSON.parse(read(path));
@@ -58,6 +59,7 @@ const retiredSymbols = [
 
 function baseSymbolPolicy() {
   const candidates = [
+    sourceMergeBase().sha,
     process.env.GITHUB_BASE_REF
       ? `origin/${process.env.GITHUB_BASE_REF}`
       : null,

--- a/scripts/source-acceptance-git.test.mjs
+++ b/scripts/source-acceptance-git.test.mjs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -52,24 +53,95 @@ test('Project Cut composition retains branch merge-base fallback', () => {
   ]);
 });
 
-test('source acceptance fetches only merge-group base trees', () => {
+test('source acceptance fetches exact merge-group base ancestry without blobs', () => {
   const commit = 'a'.repeat(40);
   const calls = [];
   fetchSourceAcceptanceCommit(commit, (command, args, options) => {
     calls.push({ command, args, options });
-    return { status: 0, stderr: '' };
+    return calls.length === 1
+      ? { status: 0, stdout: 'true\n', stderr: '' }
+      : { status: 0, stdout: '', stderr: '' };
   });
   assert.deepEqual(calls[0].command, 'git');
-  assert.deepEqual(calls[0].args, [
+  assert.deepEqual(calls[0].args, ['rev-parse', '--is-shallow-repository']);
+  assert.deepEqual(calls[1].args, [
     'fetch',
     '--no-tags',
     '--no-write-fetch-head',
     '--filter=blob:none',
-    '--depth=1',
+    '--unshallow',
     'origin',
     commit,
   ]);
-  assert.equal(calls[0].options.encoding, 'utf8');
+  assert.equal(calls[1].options.encoding, 'utf8');
+});
+
+test('source acceptance does not unshallow a complete repository', () => {
+  const commit = 'a'.repeat(40);
+  const calls = [];
+  fetchSourceAcceptanceCommit(commit, (command, args, options) => {
+    calls.push({ command, args, options });
+    return calls.length === 1
+      ? { status: 0, stdout: 'false\n', stderr: '' }
+      : { status: 0, stdout: '', stderr: '' };
+  });
+  assert.deepEqual(calls[1].args, [
+    'fetch',
+    '--no-tags',
+    '--no-write-fetch-head',
+    '--filter=blob:none',
+    'origin',
+    commit,
+  ]);
+});
+
+test('source acceptance exact-base fetch repairs a depth-one history walk', (t) => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-source-acceptance-shallow-history-'),
+  );
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const origin = path.join(root, 'origin');
+  const checkout = path.join(root, 'checkout');
+  const git = (cwd, args) => readSourceAcceptanceGit(args, { cwd });
+
+  fs.mkdirSync(origin);
+  git(origin, ['init', '--quiet']);
+  git(origin, ['config', 'user.name', 'KFD Fixture']);
+  git(origin, ['config', 'user.email', 'kfd-fixture@kungfu.invalid']);
+  fs.writeFileSync(path.join(origin, 'history.txt'), 'baseline\n');
+  git(origin, ['add', 'history.txt']);
+  git(origin, ['commit', '--quiet', '-m', 'baseline']);
+  const baselineSha = git(origin, ['rev-parse', 'HEAD']);
+  fs.appendFileSync(path.join(origin, 'history.txt'), 'base\n');
+  git(origin, ['commit', '--quiet', '-am', 'base']);
+  const baseSha = git(origin, ['rev-parse', 'HEAD']);
+  fs.appendFileSync(path.join(origin, 'history.txt'), 'head\n');
+  git(origin, ['commit', '--quiet', '-am', 'head']);
+
+  const cloned = spawnSync(
+    'git',
+    ['clone', '--quiet', '--depth=1', `file://${origin}`, checkout],
+    { encoding: 'utf8' },
+  );
+  assert.equal(cloned.status, 0, cloned.stderr);
+  assert.notEqual(
+    spawnSync('git', ['cat-file', '-e', `${baselineSha}^{commit}`], {
+      cwd: checkout,
+      encoding: 'utf8',
+    }).status,
+    0,
+    'depth-one fixture must begin without the historical baseline',
+  );
+
+  fetchSourceAcceptanceCommit(baseSha, (command, args, options) =>
+    spawnSync(command, args, { ...options, cwd: checkout }),
+  );
+  assert.equal(git(checkout, ['cat-file', '-t', baselineSha]), 'commit');
+  assert.equal(
+    git(checkout, ['log', '--format=%H', `${baselineSha}..HEAD`]).split('\n')
+      .length,
+    2,
+  );
 });
 
 test('source acceptance falls back to the verified merge-group base ref', () => {

--- a/scripts/source-acceptance.mjs
+++ b/scripts/source-acceptance.mjs
@@ -167,23 +167,32 @@ export function sourceAcceptanceMergeBaseCandidates(
 }
 
 export function fetchSourceAcceptanceCommit(commit, spawn = spawnSync) {
-  const result = spawn(
+  const options = {
+    cwd: ROOT,
+    encoding: 'utf8',
+    maxBuffer: SOURCE_ACCEPTANCE_GIT_MAX_BUFFER_BYTES,
+  };
+  const shallowProbe = spawn(
     'git',
-    [
-      'fetch',
-      '--no-tags',
-      '--no-write-fetch-head',
-      '--filter=blob:none',
-      '--depth=1',
-      'origin',
-      commit,
-    ],
-    {
-      cwd: ROOT,
-      encoding: 'utf8',
-      maxBuffer: SOURCE_ACCEPTANCE_GIT_MAX_BUFFER_BYTES,
-    },
+    ['rev-parse', '--is-shallow-repository'],
+    options,
   );
+  if (shallowProbe.status !== 0) {
+    throw new Error(
+      `cannot inspect source-acceptance checkout depth: ${(shallowProbe.stderr || '').trim()}`,
+    );
+  }
+  const fetchArgs = [
+    'fetch',
+    '--no-tags',
+    '--no-write-fetch-head',
+    '--filter=blob:none',
+  ];
+  if ((shallowProbe.stdout || '').trim() === 'true') {
+    fetchArgs.push('--unshallow');
+  }
+  fetchArgs.push('origin', commit);
+  const result = spawn('git', fetchArgs, options);
   if (result.status !== 0) {
     throw new Error(
       `cannot fetch source-acceptance merge-group base ${commit}: ${(result.stderr || '').trim()}`,


### PR DESCRIPTION
## Summary

Repair merge-group source acceptance in shallow checkouts by hydrating the ancestry of the exact event-authorized base commit. Use the same authoritative base for the KFD-7 library boundary comparison.

## Related issue

Follow-up for #3318.

## Changes

- Detect whether the checkout is shallow before fetching the exact merge-group base.
- Unshallow with blob filtering so historical integrity and complexity walks can resolve their retained baselines.
- Prefer the event-authorized source acceptance base in the KFD-7 boundary gate.
- Cover shallow and complete repositories, including a real depth-one history fixture.

## Verification

- `SHIFU_CACHE_SCOPE=development CI=true ./shifu check:staged`
- `SHIFU_CACHE_SCOPE=development CI=true ./shifu check:source`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix restores existing merge-group source-history and KFD-7 gate behavior without changing an architecture contract."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required; gate behavior is restored and tests document the regression)
