### PR TITLE
fix(core): sequence watcher after coordinator readiness

### DIFF
--- a/framework/core/tests/fixtures/watcher-runtime-probe.js
+++ b/framework/core/tests/fixtures/watcher-runtime-probe.js
@@ -12,12 +12,16 @@ const coreDir = path.resolve(__dirname, '..', '..');
 const binding = require(path.join(coreDir, 'dist', 'kungfu', 'kungfu_node.node'));
 const temporaryRoot = process.platform === 'win32' ? os.tmpdir() : '/tmp';
 const home = fs.mkdtempSync(path.join(temporaryRoot, 'kfwr.'));
-const watcher = new binding.Watcher(
-  path.join(home, 'runtime'),
-  `runtime_${mode}`,
-  true,
-  2,
-);
+let watcher = null;
+
+function createWatcher() {
+  return new binding.Watcher(
+    path.join(home, 'runtime'),
+    `runtime_${mode}`,
+    true,
+    2,
+  );
+}
 const reconnectDeadlines = Object.freeze({
   coordinatorStartup: process.platform === 'win32' ? 30_000 : 15_000,
   watcherConnect: process.platform === 'win32' ? 30_000 : 8_000,
@@ -27,6 +31,7 @@ const reconnectDeadlines = Object.freeze({
 });
 
 function printableStats() {
+  if (watcher === null) return null;
   return Object.fromEntries(
     Object.entries(watcher.runtimeStats()).map(([key, value]) => [
       key,
@@ -221,6 +226,7 @@ async function reconnectProbe() {
         `coordinator exited during startup: ${JSON.stringify(reconnectContext(coordinator, 'initial-coordinator-startup'))}`,
       );
     }
+    watcher = createWatcher();
     watcher.start();
     await waitFor(
       () => watcher.isLive(),
@@ -271,6 +277,10 @@ async function reconnectProbe() {
     await stopCoordinator(coordinator);
   }
   process.stdout.write(`${JSON.stringify(result)}\n`, () => process.exit(0));
+}
+
+if (mode !== 'reconnect') {
+  watcher = createWatcher();
 }
 
 if (mode === 'pool') {

--- a/framework/core/tests/watcher-runtime-boundary.test.js
+++ b/framework/core/tests/watcher-runtime-boundary.test.js
@@ -25,6 +25,10 @@ const watcherBenchDriver = path.join(
   'dispatch_bench_watcher.mjs',
 );
 const watcherProbeSource = fs.readFileSync(probe, 'utf8');
+const reconnectProbeSource = watcherProbeSource.slice(
+  watcherProbeSource.indexOf('async function reconnectProbe()'),
+  watcherProbeSource.indexOf("if (mode !== 'reconnect')"),
+);
 const nativeTest = {
   skip: fs.existsSync(bindingPath)
     ? false
@@ -95,7 +99,7 @@ test('watcher dispatch bench follows and proves the load peer carrier', () => {
   assert.match(driver, /coordinator\.kill\(\)/);
 });
 
-test('watcher reconnect fixture owns process trees and bounds Windows transitions', () => {
+test('watcher reconnect fixture sequences readiness, owns process trees, and bounds Windows transitions', () => {
   assert.match(
     watcherProbeSource,
     /watcherConnect: process\.platform === 'win32' \? 30_000 : 8_000/,
@@ -109,6 +113,25 @@ test('watcher reconnect fixture owns process trees and bounds Windows transition
     /\['\/pid', String\(child\.pid\), '\/T', '\/F'\]/,
   );
   assert.match(watcherProbeSource, /process\.kill\(-child\.pid, 'SIGTERM'\)/);
+  const coordinatorReady = reconnectProbeSource.indexOf(
+    "'initial-coordinator-startup'",
+  );
+  const watcherConstruction = reconnectProbeSource.indexOf(
+    'watcher = createWatcher();',
+  );
+  const watcherStart = reconnectProbeSource.indexOf('watcher.start();');
+  assert.ok(
+    coordinatorReady >= 0,
+    'the initial readiness boundary is explicit',
+  );
+  assert.ok(
+    coordinatorReady < watcherConstruction,
+    'the reconnect watcher is constructed only after coordinator readiness',
+  );
+  assert.ok(
+    watcherConstruction < watcherStart,
+    'the reconnect watcher is constructed before its worker starts',
+  );
 });
 
 test(


### PR DESCRIPTION
## Summary

Remove the Windows watcher reconnect probe's startup race by constructing and
starting the watcher only after the coordinator reports readiness. Production
watcher API, ABI, callback ownership, and reconnect semantics are unchanged.

This preserves the failed protected evidence from landing `9814b24cdd`; the
Windows advisory failure is workflow run `32537365677`, job `96940796533`.

## Related issue

Supplemental repair Assignment
`2026-08-21-kungfu-windows-watcher-reconnect-reliability` under
`2026-08-18-kungfu-mainline-quality-convergence`.

## Changes

- wait for coordinator readiness before constructing the reconnect watcher
- keep watcher construction and start order explicit in the probe
- add structural coverage that fails if construction moves before readiness
- retain bounded deadlines, process-tree cleanup, and fail-closed diagnostics

## Verification

- focused watcher runtime boundary suite: 9 passed, 0 failed
- `CI=true ./shifu check:source`: passed
- normal pre-commit staged gate: passed
- exact-head work admission: `sha256:e16998693c97dc497b56dab8904a49e0903ad00230a1b024ce07e1145f8e239c`
- initial PR source acceptance and immutable report projection at `cb5d01d1ea6b7294ffa840bef9641673a490c40d`: passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This repair changes only qualification harness startup sequencing and structural regression coverage; production watcher contracts and behavior are unchanged."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable: harness-only repair)
