### PR TITLE
fix(agent-session): stabilize ambient process locale

### DIFF
--- a/framework/core/src/python/kungfu/agent/session_surface.py
+++ b/framework/core/src/python/kungfu/agent/session_surface.py
@@ -479,6 +479,7 @@ def _process_identity_row(pid: int) -> tuple[int, str, str] | None:
         text=True,
         check=False,
         timeout=1,
+        env={**os.environ, "LC_ALL": "C", "LANG": "C"},
     )
     if completed.returncode != 0:
         return None

--- a/framework/core/tests/python/test_agent_console_ambient_adoption.py
+++ b/framework/core/tests/python/test_agent_console_ambient_adoption.py
@@ -25,6 +25,27 @@ def process_identity():
     }
 
 
+def test_process_identity_row_uses_stable_locale(monkeypatch):
+    calls = []
+
+    def run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return SimpleNamespace(
+            returncode=0,
+            stdout=("40 Thu Aug 13 10:59:00 2026 /Users/example/.local/bin/codex\n"),
+        )
+
+    monkeypatch.setattr(session_surface.subprocess, "run", run)
+
+    assert session_surface._process_identity_row(50) == (
+        40,
+        "Thu Aug 13 10:59:00 2026",
+        "/Users/example/.local/bin/codex",
+    )
+    assert calls[0][1]["env"]["LC_ALL"] == "C"
+    assert calls[0][1]["env"]["LANG"] == "C"
+
+
 def console_envelope():
     body = {
         "schema": "kungfu.agent-console-envelope/v1",


### PR DESCRIPTION
## Summary

Stabilize ambient Codex Console process identity discovery across localized macOS environments.

## Related issue

None.

## Changes

- Force C locale for the exact ps process-identity probe.
- Add a regression test for locale-independent process row parsing.

## Verification

- ./shifu test:agent-console-contract — 134 passed, 3 skipped.
- ./shifu check:source — passed after cache warm-up.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This localized process-probe fix preserves the existing Console identity contract and does not alter an architecture decision."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation is not required because the public behavior and contract are unchanged