### PR TITLE
fix(core): stabilize Windows watcher reconnect probe

### DIFF
--- a/framework/core/tests/fixtures/watcher-runtime-probe.js
+++ b/framework/core/tests/fixtures/watcher-runtime-probe.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 const crypto = require('node:crypto');
-const { spawn } = require('node:child_process');
+const { spawn, spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
@@ -18,6 +18,13 @@ const watcher = new binding.Watcher(
   true,
   2,
 );
+const reconnectDeadlines = Object.freeze({
+  coordinatorStartup: process.platform === 'win32' ? 30_000 : 15_000,
+  watcherConnect: process.platform === 'win32' ? 30_000 : 8_000,
+  watcherDisconnect: process.platform === 'win32' ? 30_000 : 8_000,
+  watcherReconnect: process.platform === 'win32' ? 30_000 : 10_000,
+  watcherStop: process.platform === 'win32' ? 15_000 : 5_000,
+});
 
 function printableStats() {
   return Object.fromEntries(
@@ -33,7 +40,7 @@ function fail(message) {
   process.exit(2);
 }
 
-function waitFor(predicate, timeoutMs, message) {
+function waitFor(predicate, timeoutMs, message, context = () => ({})) {
   return new Promise((resolve, reject) => {
     const deadline = Date.now() + timeoutMs;
     const poll = setInterval(() => {
@@ -42,7 +49,11 @@ function waitFor(predicate, timeoutMs, message) {
         resolve();
       } else if (Date.now() > deadline) {
         clearInterval(poll);
-        reject(new Error(message));
+        reject(
+          new Error(
+            `${message}: ${JSON.stringify({ timeoutMs, ...context() })}`,
+          ),
+        );
       }
     }, 20);
   });
@@ -77,11 +88,38 @@ function startCoordinator() {
       path.join(home, 'runtime'),
       '--low-latency',
     ],
-    { cwd: coreDir, env: environment, stdio: ['ignore', output, output] },
+    {
+      cwd: coreDir,
+      env: environment,
+      stdio: ['ignore', output, output],
+      detached: process.platform !== 'win32',
+    },
   );
   fs.closeSync(output);
   child.coordinatorLogOffset = logOffset;
   return child;
+}
+
+function coordinatorLogTail(child) {
+  const outputPath = path.join(home, 'coordinator.out');
+  const output = fs.existsSync(outputPath)
+    ? fs.readFileSync(outputPath, 'utf8').slice(child.coordinatorLogOffset)
+    : '';
+  return output.slice(-4_000);
+}
+
+function reconnectContext(child, stage) {
+  return {
+    stage,
+    platform: process.platform,
+    coordinator: {
+      pid: child?.pid ?? null,
+      exitCode: child?.exitCode ?? null,
+      signalCode: child?.signalCode ?? null,
+      logTail: child ? coordinatorLogTail(child) : '',
+    },
+    watcher: printableStats(),
+  };
 }
 
 function coordinatorReady(child) {
@@ -113,9 +151,29 @@ function waitForExitWithin(child, timeoutMs) {
 
 async function stopCoordinator(child) {
   if (child.exitCode !== null || child.signalCode !== null) return;
-  child.kill('SIGTERM');
+  if (process.platform === 'win32') {
+    const terminated = spawnSync(
+      'taskkill',
+      ['/pid', String(child.pid), '/T', '/F'],
+      { encoding: 'utf8', windowsHide: true },
+    );
+    if (terminated.error) {
+      throw new Error(`taskkill failed to launch: ${terminated.error.message}`);
+    }
+    if (terminated.status !== 0 && child.exitCode === null) {
+      throw new Error(
+        `taskkill failed (${terminated.status}): ${terminated.stderr.trim()}`,
+      );
+    }
+  } else {
+    process.kill(-child.pid, 'SIGTERM');
+  }
   if (await waitForExitWithin(child, 3_000)) return;
-  child.kill('SIGKILL');
+  if (process.platform === 'win32') {
+    child.kill();
+  } else {
+    process.kill(-child.pid, 'SIGKILL');
+  }
   if (!(await waitForExitWithin(child, 3_000))) {
     throw new Error('coordinator did not exit after SIGKILL');
   }
@@ -154,23 +212,29 @@ async function reconnectProbe() {
         coordinatorReady(coordinator) ||
         coordinator.exitCode !== null ||
         coordinator.signalCode !== null,
-      15_000,
+      reconnectDeadlines.coordinatorStartup,
       'coordinator startup did not reach a terminal state',
+      () => reconnectContext(coordinator, 'initial-coordinator-startup'),
     );
     if (coordinator.exitCode !== null || coordinator.signalCode !== null) {
       throw new Error(
-        `coordinator exited during startup: ${fs.readFileSync(path.join(home, 'coordinator.out'), 'utf8').trim()}`,
+        `coordinator exited during startup: ${JSON.stringify(reconnectContext(coordinator, 'initial-coordinator-startup'))}`,
       );
     }
     watcher.start();
-    await waitFor(() => watcher.isLive(), 8_000, 'watcher did not connect');
+    await waitFor(
+      () => watcher.isLive(),
+      reconnectDeadlines.watcherConnect,
+      'watcher did not connect',
+      () => reconnectContext(coordinator, 'initial-watcher-connect'),
+    );
 
-    coordinator.kill();
-    await waitForExit(coordinator);
+    await stopCoordinator(coordinator);
     await waitFor(
       () => !watcher.isLive(),
-      8_000,
+      reconnectDeadlines.watcherDisconnect,
       'watcher did not observe coordinator exit',
+      () => reconnectContext(coordinator, 'watcher-disconnect'),
     );
 
     coordinator = startCoordinator();
@@ -179,22 +243,27 @@ async function reconnectProbe() {
         coordinatorReady(coordinator) ||
         coordinator.exitCode !== null ||
         coordinator.signalCode !== null,
-      15_000,
+      reconnectDeadlines.coordinatorStartup,
       'replacement coordinator startup did not reach a terminal state',
+      () => reconnectContext(coordinator, 'replacement-coordinator-startup'),
     );
     if (coordinator.exitCode !== null || coordinator.signalCode !== null) {
-      throw new Error('replacement coordinator exited during startup');
+      throw new Error(
+        `replacement coordinator exited during startup: ${JSON.stringify(reconnectContext(coordinator, 'replacement-coordinator-startup'))}`,
+      );
     }
     await waitFor(
       () => watcher.isLive(),
-      10_000,
+      reconnectDeadlines.watcherReconnect,
       'watcher did not reconnect to the restarted coordinator',
+      () => reconnectContext(coordinator, 'watcher-reconnect'),
     );
     watcher.quit();
     await waitFor(
       () => !watcher.runtimeStats().running,
-      5_000,
+      reconnectDeadlines.watcherStop,
       'watcher did not stop after reconnect',
+      () => reconnectContext(coordinator, 'watcher-stop'),
     );
     result = { mode, reconnected: true, stats: printableStats() };
   } finally {
@@ -249,6 +318,13 @@ if (mode === 'pool') {
   setTimeout(() => process.exit(0), 25);
 } else if (mode === 'reconnect') {
   reconnectProbe().catch((error) => fail(error.message));
+} else if (mode === 'deadline-failure') {
+  waitFor(
+    () => false,
+    25,
+    'synthetic watcher deadline',
+    () => reconnectContext(null, 'synthetic-deadline'),
+  ).catch((error) => fail(error.message));
 } else {
   fail(`unknown probe mode: ${mode}`);
 }

--- a/framework/core/tests/watcher-runtime-boundary.test.js
+++ b/framework/core/tests/watcher-runtime-boundary.test.js
@@ -24,6 +24,7 @@ const watcherBenchDriver = path.join(
   'bench',
   'dispatch_bench_watcher.mjs',
 );
+const watcherProbeSource = fs.readFileSync(probe, 'utf8');
 const nativeTest = {
   skip: fs.existsSync(bindingPath)
     ? false
@@ -35,7 +36,12 @@ function runProbe(mode, environment = {}) {
     cwd: path.resolve(coreDir, '..', '..'),
     env: { ...process.env, ...environment },
     encoding: 'utf8',
-    timeout: mode === 'reconnect' ? 35_000 : 10_000,
+    timeout:
+      mode === 'reconnect' && process.platform === 'win32'
+        ? 150_000
+        : mode === 'reconnect'
+          ? 55_000
+          : 10_000,
   });
   assert.equal(
     result.error,
@@ -50,6 +56,18 @@ function runProbe(mode, environment = {}) {
   return result.stdout.trim()
     ? JSON.parse(result.stdout.trim().split('\n').at(-1))
     : null;
+}
+
+function runFailingProbe(mode) {
+  const result = spawnSync(process.execPath, [probe, mode], {
+    cwd: path.resolve(coreDir, '..', '..'),
+    env: process.env,
+    encoding: 'utf8',
+    timeout: 10_000,
+  });
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 2, `${mode} must fail closed: ${result.stderr}`);
+  return JSON.parse(result.stderr.trim().split('\n').at(-1));
 }
 
 test('watcher source does not reserve a libuv worker-pool job', () => {
@@ -75,6 +93,22 @@ test('watcher dispatch bench follows and proves the load peer carrier', () => {
   assert.match(driver, /watcher observed \$\{observed\} requested carrier/);
   assert.match(driver, /if \(observed < count\)/);
   assert.match(driver, /coordinator\.kill\(\)/);
+});
+
+test('watcher reconnect fixture owns process trees and bounds Windows transitions', () => {
+  assert.match(
+    watcherProbeSource,
+    /watcherConnect: process\.platform === 'win32' \? 30_000 : 8_000/,
+  );
+  assert.match(
+    watcherProbeSource,
+    /watcherReconnect: process\.platform === 'win32' \? 30_000 : 10_000/,
+  );
+  assert.match(
+    watcherProbeSource,
+    /\['\/pid', String\(child\.pid\), '\/T', '\/F'\]/,
+  );
+  assert.match(watcherProbeSource, /process\.kill\(-child\.pid, 'SIGTERM'\)/);
 });
 
 test(
@@ -133,5 +167,18 @@ test(
     assert.equal(result.stats.running, false);
     assert.equal(result.stats.stopRequested, true);
     assert.equal(result.stats.bridgeFailures, '0');
+  },
+);
+
+test(
+  'watcher transition deadlines fail closed with actionable diagnostics',
+  nativeTest,
+  () => {
+    const result = runFailingProbe('deadline-failure');
+    assert.equal(result.mode, 'deadline-failure');
+    assert.match(result.error, /synthetic watcher deadline/);
+    assert.match(result.error, /"stage":"synthetic-deadline"/);
+    assert.match(result.error, /"platform":"[^"]+"/);
+    assert.match(result.error, /"watcher":\{/);
   },
 );


### PR DESCRIPTION
## Summary

Stabilize the Windows watcher reconnect qualification probe without changing the production watcher API, ABI, callback ownership, or reconnect semantics.

This preserves the exact failed protected evidence from heads `22cecbb842`, `8330b13554`, and `44a6868a47`; the latest failed coordinates are workflow run `32523149950`, attempt 1 job `96899711315`, and attempt 2 job `96914534282`.

## Related issue

Supplemental repair Assignment `2026-08-21-kungfu-windows-watcher-reconnect-reliability` under `2026-08-18-kungfu-mainline-quality-convergence`.

## Changes

- terminate the complete coordinator process tree on Windows and POSIX
- use explicit Windows-only transition budgets as harness scheduling tolerance
- report bounded coordinator log and watcher runtime state on every transition timeout
- add fail-closed diagnostics and process-ownership contract coverage

## Verification

- focused watcher runtime boundary suite: 9 passed, 0 failed
- `CI=true ./shifu check:source`: 1164 tests, 1153 passed, 11 skipped, 0 failed
- pre-commit staged gate: passed
- exact-head work admission: `sha256:51264aecbc76ef7ea1255a9232ca4f2271fd7bc7b4b12fec872d7e159997288d`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This repair changes only qualification harness process ownership, bounded scheduling tolerance, and failure diagnostics; production watcher contracts and behavior are unchanged."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable: harness-only repair)