### PR TITLE
fix(upgrade): accept named release artifacts

### DIFF
--- a/.buildchain/kfd/kfd-1/contract-world.witness.json
+++ b/.buildchain/kfd/kfd-1/contract-world.witness.json
@@ -35,7 +35,7 @@
   "sourceVerificationRequired": false,
   "canonicalPolicy": {
     "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-    "sha256": "9f5d5c59b307daa5146d17d4a8ba79c87fc49b6be6faf3cc4d57b5ff2731b632"
+    "sha256": "da6bb08e01c9897ba04b2fd0923811e887644c3ea02f3a21e28ea74199b418a7"
   },
   "registry": {
     "path": "framework/contract/kungfu-contracts.registry.json",
@@ -101,9 +101,9 @@
     {
       "name": "kungfu-product-upgrade",
       "sourcePath": "framework/upgrade/kungfu-upgrade.contract.json",
-      "sourceSha256": "fc47eb7b4c40efddcae878ba94d35f5396ebc173333587c82e145d7591d0e70f",
+      "sourceSha256": "efd9c36e2e0a0fa79c8b7b0e8264e2570400c61ee99c075bf9d0d77e556c06c8",
       "artifactPath": "config/kungfu-upgrade.contract.json",
-      "expectedSha256": "fc47eb7b4c40efddcae878ba94d35f5396ebc173333587c82e145d7591d0e70f",
+      "expectedSha256": "efd9c36e2e0a0fa79c8b7b0e8264e2570400c61ee99c075bf9d0d77e556c06c8",
       "byteForByte": true
     },
     {

--- a/.buildchain/kfd/kfd-1/release-gate.json
+++ b/.buildchain/kfd/kfd-1/release-gate.json
@@ -106,13 +106,13 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "2976b96dba739f9e17beaf037f7a5202e7631cc92a749a4bf1fc720ac57dea84",
+      "preBuildWitnessSha256": "6b2e1a93eaef4acd321dbed4120ce89245c55fb25be5e275bfd5345e8695d6b3",
       "sourceHashes": {
-        "sha256": "4f846835b83b0d82c9f103029dfc374406122ecd651b73a142dbc5769559bfa0",
+        "sha256": "f1bc18d96fc7d8a7209db18fbd64dbd56b6ac58984315d0d19e23cdeffce5f5b",
         "surfaceCount": 23
       },
       "artifactHashes": {
-        "sha256": "74122ef17a5ebe82c361a951a4cc8b1880f546f7c72697f7f614a1b35ab05a74",
+        "sha256": "021baf390231200eede3aa6e1af41ce2bf1f1b691ee4e14105c4fd7d6baef831",
         "surfaceCount": 23
       },
       "witness": {
@@ -152,7 +152,7 @@
         "sourceVerificationRequired": true,
         "canonicalPolicy": {
           "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-          "sha256": "9f5d5c59b307daa5146d17d4a8ba79c87fc49b6be6faf3cc4d57b5ff2731b632"
+          "sha256": "da6bb08e01c9897ba04b2fd0923811e887644c3ea02f3a21e28ea74199b418a7"
         },
         "registry": {
           "path": "framework/contract/kungfu-contracts.registry.json",
@@ -218,9 +218,9 @@
           {
             "name": "kungfu-product-upgrade",
             "sourcePath": "framework/upgrade/kungfu-upgrade.contract.json",
-            "sourceSha256": "fc47eb7b4c40efddcae878ba94d35f5396ebc173333587c82e145d7591d0e70f",
+            "sourceSha256": "efd9c36e2e0a0fa79c8b7b0e8264e2570400c61ee99c075bf9d0d77e556c06c8",
             "artifactPath": "config/kungfu-upgrade.contract.json",
-            "expectedSha256": "fc47eb7b4c40efddcae878ba94d35f5396ebc173333587c82e145d7591d0e70f",
+            "expectedSha256": "efd9c36e2e0a0fa79c8b7b0e8264e2570400c61ee99c075bf9d0d77e556c06c8",
             "byteForByte": true
           },
           {
@@ -497,8 +497,8 @@
           {
             "name": "kungfu-product-upgrade",
             "sourcePath": "framework/upgrade/kungfu-upgrade.contract.json",
-            "expectedSha256": "fc47eb7b4c40efddcae878ba94d35f5396ebc173333587c82e145d7591d0e70f",
-            "actualSha256": "fc47eb7b4c40efddcae878ba94d35f5396ebc173333587c82e145d7591d0e70f",
+            "expectedSha256": "efd9c36e2e0a0fa79c8b7b0e8264e2570400c61ee99c075bf9d0d77e556c06c8",
+            "actualSha256": "efd9c36e2e0a0fa79c8b7b0e8264e2570400c61ee99c075bf9d0d77e556c06c8",
             "status": "passed",
             "reason": ""
           },
@@ -708,10 +708,10 @@
           {
             "name": "kungfu-product-upgrade",
             "sourcePath": "framework/upgrade/kungfu-upgrade.contract.json",
-            "sourceSha256": "fc47eb7b4c40efddcae878ba94d35f5396ebc173333587c82e145d7591d0e70f",
+            "sourceSha256": "efd9c36e2e0a0fa79c8b7b0e8264e2570400c61ee99c075bf9d0d77e556c06c8",
             "artifactPath": "config/kungfu-upgrade.contract.json",
-            "expectedSha256": "fc47eb7b4c40efddcae878ba94d35f5396ebc173333587c82e145d7591d0e70f",
-            "actualSha256": "fc47eb7b4c40efddcae878ba94d35f5396ebc173333587c82e145d7591d0e70f",
+            "expectedSha256": "efd9c36e2e0a0fa79c8b7b0e8264e2570400c61ee99c075bf9d0d77e556c06c8",
+            "actualSha256": "efd9c36e2e0a0fa79c8b7b0e8264e2570400c61ee99c075bf9d0d77e556c06c8",
             "byteForByte": true,
             "status": "passed",
             "reason": ""

--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.3",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.3",
-    "sourceSha": "c8fd32f901b3af15532a11599c9b34af0b0f42bc"
+    "sourceSha": "c019142e10150ff472a509d319e24d17860be4b0"
   },
   "claims": [
     {

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "c8fd32f901b3af15532a11599c9b34af0b0f42bc",
+    "sourceSha": "c019142e10150ff472a509d319e24d17860be4b0",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:1da3f77d18ac159f14f16275fd77d1e094164324f73ddb67dfcc0bfe9d9a9554"
   },

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:6e7bedcd893feaadcf196e1b48f544b431c4bc207bd908d226ab2932cf57feb0"
+            "sha256": "sha256:3d15d7778bbbcf8011405c6c483e5aa46ba38e74d3fc785ac673ca3c6a6799ce"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/config/kungfu-agent-first-canonical-policy.json
+++ b/config/kungfu-agent-first-canonical-policy.json
@@ -362,13 +362,13 @@
       },
       "source": {
         "path": "framework/upgrade/kungfu-upgrade.contract.json",
-        "sha256": "sha256:fc47eb7b4c40efddcae878ba94d35f5396ebc173333587c82e145d7591d0e70f",
-        "renderedSha256": "sha256:fc47eb7b4c40efddcae878ba94d35f5396ebc173333587c82e145d7591d0e70f",
+        "sha256": "sha256:efd9c36e2e0a0fa79c8b7b0e8264e2570400c61ee99c075bf9d0d77e556c06c8",
+        "renderedSha256": "sha256:efd9c36e2e0a0fa79c8b7b0e8264e2570400c61ee99c075bf9d0d77e556c06c8",
         "byteForByte": true
       },
       "artifact": {
         "path": "config/kungfu-upgrade.contract.json",
-        "expectedSha256": "sha256:fc47eb7b4c40efddcae878ba94d35f5396ebc173333587c82e145d7591d0e70f"
+        "expectedSha256": "sha256:efd9c36e2e0a0fa79c8b7b0e8264e2570400c61ee99c075bf9d0d77e556c06c8"
       }
     },
     {

--- a/developer/sdk/kfd/kfd-1/contract-world.witness.json
+++ b/developer/sdk/kfd/kfd-1/contract-world.witness.json
@@ -35,7 +35,7 @@
   "sourceVerificationRequired": false,
   "canonicalPolicy": {
     "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-    "sha256": "9f5d5c59b307daa5146d17d4a8ba79c87fc49b6be6faf3cc4d57b5ff2731b632"
+    "sha256": "da6bb08e01c9897ba04b2fd0923811e887644c3ea02f3a21e28ea74199b418a7"
   },
   "registry": {
     "path": "framework/contract/kungfu-contracts.registry.json",
@@ -101,9 +101,9 @@
     {
       "name": "kungfu-product-upgrade",
       "sourcePath": "framework/upgrade/kungfu-upgrade.contract.json",
-      "sourceSha256": "fc47eb7b4c40efddcae878ba94d35f5396ebc173333587c82e145d7591d0e70f",
+      "sourceSha256": "efd9c36e2e0a0fa79c8b7b0e8264e2570400c61ee99c075bf9d0d77e556c06c8",
       "artifactPath": "config/kungfu-upgrade.contract.json",
-      "expectedSha256": "fc47eb7b4c40efddcae878ba94d35f5396ebc173333587c82e145d7591d0e70f",
+      "expectedSha256": "efd9c36e2e0a0fa79c8b7b0e8264e2570400c61ee99c075bf9d0d77e556c06c8",
       "byteForByte": true
     },
     {

--- a/developer/sdk/kfd/kfd-1/release-gate.json
+++ b/developer/sdk/kfd/kfd-1/release-gate.json
@@ -106,13 +106,13 @@
       "standard": "KFD-1",
       "standardKey": "kfd-1",
       "result": "passed",
-      "preBuildWitnessSha256": "2976b96dba739f9e17beaf037f7a5202e7631cc92a749a4bf1fc720ac57dea84",
+      "preBuildWitnessSha256": "6b2e1a93eaef4acd321dbed4120ce89245c55fb25be5e275bfd5345e8695d6b3",
       "sourceHashes": {
-        "sha256": "4f846835b83b0d82c9f103029dfc374406122ecd651b73a142dbc5769559bfa0",
+        "sha256": "f1bc18d96fc7d8a7209db18fbd64dbd56b6ac58984315d0d19e23cdeffce5f5b",
         "surfaceCount": 23
       },
       "artifactHashes": {
-        "sha256": "74122ef17a5ebe82c361a951a4cc8b1880f546f7c72697f7f614a1b35ab05a74",
+        "sha256": "021baf390231200eede3aa6e1af41ce2bf1f1b691ee4e14105c4fd7d6baef831",
         "surfaceCount": 23
       },
       "witness": {
@@ -152,7 +152,7 @@
         "sourceVerificationRequired": true,
         "canonicalPolicy": {
           "path": "framework/contract/kungfu-agent-first-canonical-policy.json",
-          "sha256": "9f5d5c59b307daa5146d17d4a8ba79c87fc49b6be6faf3cc4d57b5ff2731b632"
+          "sha256": "da6bb08e01c9897ba04b2fd0923811e887644c3ea02f3a21e28ea74199b418a7"
         },
         "registry": {
           "path": "framework/contract/kungfu-contracts.registry.json",
@@ -218,9 +218,9 @@
           {
             "name": "kungfu-product-upgrade",
             "sourcePath": "framework/upgrade/kungfu-upgrade.contract.json",
-            "sourceSha256": "fc47eb7b4c40efddcae878ba94d35f5396ebc173333587c82e145d7591d0e70f",
+            "sourceSha256": "efd9c36e2e0a0fa79c8b7b0e8264e2570400c61ee99c075bf9d0d77e556c06c8",
             "artifactPath": "config/kungfu-upgrade.contract.json",
-            "expectedSha256": "fc47eb7b4c40efddcae878ba94d35f5396ebc173333587c82e145d7591d0e70f",
+            "expectedSha256": "efd9c36e2e0a0fa79c8b7b0e8264e2570400c61ee99c075bf9d0d77e556c06c8",
             "byteForByte": true
           },
           {
@@ -497,8 +497,8 @@
           {
             "name": "kungfu-product-upgrade",
             "sourcePath": "framework/upgrade/kungfu-upgrade.contract.json",
-            "expectedSha256": "fc47eb7b4c40efddcae878ba94d35f5396ebc173333587c82e145d7591d0e70f",
-            "actualSha256": "fc47eb7b4c40efddcae878ba94d35f5396ebc173333587c82e145d7591d0e70f",
+            "expectedSha256": "efd9c36e2e0a0fa79c8b7b0e8264e2570400c61ee99c075bf9d0d77e556c06c8",
+            "actualSha256": "efd9c36e2e0a0fa79c8b7b0e8264e2570400c61ee99c075bf9d0d77e556c06c8",
             "status": "passed",
             "reason": ""
           },
@@ -708,10 +708,10 @@
           {
             "name": "kungfu-product-upgrade",
             "sourcePath": "framework/upgrade/kungfu-upgrade.contract.json",
-            "sourceSha256": "fc47eb7b4c40efddcae878ba94d35f5396ebc173333587c82e145d7591d0e70f",
+            "sourceSha256": "efd9c36e2e0a0fa79c8b7b0e8264e2570400c61ee99c075bf9d0d77e556c06c8",
             "artifactPath": "config/kungfu-upgrade.contract.json",
-            "expectedSha256": "fc47eb7b4c40efddcae878ba94d35f5396ebc173333587c82e145d7591d0e70f",
-            "actualSha256": "fc47eb7b4c40efddcae878ba94d35f5396ebc173333587c82e145d7591d0e70f",
+            "expectedSha256": "efd9c36e2e0a0fa79c8b7b0e8264e2570400c61ee99c075bf9d0d77e556c06c8",
+            "actualSha256": "efd9c36e2e0a0fa79c8b7b0e8264e2570400c61ee99c075bf9d0d77e556c06c8",
             "byteForByte": true,
             "status": "passed",
             "reason": ""

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.3",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.3",
-    "sourceSha": "c8fd32f901b3af15532a11599c9b34af0b0f42bc"
+    "sourceSha": "c019142e10150ff472a509d319e24d17860be4b0"
   },
   "claims": [
     {

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:6e7bedcd893feaadcf196e1b48f544b431c4bc207bd908d226ab2932cf57feb0"
+            "sha256": "sha256:3d15d7778bbbcf8011405c6c483e5aa46ba38e74d3fc785ac673ca3c6a6799ce"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/framework/contract/kungfu-agent-first-canonical-policy.json
+++ b/framework/contract/kungfu-agent-first-canonical-policy.json
@@ -362,13 +362,13 @@
       },
       "source": {
         "path": "framework/upgrade/kungfu-upgrade.contract.json",
-        "sha256": "sha256:fc47eb7b4c40efddcae878ba94d35f5396ebc173333587c82e145d7591d0e70f",
-        "renderedSha256": "sha256:fc47eb7b4c40efddcae878ba94d35f5396ebc173333587c82e145d7591d0e70f",
+        "sha256": "sha256:efd9c36e2e0a0fa79c8b7b0e8264e2570400c61ee99c075bf9d0d77e556c06c8",
+        "renderedSha256": "sha256:efd9c36e2e0a0fa79c8b7b0e8264e2570400c61ee99c075bf9d0d77e556c06c8",
         "byteForByte": true
       },
       "artifact": {
         "path": "config/kungfu-upgrade.contract.json",
-        "expectedSha256": "sha256:fc47eb7b4c40efddcae878ba94d35f5396ebc173333587c82e145d7591d0e70f"
+        "expectedSha256": "sha256:efd9c36e2e0a0fa79c8b7b0e8264e2570400c61ee99c075bf9d0d77e556c06c8"
       }
     },
     {

--- a/framework/core/tests/python/test_release_channel.py
+++ b/framework/core/tests/python/test_release_channel.py
@@ -807,6 +807,7 @@ def test_bootstrap_verifier_binds_staged_archive_product_and_channel(
                 "signature": "sigstore:fixture",
             },
             {
+                "name": "kungfu-episodes-cli-linux-x64.tar.gz",
                 "kind": "cli",
                 "url": "https://releases.kungfu.invalid/kungfu-cli-linux-x64.tar.gz",
                 "size": archive.stat().st_size,

--- a/framework/core/tests/python/test_runtime_upgrade.py
+++ b/framework/core/tests/python/test_runtime_upgrade.py
@@ -140,6 +140,39 @@ def _reference(build_id: str, state: str = "active") -> dict:
     }
 
 
+def test_release_manifest_accepts_named_artifacts_without_weakening_schema(
+    tmp_path,
+):
+    source = _source(tmp_path, "runtime-named-artifacts")
+    manifest = _manifest(source, "runtime-named-artifacts")
+    manifest["artifacts"].extend(
+        [
+            {
+                "name": "Kungfu.Episodes.Setup.4.0.0-alpha.2.exe",
+                "kind": "desktop",
+                "url": "https://example.invalid/Kungfu.Episodes.Setup.4.0.0-alpha.2.exe",
+                "size": 2,
+                "digest": f"sha256:{'2' * 64}",
+                "signature": "sigstore:desktop-fixture",
+            },
+            {
+                "name": "kungfu-episodes-cli-windows-x64.zip",
+                "kind": "cli",
+                "url": "https://example.invalid/kungfu-episodes-cli-windows-x64.zip",
+                "size": 3,
+                "digest": f"sha256:{'3' * 64}",
+                "signature": "sigstore:cli-fixture",
+            },
+        ]
+    )
+
+    assert runtime_upgrade.validate_manifest(manifest) == manifest
+
+    manifest["artifacts"][1]["unexpected"] = "not-authority"
+    with pytest.raises(ValueError, match="Additional properties are not allowed"):
+        runtime_upgrade.validate_manifest(manifest)
+
+
 def test_user_message_answers_product_questions_and_links_exact_reason() -> None:
     message = runtime_upgrade.user_message(
         "active-work-incompatible",

--- a/framework/upgrade/kungfu-upgrade.contract.json
+++ b/framework/upgrade/kungfu-upgrade.contract.json
@@ -372,6 +372,10 @@
           "signature"
         ],
         "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
           "kind": {
             "enum": [
               "runtime",


### PR DESCRIPTION
## Summary

Allow the strict runtime upgrade consumer to accept the optional non-empty `name` field already emitted by the signed public release-channel manifest. This keeps signature, digest, authority, and unknown-field validation intact while restoring Alpha.2 CLI bootstrap compatibility.

## Related issue

Fixes #3334

## Changes

- Add optional non-empty artifact `name` to the canonical upgrade contract.
- Cover the public-manifest compatibility path in Python and Node release-channel tests.
- Regenerate canonical policy and KFD projection evidence without changing immutable Alpha.2 assets.

## Verification

- `./shifu test:runtime-upgrade` — 135 passed.
- `./shifu test:release-channel` — 12/12 Node and 135/135 Python passed.
- `./shifu check:source` — 1153 passed, 0 failed, 11 skipped; docs 141 passed; zero-write gate passed.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix aligns the strict bootstrap consumer schema with the existing signed release-manifest contract without changing architecture authority."
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change only broadens the consumer schema to the already-signed manifest field and preserves all cryptographic and authority checks. The immutable Alpha.2 publication remains untouched.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed