### PR TITLE
fix(core): make watcher reconnect probes race-safe

### DIFF
--- a/framework/core/src/libkungfu/src/runtime/io/io.cpp
+++ b/framework/core/src/libkungfu/src/runtime/io/io.cpp
@@ -19,6 +19,10 @@ using namespace kungfu::runtime::journal;
 using namespace kungfu::runtime::nanomsg;
 
 namespace kungfu::runtime {
+namespace {
+constexpr int USABILITY_PROBE_ATTEMPTS = 5;
+}
+
 class ipc_url_factory : public url_factory {
 public:
   virtual ~ipc_url_factory() {}
@@ -250,10 +254,19 @@ io_device_peer::io_device_peer(data::location_ptr home, bool low_latency)
 bool io_device_peer::is_usable() {
   nanomsg_publisher_peer publisher(*this, false);
   nanomsg_observer_peer observer(*this, false);
-  publisher.setup();
-  observer.setup();
-  std::this_thread::sleep_for(std::chrono::milliseconds(TEST_USABLE_TIMEOUT));
-  return publisher.is_usable() and observer.is_usable();
+  if (not publisher.setup() or not observer.setup()) {
+    return false;
+  }
+  // Keep the same sockets across this bounded handshake. Recreating the SUB
+  // socket after every missed pong repeats the NNG slow-joiner window on
+  // Windows and can prevent a healthy coordinator from ever becoming usable.
+  for (int attempt = 0; attempt < USABILITY_PROBE_ATTEMPTS; ++attempt) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(TEST_USABLE_TIMEOUT));
+    if (publisher.is_usable() and observer.is_usable()) {
+      return true;
+    }
+  }
+  return false;
 }
 
 bool io_device_peer::setup() {

--- a/framework/core/tests/fixtures/watcher-runtime-probe.js
+++ b/framework/core/tests/fixtures/watcher-runtime-probe.js
@@ -142,15 +142,23 @@ function waitForExitWithin(child, timeoutMs) {
     return Promise.resolve(true);
   }
   return new Promise((resolve) => {
+    let settled = false;
     const onExit = () => {
+      if (settled) return;
+      settled = true;
       clearTimeout(timer);
       resolve(true);
     };
     const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
       child.off('exit', onExit);
       resolve(false);
     }, timeoutMs);
     child.once('exit', onExit);
+    // Close the check/listener race: the process can exit after the caller's
+    // fast-path check but before this listener is installed.
+    if (child.exitCode !== null || child.signalCode !== null) onExit();
   });
 }
 

--- a/framework/core/tests/fixtures/watcher-runtime-probe.js
+++ b/framework/core/tests/fixtures/watcher-runtime-probe.js
@@ -12,12 +12,16 @@ const coreDir = path.resolve(__dirname, '..', '..');
 const binding = require(path.join(coreDir, 'dist', 'kungfu', 'kungfu_node.node'));
 const temporaryRoot = process.platform === 'win32' ? os.tmpdir() : '/tmp';
 const home = fs.mkdtempSync(path.join(temporaryRoot, 'kfwr.'));
-const watcher = new binding.Watcher(
-  path.join(home, 'runtime'),
-  `runtime_${mode}`,
-  true,
-  2,
-);
+let watcher = null;
+
+function createWatcher() {
+  return new binding.Watcher(
+    path.join(home, 'runtime'),
+    `runtime_${mode}`,
+    true,
+    2,
+  );
+}
 const reconnectDeadlines = Object.freeze({
   coordinatorStartup: process.platform === 'win32' ? 30_000 : 15_000,
   watcherConnect: process.platform === 'win32' ? 30_000 : 8_000,
@@ -27,6 +31,7 @@ const reconnectDeadlines = Object.freeze({
 });
 
 function printableStats() {
+  if (watcher === null) return null;
   return Object.fromEntries(
     Object.entries(watcher.runtimeStats()).map(([key, value]) => [
       key,
@@ -221,6 +226,7 @@ async function reconnectProbe() {
         `coordinator exited during startup: ${JSON.stringify(reconnectContext(coordinator, 'initial-coordinator-startup'))}`,
       );
     }
+    watcher = createWatcher();
     watcher.start();
     await waitFor(
       () => watcher.isLive(),
@@ -271,6 +277,10 @@ async function reconnectProbe() {
     await stopCoordinator(coordinator);
   }
   process.stdout.write(`${JSON.stringify(result)}\n`, () => process.exit(0));
+}
+
+if (mode !== 'reconnect') {
+  watcher = createWatcher();
 }
 
 if (mode === 'pool') {

--- a/framework/core/tests/watcher-runtime-boundary.test.js
+++ b/framework/core/tests/watcher-runtime-boundary.test.js
@@ -24,6 +24,15 @@ const watcherBenchDriver = path.join(
   'bench',
   'dispatch_bench_watcher.mjs',
 );
+const ioSource = path.join(
+  coreDir,
+  'src',
+  'libkungfu',
+  'src',
+  'runtime',
+  'io',
+  'io.cpp',
+);
 const watcherProbeSource = fs.readFileSync(probe, 'utf8');
 const reconnectProbeSource = watcherProbeSource.slice(
   watcherProbeSource.indexOf('async function reconnectProbe()'),
@@ -131,6 +140,42 @@ test('watcher reconnect fixture sequences readiness, owns process trees, and bou
   assert.ok(
     watcherConstruction < watcherStart,
     'the reconnect watcher is constructed before its worker starts',
+  );
+  const exitWaitSource = watcherProbeSource.slice(
+    watcherProbeSource.indexOf('function waitForExitWithin('),
+    watcherProbeSource.indexOf('async function stopCoordinator('),
+  );
+  const exitListener = exitWaitSource.indexOf("child.once('exit', onExit);");
+  const postListenerStateCheck = exitWaitSource.indexOf(
+    'if (child.exitCode !== null || child.signalCode !== null) onExit();',
+  );
+  assert.ok(exitListener >= 0, 'coordinator exit is observed by a listener');
+  assert.ok(
+    exitListener < postListenerStateCheck,
+    'coordinator exit state is rechecked after listener installation',
+  );
+  assert.match(exitWaitSource, /let settled = false;/);
+});
+
+test('peer usability keeps one bounded handshake across slow-joiner retries', () => {
+  const source = fs.readFileSync(ioSource, 'utf8');
+  const peerUsabilitySource = source.slice(
+    source.indexOf('bool io_device_peer::is_usable()'),
+    source.indexOf('bool io_device_peer::setup()'),
+  );
+  assert.match(source, /constexpr int USABILITY_PROBE_ATTEMPTS = 5;/);
+  assert.match(
+    peerUsabilitySource,
+    /if \(not publisher\.setup\(\) or not observer\.setup\(\)\)/,
+  );
+  assert.match(
+    peerUsabilitySource,
+    /for \(int attempt = 0; attempt < USABILITY_PROBE_ATTEMPTS; \+\+attempt\)/,
+  );
+  assert.equal(
+    peerUsabilitySource.match(/nanomsg_observer_peer observer/g)?.length,
+    1,
+    'the SUB socket must not be recreated inside the retry loop',
   );
 });
 

--- a/framework/core/tests/watcher-runtime-boundary.test.js
+++ b/framework/core/tests/watcher-runtime-boundary.test.js
@@ -25,6 +25,10 @@ const watcherBenchDriver = path.join(
   'dispatch_bench_watcher.mjs',
 );
 const watcherProbeSource = fs.readFileSync(probe, 'utf8');
+const reconnectProbeSource = watcherProbeSource.slice(
+  watcherProbeSource.indexOf('async function reconnectProbe()'),
+  watcherProbeSource.indexOf("if (mode !== 'reconnect')"),
+);
 const nativeTest = {
   skip: fs.existsSync(bindingPath)
     ? false
@@ -95,7 +99,7 @@ test('watcher dispatch bench follows and proves the load peer carrier', () => {
   assert.match(driver, /coordinator\.kill\(\)/);
 });
 
-test('watcher reconnect fixture owns process trees and bounds Windows transitions', () => {
+test('watcher reconnect fixture sequences readiness, owns process trees, and bounds Windows transitions', () => {
   assert.match(
     watcherProbeSource,
     /watcherConnect: process\.platform === 'win32' \? 30_000 : 8_000/,
@@ -109,6 +113,25 @@ test('watcher reconnect fixture owns process trees and bounds Windows transition
     /\['\/pid', String\(child\.pid\), '\/T', '\/F'\]/,
   );
   assert.match(watcherProbeSource, /process\.kill\(-child\.pid, 'SIGTERM'\)/);
+  const coordinatorReady = reconnectProbeSource.indexOf(
+    "'initial-coordinator-startup'",
+  );
+  const watcherConstruction = reconnectProbeSource.indexOf(
+    'watcher = createWatcher();',
+  );
+  const watcherStart = reconnectProbeSource.indexOf('watcher.start();');
+  assert.ok(
+    coordinatorReady >= 0,
+    'the initial readiness boundary is explicit',
+  );
+  assert.ok(
+    coordinatorReady < watcherConstruction,
+    'the reconnect watcher is constructed only after coordinator readiness',
+  );
+  assert.ok(
+    watcherConstruction < watcherStart,
+    'the reconnect watcher is constructed before its worker starts',
+  );
 });
 
 test(


### PR DESCRIPTION
## Summary

Repair both exact post-merge watcher failures retained from protected landing `c019142e10150ff472a509d319e24d17860be4b0`:

- keep one publisher/subscriber pair alive across a bounded usability handshake so Windows does not repeatedly re-enter the NNG slow-joiner window
- close the coordinator exit check/listener race so Linux cannot miss a SIGKILL exit between the fast-path check and listener installation
- add structural regression coverage for both boundaries

The failed protected evidence remains workflow `32544080451`: Linux job `96959479851` and Windows job `96959479845`.

## Related Assignment

Supplemental repair Assignment `2026-08-21-kungfu-windows-watcher-reconnect-reliability` under parent `2026-08-18-kungfu-mainline-quality-convergence`.

## Verification

- rebuilt native Core from this checkout: passed
- watcher runtime boundary suite against rebuilt binding: 10 passed, 0 failed (repeated twice)
- `CI=true ./shifu check:source`: passed
- normal DCO pre-commit staged gate: passed
- exact-head work admission: `sha256:bd9f11e9bbe6abd51e4113f5783fe652b3337120e71c4ec16fe7f35816b2fae8`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded bug fix hardens existing watcher readiness and test-process exit behavior without changing public APIs, ABI, ownership, or architectural authority."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Regression coverage added for both failed platform boundaries