### PR TITLE
fix(core): persist watcher readiness probes

### DIFF
--- a/framework/core/src/libkungfu/include/kungfu/runtime/io.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/io.h
@@ -7,6 +7,8 @@
 #ifndef KUNGFU_IO_H
 #define KUNGFU_IO_H
 
+#include <mutex>
+
 #include <kungfu/runtime/common.h>
 
 #include <kungfu/runtime/nanomsg/socket.h>
@@ -132,6 +134,11 @@ public:
   bool is_usable() override;
 
   bool setup() override;
+
+private:
+  std::mutex usability_probe_mutex_;
+  publisher_ptr usability_probe_publisher_;
+  observer_ptr usability_probe_observer_;
 };
 
 DECLARE_PTR(io_device_peer)

--- a/framework/core/src/libkungfu/src/runtime/io/io.cpp
+++ b/framework/core/src/libkungfu/src/runtime/io/io.cpp
@@ -19,6 +19,10 @@ using namespace kungfu::runtime::journal;
 using namespace kungfu::runtime::nanomsg;
 
 namespace kungfu::runtime {
+namespace {
+constexpr int USABILITY_PROBE_ATTEMPTS = 5;
+}
+
 class ipc_url_factory : public url_factory {
 public:
   virtual ~ipc_url_factory() {}
@@ -250,10 +254,19 @@ io_device_peer::io_device_peer(data::location_ptr home, bool low_latency)
 bool io_device_peer::is_usable() {
   nanomsg_publisher_peer publisher(*this, false);
   nanomsg_observer_peer observer(*this, false);
-  publisher.setup();
-  observer.setup();
-  std::this_thread::sleep_for(std::chrono::milliseconds(TEST_USABLE_TIMEOUT));
-  return publisher.is_usable() and observer.is_usable();
+  if (not publisher.setup() or not observer.setup()) {
+    return false;
+  }
+  // Keep the same sockets across this bounded handshake. Recreating the SUB
+  // socket after every missed pong repeats the NNG slow-joiner window on
+  // Windows and can prevent a healthy coordinator from ever becoming usable.
+  for (int attempt = 0; attempt < USABILITY_PROBE_ATTEMPTS; ++attempt) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(TEST_USABLE_TIMEOUT));
+    if (publisher.is_usable() and observer.is_usable()) {
+      return true;
+    }
+  }
+  return false;
 }
 
 bool io_device_peer::setup() {

--- a/framework/core/src/libkungfu/src/runtime/io/io.cpp
+++ b/framework/core/src/libkungfu/src/runtime/io/io.cpp
@@ -252,17 +252,25 @@ io_device_peer::io_device_peer(data::location_ptr home, bool low_latency)
     : io_device(std::move(home), low_latency, io_mapping_policy::peer()) {}
 
 bool io_device_peer::is_usable() {
-  nanomsg_publisher_peer publisher(*this, false);
-  nanomsg_observer_peer observer(*this, false);
-  if (not publisher.setup() or not observer.setup()) {
-    return false;
+  std::lock_guard<std::mutex> guard(usability_probe_mutex_);
+  if (not usability_probe_publisher_ or not usability_probe_observer_) {
+    auto observer = std::make_shared<nanomsg_observer_peer>(*this, false);
+    auto publisher = std::make_shared<nanomsg_publisher_peer>(*this, false);
+    if (not observer->setup() or not publisher->setup()) {
+      return false;
+    }
+    usability_probe_observer_ = std::move(observer);
+    usability_probe_publisher_ = std::move(publisher);
   }
-  // Keep the same sockets across this bounded handshake. Recreating the SUB
-  // socket after every missed pong repeats the NNG slow-joiner window on
-  // Windows and can prevent a healthy coordinator from ever becoming usable.
+  // Keep the same sockets across bounded calls. A single call must stay short
+  // because Watcher construction performs this check on the Node thread, while
+  // retaining the pair lets the dedicated worker survive Windows' NNG
+  // slow-joiner window instead of restarting it after every missed pong.
   for (int attempt = 0; attempt < USABILITY_PROBE_ATTEMPTS; ++attempt) {
     std::this_thread::sleep_for(std::chrono::milliseconds(TEST_USABLE_TIMEOUT));
-    if (publisher.is_usable() and observer.is_usable()) {
+    if (usability_probe_publisher_->is_usable() and usability_probe_observer_->is_usable()) {
+      usability_probe_observer_.reset();
+      usability_probe_publisher_.reset();
       return true;
     }
   }
@@ -270,6 +278,11 @@ bool io_device_peer::is_usable() {
 }
 
 bool io_device_peer::setup() {
+  {
+    std::lock_guard<std::mutex> guard(usability_probe_mutex_);
+    usability_probe_observer_.reset();
+    usability_probe_publisher_.reset();
+  }
   publisher_ = std::make_shared<nanomsg_publisher_peer>(*this, is_low_latency());
   observer_ = std::make_shared<nanomsg_observer_peer>(*this, is_low_latency());
   auto is_live_mode = get_home()->mode == mode::LIVE;

--- a/framework/core/tests/fixtures/watcher-runtime-probe.js
+++ b/framework/core/tests/fixtures/watcher-runtime-probe.js
@@ -162,6 +162,34 @@ function waitForExitWithin(child, timeoutMs) {
   });
 }
 
+function signalPosixProcessTree(child, signal) {
+  let groupError = null;
+  try {
+    process.kill(-child.pid, signal);
+  } catch (error) {
+    if (error.code !== 'ESRCH') groupError = error;
+  }
+
+  let childSignalled = false;
+  if (child.exitCode === null && child.signalCode === null) {
+    try {
+      childSignalled = child.kill(signal);
+    } catch (error) {
+      if (error.code !== 'ESRCH' && groupError === null) groupError = error;
+    }
+  }
+  if (
+    groupError !== null &&
+    !childSignalled &&
+    child.exitCode === null &&
+    child.signalCode === null
+  ) {
+    throw new Error(
+      `failed to signal coordinator process tree with ${signal}: ${groupError.message}`,
+    );
+  }
+}
+
 async function stopCoordinator(child) {
   if (child.exitCode !== null || child.signalCode !== null) return;
   if (process.platform === 'win32') {
@@ -179,13 +207,13 @@ async function stopCoordinator(child) {
       );
     }
   } else {
-    process.kill(-child.pid, 'SIGTERM');
+    signalPosixProcessTree(child, 'SIGTERM');
   }
   if (await waitForExitWithin(child, 3_000)) return;
   if (process.platform === 'win32') {
     child.kill();
   } else {
-    process.kill(-child.pid, 'SIGKILL');
+    signalPosixProcessTree(child, 'SIGKILL');
   }
   if (!(await waitForExitWithin(child, 3_000))) {
     throw new Error('coordinator did not exit after SIGKILL');

--- a/framework/core/tests/fixtures/watcher-runtime-probe.js
+++ b/framework/core/tests/fixtures/watcher-runtime-probe.js
@@ -142,15 +142,23 @@ function waitForExitWithin(child, timeoutMs) {
     return Promise.resolve(true);
   }
   return new Promise((resolve) => {
+    let settled = false;
     const onExit = () => {
+      if (settled) return;
+      settled = true;
       clearTimeout(timer);
       resolve(true);
     };
     const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
       child.off('exit', onExit);
       resolve(false);
     }, timeoutMs);
     child.once('exit', onExit);
+    // Close the check/listener race: the process can exit after the caller's
+    // fast-path check but before this listener is installed.
+    if (child.exitCode !== null || child.signalCode !== null) onExit();
   });
 }
 

--- a/framework/core/tests/fixtures/watcher-runtime-probe.js
+++ b/framework/core/tests/fixtures/watcher-runtime-probe.js
@@ -12,12 +12,16 @@ const coreDir = path.resolve(__dirname, '..', '..');
 const binding = require(path.join(coreDir, 'dist', 'kungfu', 'kungfu_node.node'));
 const temporaryRoot = process.platform === 'win32' ? os.tmpdir() : '/tmp';
 const home = fs.mkdtempSync(path.join(temporaryRoot, 'kfwr.'));
-const watcher = new binding.Watcher(
-  path.join(home, 'runtime'),
-  `runtime_${mode}`,
-  true,
-  2,
-);
+let watcher = null;
+
+function createWatcher() {
+  return new binding.Watcher(
+    path.join(home, 'runtime'),
+    `runtime_${mode}`,
+    true,
+    2,
+  );
+}
 const reconnectDeadlines = Object.freeze({
   coordinatorStartup: process.platform === 'win32' ? 30_000 : 15_000,
   watcherConnect: process.platform === 'win32' ? 30_000 : 8_000,
@@ -27,6 +31,7 @@ const reconnectDeadlines = Object.freeze({
 });
 
 function printableStats() {
+  if (watcher === null) return null;
   return Object.fromEntries(
     Object.entries(watcher.runtimeStats()).map(([key, value]) => [
       key,
@@ -221,6 +226,7 @@ async function reconnectProbe() {
         `coordinator exited during startup: ${JSON.stringify(reconnectContext(coordinator, 'initial-coordinator-startup'))}`,
       );
     }
+    watcher = createWatcher();
     watcher.start();
     await waitFor(
       () => watcher.isLive(),
@@ -271,6 +277,10 @@ async function reconnectProbe() {
     await stopCoordinator(coordinator);
   }
   process.stdout.write(`${JSON.stringify(result)}\n`, () => process.exit(0));
+}
+
+if (mode !== 'reconnect') {
+  watcher = createWatcher();
 }
 
 if (mode === 'pool') {

--- a/framework/core/tests/watcher-runtime-boundary.test.js
+++ b/framework/core/tests/watcher-runtime-boundary.test.js
@@ -24,6 +24,15 @@ const watcherBenchDriver = path.join(
   'bench',
   'dispatch_bench_watcher.mjs',
 );
+const ioSource = path.join(
+  coreDir,
+  'src',
+  'libkungfu',
+  'src',
+  'runtime',
+  'io',
+  'io.cpp',
+);
 const watcherProbeSource = fs.readFileSync(probe, 'utf8');
 const reconnectProbeSource = watcherProbeSource.slice(
   watcherProbeSource.indexOf('async function reconnectProbe()'),
@@ -131,6 +140,42 @@ test('watcher reconnect fixture sequences readiness, owns process trees, and bou
   assert.ok(
     watcherConstruction < watcherStart,
     'the reconnect watcher is constructed before its worker starts',
+  );
+  const exitWaitSource = watcherProbeSource.slice(
+    watcherProbeSource.indexOf('function waitForExitWithin('),
+    watcherProbeSource.indexOf('async function stopCoordinator('),
+  );
+  const exitListener = exitWaitSource.indexOf("child.once('exit', onExit);");
+  const postListenerStateCheck = exitWaitSource.indexOf(
+    'if (child.exitCode !== null || child.signalCode !== null) onExit();',
+  );
+  assert.ok(exitListener >= 0, 'coordinator exit is observed by a listener');
+  assert.ok(
+    exitListener < postListenerStateCheck,
+    'coordinator exit state is rechecked after listener installation',
+  );
+  assert.match(exitWaitSource, /let settled = false;/);
+});
+
+test('peer usability keeps one bounded handshake across slow-joiner retries', () => {
+  const source = fs.readFileSync(ioSource, 'utf8');
+  const peerUsabilitySource = source.slice(
+    source.indexOf('bool io_device_peer::is_usable()'),
+    source.indexOf('bool io_device_peer::setup()'),
+  );
+  assert.match(source, /constexpr int USABILITY_PROBE_ATTEMPTS = 5;/);
+  assert.match(
+    peerUsabilitySource,
+    /if \(not publisher\.setup\(\) or not observer\.setup\(\)\)/,
+  );
+  assert.match(
+    peerUsabilitySource,
+    /for \(int attempt = 0; attempt < USABILITY_PROBE_ATTEMPTS; \+\+attempt\)/,
+  );
+  assert.equal(
+    peerUsabilitySource.match(/nanomsg_observer_peer observer/g)?.length,
+    1,
+    'the SUB socket must not be recreated inside the retry loop',
   );
 });
 

--- a/framework/core/tests/watcher-runtime-boundary.test.js
+++ b/framework/core/tests/watcher-runtime-boundary.test.js
@@ -33,6 +33,15 @@ const ioSource = path.join(
   'io',
   'io.cpp',
 );
+const ioHeader = path.join(
+  coreDir,
+  'src',
+  'libkungfu',
+  'include',
+  'kungfu',
+  'runtime',
+  'io.h',
+);
 const watcherProbeSource = fs.readFileSync(probe, 'utf8');
 const reconnectProbeSource = watcherProbeSource.slice(
   watcherProbeSource.indexOf('async function reconnectProbe()'),
@@ -121,7 +130,20 @@ test('watcher reconnect fixture sequences readiness, owns process trees, and bou
     watcherProbeSource,
     /\['\/pid', String\(child\.pid\), '\/T', '\/F'\]/,
   );
-  assert.match(watcherProbeSource, /process\.kill\(-child\.pid, 'SIGTERM'\)/);
+  assert.match(
+    watcherProbeSource,
+    /signalPosixProcessTree\(child, 'SIGTERM'\)/,
+  );
+  assert.match(
+    watcherProbeSource,
+    /signalPosixProcessTree\(child, 'SIGKILL'\)/,
+  );
+  const posixSignalSource = watcherProbeSource.slice(
+    watcherProbeSource.indexOf('function signalPosixProcessTree('),
+    watcherProbeSource.indexOf('async function stopCoordinator('),
+  );
+  assert.match(posixSignalSource, /process\.kill\(-child\.pid, signal\)/);
+  assert.match(posixSignalSource, /child\.kill\(signal\)/);
   const coordinatorReady = reconnectProbeSource.indexOf(
     "'initial-coordinator-startup'",
   );
@@ -157,8 +179,9 @@ test('watcher reconnect fixture sequences readiness, owns process trees, and bou
   assert.match(exitWaitSource, /let settled = false;/);
 });
 
-test('peer usability keeps one bounded handshake across slow-joiner retries', () => {
+test('peer usability persists one bounded handshake across slow-joiner retries', () => {
   const source = fs.readFileSync(ioSource, 'utf8');
+  const header = fs.readFileSync(ioHeader, 'utf8');
   const peerUsabilitySource = source.slice(
     source.indexOf('bool io_device_peer::is_usable()'),
     source.indexOf('bool io_device_peer::setup()'),
@@ -166,17 +189,32 @@ test('peer usability keeps one bounded handshake across slow-joiner retries', ()
   assert.match(source, /constexpr int USABILITY_PROBE_ATTEMPTS = 5;/);
   assert.match(
     peerUsabilitySource,
-    /if \(not publisher\.setup\(\) or not observer\.setup\(\)\)/,
+    /std::lock_guard<std::mutex> guard\(usability_probe_mutex_\)/,
+  );
+  assert.match(
+    peerUsabilitySource,
+    /if \(not usability_probe_publisher_ or not usability_probe_observer_\)/,
+  );
+  assert.match(
+    peerUsabilitySource,
+    /if \(not observer->setup\(\) or not publisher->setup\(\)\)/,
   );
   assert.match(
     peerUsabilitySource,
     /for \(int attempt = 0; attempt < USABILITY_PROBE_ATTEMPTS; \+\+attempt\)/,
   );
   assert.equal(
-    peerUsabilitySource.match(/nanomsg_observer_peer observer/g)?.length,
+    peerUsabilitySource.match(/make_shared<nanomsg_observer_peer>/g)?.length,
     1,
     'the SUB socket must not be recreated inside the retry loop',
   );
+  assert.match(
+    peerUsabilitySource,
+    /usability_probe_publisher_->is_usable\(\) and usability_probe_observer_->is_usable\(\)/,
+  );
+  assert.match(header, /std::mutex usability_probe_mutex_;/);
+  assert.match(header, /publisher_ptr usability_probe_publisher_;/);
+  assert.match(header, /observer_ptr usability_probe_observer_;/);
 });
 
 test(

--- a/framework/core/tests/watcher-runtime-boundary.test.js
+++ b/framework/core/tests/watcher-runtime-boundary.test.js
@@ -25,6 +25,10 @@ const watcherBenchDriver = path.join(
   'dispatch_bench_watcher.mjs',
 );
 const watcherProbeSource = fs.readFileSync(probe, 'utf8');
+const reconnectProbeSource = watcherProbeSource.slice(
+  watcherProbeSource.indexOf('async function reconnectProbe()'),
+  watcherProbeSource.indexOf("if (mode !== 'reconnect')"),
+);
 const nativeTest = {
   skip: fs.existsSync(bindingPath)
     ? false
@@ -95,7 +99,7 @@ test('watcher dispatch bench follows and proves the load peer carrier', () => {
   assert.match(driver, /coordinator\.kill\(\)/);
 });
 
-test('watcher reconnect fixture owns process trees and bounds Windows transitions', () => {
+test('watcher reconnect fixture sequences readiness, owns process trees, and bounds Windows transitions', () => {
   assert.match(
     watcherProbeSource,
     /watcherConnect: process\.platform === 'win32' \? 30_000 : 8_000/,
@@ -109,6 +113,25 @@ test('watcher reconnect fixture owns process trees and bounds Windows transition
     /\['\/pid', String\(child\.pid\), '\/T', '\/F'\]/,
   );
   assert.match(watcherProbeSource, /process\.kill\(-child\.pid, 'SIGTERM'\)/);
+  const coordinatorReady = reconnectProbeSource.indexOf(
+    "'initial-coordinator-startup'",
+  );
+  const watcherConstruction = reconnectProbeSource.indexOf(
+    'watcher = createWatcher();',
+  );
+  const watcherStart = reconnectProbeSource.indexOf('watcher.start();');
+  assert.ok(
+    coordinatorReady >= 0,
+    'the initial readiness boundary is explicit',
+  );
+  assert.ok(
+    coordinatorReady < watcherConstruction,
+    'the reconnect watcher is constructed only after coordinator readiness',
+  );
+  assert.ok(
+    watcherConstruction < watcherStart,
+    'the reconnect watcher is constructed before its worker starts',
+  );
 });
 
 test(


### PR DESCRIPTION
## Summary

Repair the two residual platform failures observed after protected landing `ce77c38825163576d13bdbafa0000915ec26cc14`:

- retain one bounded NNG publisher/subscriber probe pair across worker calls so Windows does not re-enter the slow-joiner window on every readiness attempt
- serialize access to that persistent probe state and reset it before the real watcher setup
- signal both the POSIX process group and child leader during coordinator shutdown so Linux does not leave the killed coordinator alive
- extend structural regression coverage for the persistent probe lifecycle and shutdown boundary

The protected CI failures being repaired are workflow `32550613715`, Linux job `96976692267`, and Windows job `96976692271`. Darwin passed in that same workflow.

## Related Assignment

Supplemental repair Assignment `2026-08-21-kungfu-windows-watcher-reconnect-reliability` under parent `2026-08-18-kungfu-mainline-quality-convergence`.

## Verification

Local exact-source capture at `e25dca339c256aa7dbeff49462c339128327235c` (not CI output):

- rebuilt native Core from this checkout: passed
- watcher runtime boundary suite against the rebuilt binding: 10 passed, 0 failed (repeated twice)
- `CI=true ./shifu check:source`: passed
- normal DCO pre-commit staged gate: passed

Protected CI evidence for this PR will be supplied by GitHub required checks bound to the exact PR head; no local capture is represented as a CI artifact.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded bug fix hardens existing watcher readiness and coordinator shutdown behavior without changing public APIs, ABI, ownership, or architectural authority."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Regression coverage added for both failed platform boundaries