### PR TITLE
fix(core): harden watcher readiness lifecycle

### DIFF
--- a/framework/core/src/bindings/node/binding/watcher.cpp
+++ b/framework/core/src/bindings/node/binding/watcher.cpp
@@ -794,6 +794,7 @@ void Watcher::SyncSnapshot() {
 void Watcher::StopAndJoinForCleanup() {
   environment_closing_ = true;
   worker_live_ = false;
+  get_io_device()->cancel_usability_probe();
   if (worker_thread_.joinable()) {
     worker_thread_.join();
   }
@@ -840,6 +841,7 @@ void Watcher::Quit(const Napi::CallbackInfo &info) {
   RequestDeregister();
   quit_ = true;
   worker_live_ = false;
+  get_io_device()->cancel_usability_probe();
 }
 
 void Watcher::RequestDeregister() {

--- a/framework/core/src/libkungfu/include/kungfu/runtime/io.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/io.h
@@ -7,6 +7,8 @@
 #ifndef KUNGFU_IO_H
 #define KUNGFU_IO_H
 
+#include <mutex>
+
 #include <kungfu/runtime/common.h>
 
 #include <kungfu/runtime/nanomsg/socket.h>
@@ -132,6 +134,11 @@ public:
   bool is_usable() override;
 
   bool setup() override;
+
+private:
+  std::mutex usability_probe_mutex_;
+  publisher_ptr usability_probe_publisher_;
+  observer_ptr usability_probe_observer_;
 };
 
 DECLARE_PTR(io_device_peer)

--- a/framework/core/src/libkungfu/include/kungfu/runtime/io.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/io.h
@@ -7,6 +7,8 @@
 #ifndef KUNGFU_IO_H
 #define KUNGFU_IO_H
 
+#include <atomic>
+#include <condition_variable>
 #include <mutex>
 
 #include <kungfu/runtime/common.h>
@@ -65,6 +67,8 @@ public:
     bool orc = observer_->setup();
     return prc && orc;
   }
+
+  virtual void cancel_usability_probe() {}
 
   [[nodiscard]] const data::locator_ptr &get_locator() const { return home_->locator; }
 
@@ -135,8 +139,12 @@ public:
 
   bool setup() override;
 
+  void cancel_usability_probe() override;
+
 private:
+  std::atomic<bool> usability_probe_cancelled_{false};
   std::mutex usability_probe_mutex_;
+  std::condition_variable usability_probe_condition_;
   publisher_ptr usability_probe_publisher_;
   observer_ptr usability_probe_observer_;
 };

--- a/framework/core/src/libkungfu/include/kungfu/runtime/nanomsg/socket.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/nanomsg/socket.h
@@ -117,6 +117,8 @@ public:
 
   int dial(const std::string &path, int flags = 0);
 
+  int dial_quietly(const std::string &path, int flags = 0);
+
   void close();
 
   // Send policy changed to flag = 0 at app register, then notify with flag = NNG_FLAG_NONBLOCK
@@ -137,6 +139,8 @@ public:
   [[nodiscard]] const std::string &last_message() const { return message_; };
 
 private:
+  int dial_impl(const std::string &path, int flags, bool quiet_error);
+
   nng_socket sock_ = NNG_SOCKET_INITIALIZER;
   protocol protocol_;
   std::string url_;

--- a/framework/core/src/libkungfu/src/runtime/io/io.cpp
+++ b/framework/core/src/libkungfu/src/runtime/io/io.cpp
@@ -252,17 +252,25 @@ io_device_peer::io_device_peer(data::location_ptr home, bool low_latency)
     : io_device(std::move(home), low_latency, io_mapping_policy::peer()) {}
 
 bool io_device_peer::is_usable() {
-  nanomsg_publisher_peer publisher(*this, false);
-  nanomsg_observer_peer observer(*this, false);
-  if (not publisher.setup() or not observer.setup()) {
-    return false;
+  std::lock_guard<std::mutex> guard(usability_probe_mutex_);
+  if (not usability_probe_publisher_ or not usability_probe_observer_) {
+    auto observer = std::make_shared<nanomsg_observer_peer>(*this, false);
+    auto publisher = std::make_shared<nanomsg_publisher_peer>(*this, false);
+    if (not observer->setup() or not publisher->setup()) {
+      return false;
+    }
+    usability_probe_observer_ = std::move(observer);
+    usability_probe_publisher_ = std::move(publisher);
   }
-  // Keep the same sockets across this bounded handshake. Recreating the SUB
-  // socket after every missed pong repeats the NNG slow-joiner window on
-  // Windows and can prevent a healthy coordinator from ever becoming usable.
+  // Keep the same sockets across bounded calls. A single call must stay short
+  // because Watcher construction performs this check on the Node thread, while
+  // retaining the pair lets the dedicated worker survive Windows' NNG
+  // slow-joiner window instead of restarting it after every missed pong.
   for (int attempt = 0; attempt < USABILITY_PROBE_ATTEMPTS; ++attempt) {
     std::this_thread::sleep_for(std::chrono::milliseconds(TEST_USABLE_TIMEOUT));
-    if (publisher.is_usable() and observer.is_usable()) {
+    if (usability_probe_publisher_->is_usable() and usability_probe_observer_->is_usable()) {
+      usability_probe_observer_.reset();
+      usability_probe_publisher_.reset();
       return true;
     }
   }
@@ -270,6 +278,11 @@ bool io_device_peer::is_usable() {
 }
 
 bool io_device_peer::setup() {
+  {
+    std::lock_guard<std::mutex> guard(usability_probe_mutex_);
+    usability_probe_observer_.reset();
+    usability_probe_publisher_.reset();
+  }
   publisher_ = std::make_shared<nanomsg_publisher_peer>(*this, is_low_latency());
   observer_ = std::make_shared<nanomsg_observer_peer>(*this, is_low_latency());
   auto is_live_mode = get_home()->mode == mode::LIVE;

--- a/framework/core/src/libkungfu/src/runtime/io/io.cpp
+++ b/framework/core/src/libkungfu/src/runtime/io/io.cpp
@@ -83,12 +83,12 @@ public:
 
 class nanomsg_publisher_peer : public nanomsg_publisher {
 public:
-  nanomsg_publisher_peer(const io_device &io_device, bool low_latency)
-      : nanomsg_publisher(io_device, low_latency, protocol::PUSH) {}
+  nanomsg_publisher_peer(const io_device &io_device, bool low_latency, bool quiet_setup_error = false)
+      : nanomsg_publisher(io_device, low_latency, protocol::PUSH), quiet_setup_error_(quiet_setup_error) {}
 
   bool setup() override {
     socket_.setsockopt_ms(NNG_OPT_SENDTIMEO, DEFAULT_NOTICE_TIMEOUT);
-    return socket_.dial(dial_path_) == 0;
+    return (quiet_setup_error_ ? socket_.dial_quietly(dial_path_) : socket_.dial(dial_path_)) == 0;
   }
 
   bool is_usable() override {
@@ -101,6 +101,9 @@ public:
     ping["data"] = "";
     return publish(ping.dump()) == 0;
   }
+
+private:
+  const bool quiet_setup_error_;
 };
 
 class nanomsg_observer : public observer, protected nanomsg_resource {
@@ -144,16 +147,19 @@ public:
 
 class nanomsg_observer_peer : public nanomsg_observer {
 public:
-  nanomsg_observer_peer(const io_device &io_device, bool low_latency)
-      : nanomsg_observer(io_device, low_latency, protocol::SUBSCRIBE) {}
+  nanomsg_observer_peer(const io_device &io_device, bool low_latency, bool quiet_setup_error = false)
+      : nanomsg_observer(io_device, low_latency, protocol::SUBSCRIBE), quiet_setup_error_(quiet_setup_error) {}
 
   bool setup() override {
     socket_.setsockopt_str(NNG_OPT_SUB_SUBSCRIBE, "");
     socket_.setsockopt_ms(NNG_OPT_RECVTIMEO, DEFAULT_RECV_TIMEOUT);
-    return socket_.dial(dial_path_) == 0;
+    return (quiet_setup_error_ ? socket_.dial_quietly(dial_path_) : socket_.dial(dial_path_)) == 0;
   }
 
   bool is_usable() override { return socket_.recv(NNG_FLAG_ALLOC) == 0; }
+
+private:
+  const bool quiet_setup_error_;
 };
 
 namespace {
@@ -252,10 +258,16 @@ io_device_peer::io_device_peer(data::location_ptr home, bool low_latency)
     : io_device(std::move(home), low_latency, io_mapping_policy::peer()) {}
 
 bool io_device_peer::is_usable() {
-  std::lock_guard<std::mutex> guard(usability_probe_mutex_);
+  std::unique_lock<std::mutex> guard(usability_probe_mutex_);
+  if (usability_probe_cancelled_.load()) {
+    return false;
+  }
   if (not usability_probe_publisher_ or not usability_probe_observer_) {
-    auto observer = std::make_shared<nanomsg_observer_peer>(*this, false);
-    auto publisher = std::make_shared<nanomsg_publisher_peer>(*this, false);
+    // Probe failures are an expected readiness state. Keep them silent so an
+    // addon cleanup hook can cancel an in-flight probe without racing a logger
+    // whose process-exit teardown has already begun.
+    auto observer = std::make_shared<nanomsg_observer_peer>(*this, false, true);
+    auto publisher = std::make_shared<nanomsg_publisher_peer>(*this, false, true);
     if (not observer->setup() or not publisher->setup()) {
       return false;
     }
@@ -267,7 +279,10 @@ bool io_device_peer::is_usable() {
   // retaining the pair lets the dedicated worker survive Windows' NNG
   // slow-joiner window instead of restarting it after every missed pong.
   for (int attempt = 0; attempt < USABILITY_PROBE_ATTEMPTS; ++attempt) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(TEST_USABLE_TIMEOUT));
+    if (usability_probe_condition_.wait_for(guard, std::chrono::milliseconds(TEST_USABLE_TIMEOUT),
+                                            [this] { return usability_probe_cancelled_.load(); })) {
+      return false;
+    }
     if (usability_probe_publisher_->is_usable() and usability_probe_observer_->is_usable()) {
       usability_probe_observer_.reset();
       usability_probe_publisher_.reset();
@@ -275,6 +290,14 @@ bool io_device_peer::is_usable() {
     }
   }
   return false;
+}
+
+void io_device_peer::cancel_usability_probe() {
+  usability_probe_cancelled_ = true;
+  usability_probe_condition_.notify_all();
+  std::lock_guard<std::mutex> guard(usability_probe_mutex_);
+  usability_probe_observer_.reset();
+  usability_probe_publisher_.reset();
 }
 
 bool io_device_peer::setup() {

--- a/framework/core/src/libkungfu/src/runtime/util/nanomsg.cpp
+++ b/framework/core/src/libkungfu/src/runtime/util/nanomsg.cpp
@@ -115,10 +115,14 @@ int socket::listen(const std::string &path, int flags) {
   return rc;
 }
 
-int socket::dial(const std::string &path, int flags) {
+int socket::dial(const std::string &path, int flags) { return dial_impl(path, flags, false); }
+
+int socket::dial_quietly(const std::string &path, int flags) { return dial_impl(path, flags, true); }
+
+int socket::dial_impl(const std::string &path, int flags, bool quiet_error) {
   url_ = "ipc://" + path;
   int rc = nng_dial(sock_, url_.c_str(), NULL, flags);
-  if (rc != 0) {
+  if (rc != 0 && not quiet_error) {
     SPDLOG_WARN("can not dial to {}, error [{}] {}", url_, rc, nng_strerror(rc));
   }
   return rc;

--- a/framework/core/tests/fixtures/watcher-runtime-probe.js
+++ b/framework/core/tests/fixtures/watcher-runtime-probe.js
@@ -162,6 +162,34 @@ function waitForExitWithin(child, timeoutMs) {
   });
 }
 
+function signalPosixProcessTree(child, signal) {
+  let groupError = null;
+  try {
+    process.kill(-child.pid, signal);
+  } catch (error) {
+    if (error.code !== 'ESRCH') groupError = error;
+  }
+
+  let childSignalled = false;
+  if (child.exitCode === null && child.signalCode === null) {
+    try {
+      childSignalled = child.kill(signal);
+    } catch (error) {
+      if (error.code !== 'ESRCH' && groupError === null) groupError = error;
+    }
+  }
+  if (
+    groupError !== null &&
+    !childSignalled &&
+    child.exitCode === null &&
+    child.signalCode === null
+  ) {
+    throw new Error(
+      `failed to signal coordinator process tree with ${signal}: ${groupError.message}`,
+    );
+  }
+}
+
 async function stopCoordinator(child) {
   if (child.exitCode !== null || child.signalCode !== null) return;
   if (process.platform === 'win32') {
@@ -179,13 +207,13 @@ async function stopCoordinator(child) {
       );
     }
   } else {
-    process.kill(-child.pid, 'SIGTERM');
+    signalPosixProcessTree(child, 'SIGTERM');
   }
   if (await waitForExitWithin(child, 3_000)) return;
   if (process.platform === 'win32') {
     child.kill();
   } else {
-    process.kill(-child.pid, 'SIGKILL');
+    signalPosixProcessTree(child, 'SIGKILL');
   }
   if (!(await waitForExitWithin(child, 3_000))) {
     throw new Error('coordinator did not exit after SIGKILL');

--- a/framework/core/tests/watcher-runtime-boundary.test.js
+++ b/framework/core/tests/watcher-runtime-boundary.test.js
@@ -33,6 +33,15 @@ const ioSource = path.join(
   'io',
   'io.cpp',
 );
+const ioHeader = path.join(
+  coreDir,
+  'src',
+  'libkungfu',
+  'include',
+  'kungfu',
+  'runtime',
+  'io.h',
+);
 const watcherProbeSource = fs.readFileSync(probe, 'utf8');
 const reconnectProbeSource = watcherProbeSource.slice(
   watcherProbeSource.indexOf('async function reconnectProbe()'),
@@ -121,7 +130,20 @@ test('watcher reconnect fixture sequences readiness, owns process trees, and bou
     watcherProbeSource,
     /\['\/pid', String\(child\.pid\), '\/T', '\/F'\]/,
   );
-  assert.match(watcherProbeSource, /process\.kill\(-child\.pid, 'SIGTERM'\)/);
+  assert.match(
+    watcherProbeSource,
+    /signalPosixProcessTree\(child, 'SIGTERM'\)/,
+  );
+  assert.match(
+    watcherProbeSource,
+    /signalPosixProcessTree\(child, 'SIGKILL'\)/,
+  );
+  const posixSignalSource = watcherProbeSource.slice(
+    watcherProbeSource.indexOf('function signalPosixProcessTree('),
+    watcherProbeSource.indexOf('async function stopCoordinator('),
+  );
+  assert.match(posixSignalSource, /process\.kill\(-child\.pid, signal\)/);
+  assert.match(posixSignalSource, /child\.kill\(signal\)/);
   const coordinatorReady = reconnectProbeSource.indexOf(
     "'initial-coordinator-startup'",
   );
@@ -157,8 +179,9 @@ test('watcher reconnect fixture sequences readiness, owns process trees, and bou
   assert.match(exitWaitSource, /let settled = false;/);
 });
 
-test('peer usability keeps one bounded handshake across slow-joiner retries', () => {
+test('peer usability persists one bounded handshake across slow-joiner retries', () => {
   const source = fs.readFileSync(ioSource, 'utf8');
+  const header = fs.readFileSync(ioHeader, 'utf8');
   const peerUsabilitySource = source.slice(
     source.indexOf('bool io_device_peer::is_usable()'),
     source.indexOf('bool io_device_peer::setup()'),
@@ -166,17 +189,32 @@ test('peer usability keeps one bounded handshake across slow-joiner retries', ()
   assert.match(source, /constexpr int USABILITY_PROBE_ATTEMPTS = 5;/);
   assert.match(
     peerUsabilitySource,
-    /if \(not publisher\.setup\(\) or not observer\.setup\(\)\)/,
+    /std::lock_guard<std::mutex> guard\(usability_probe_mutex_\)/,
+  );
+  assert.match(
+    peerUsabilitySource,
+    /if \(not usability_probe_publisher_ or not usability_probe_observer_\)/,
+  );
+  assert.match(
+    peerUsabilitySource,
+    /if \(not observer->setup\(\) or not publisher->setup\(\)\)/,
   );
   assert.match(
     peerUsabilitySource,
     /for \(int attempt = 0; attempt < USABILITY_PROBE_ATTEMPTS; \+\+attempt\)/,
   );
   assert.equal(
-    peerUsabilitySource.match(/nanomsg_observer_peer observer/g)?.length,
+    peerUsabilitySource.match(/make_shared<nanomsg_observer_peer>/g)?.length,
     1,
     'the SUB socket must not be recreated inside the retry loop',
   );
+  assert.match(
+    peerUsabilitySource,
+    /usability_probe_publisher_->is_usable\(\) and usability_probe_observer_->is_usable\(\)/,
+  );
+  assert.match(header, /std::mutex usability_probe_mutex_;/);
+  assert.match(header, /publisher_ptr usability_probe_publisher_;/);
+  assert.match(header, /observer_ptr usability_probe_observer_;/);
 });
 
 test(

--- a/framework/core/tests/watcher-runtime-boundary.test.js
+++ b/framework/core/tests/watcher-runtime-boundary.test.js
@@ -182,6 +182,7 @@ test('watcher reconnect fixture sequences readiness, owns process trees, and bou
 test('peer usability persists one bounded handshake across slow-joiner retries', () => {
   const source = fs.readFileSync(ioSource, 'utf8');
   const header = fs.readFileSync(ioHeader, 'utf8');
+  const watcher = fs.readFileSync(watcherSource, 'utf8');
   const peerUsabilitySource = source.slice(
     source.indexOf('bool io_device_peer::is_usable()'),
     source.indexOf('bool io_device_peer::setup()'),
@@ -189,7 +190,7 @@ test('peer usability persists one bounded handshake across slow-joiner retries',
   assert.match(source, /constexpr int USABILITY_PROBE_ATTEMPTS = 5;/);
   assert.match(
     peerUsabilitySource,
-    /std::lock_guard<std::mutex> guard\(usability_probe_mutex_\)/,
+    /std::unique_lock<std::mutex> guard\(usability_probe_mutex_\)/,
   );
   assert.match(
     peerUsabilitySource,
@@ -198,6 +199,15 @@ test('peer usability persists one bounded handshake across slow-joiner retries',
   assert.match(
     peerUsabilitySource,
     /if \(not observer->setup\(\) or not publisher->setup\(\)\)/,
+  );
+  assert.match(peerUsabilitySource, /usability_probe_condition_\.wait_for\(/);
+  assert.match(
+    peerUsabilitySource,
+    /make_shared<nanomsg_observer_peer>\(\*this, false, true\)/,
+  );
+  assert.match(
+    peerUsabilitySource,
+    /make_shared<nanomsg_publisher_peer>\(\*this, false, true\)/,
   );
   assert.match(
     peerUsabilitySource,
@@ -213,8 +223,18 @@ test('peer usability persists one bounded handshake across slow-joiner retries',
     /usability_probe_publisher_->is_usable\(\) and usability_probe_observer_->is_usable\(\)/,
   );
   assert.match(header, /std::mutex usability_probe_mutex_;/);
+  assert.match(
+    header,
+    /std::atomic<bool> usability_probe_cancelled_\{false\};/,
+  );
+  assert.match(header, /std::condition_variable usability_probe_condition_;/);
   assert.match(header, /publisher_ptr usability_probe_publisher_;/);
   assert.match(header, /observer_ptr usability_probe_observer_;/);
+  assert.equal(
+    watcher.match(/get_io_device\(\)->cancel_usability_probe\(\);/g)?.length,
+    2,
+    'quit and environment cleanup must both cancel an in-flight readiness probe',
+  );
 });
 
 test(
@@ -260,7 +280,9 @@ test(
   'environment cleanup stops and joins a live watcher during addon exit',
   nativeTest,
   () => {
-    assert.equal(runProbe('addon-exit'), null);
+    for (let attempt = 0; attempt < 6; attempt += 1) {
+      assert.equal(runProbe('addon-exit'), null);
+    }
   },
 );
 

--- a/scripts/check-incubation-passport.mjs
+++ b/scripts/check-incubation-passport.mjs
@@ -216,7 +216,58 @@ function git(root, args) {
   return spawnSync('git', args, { cwd: root, encoding: 'utf8' });
 }
 
-const MERGE_GROUP_PROTECTED_HISTORY_DEPTH = 64;
+const MERGE_GROUP_PROTECTED_HISTORY_FAST_DEPTH = 128;
+
+export function recoverMergeGroupProtectedSource({
+  root = ROOT,
+  baseSha,
+  sourceSha,
+  gitIsAncestor = (ancestor, descendant) =>
+    git(root, ['merge-base', '--is-ancestor', ancestor, descendant]).status ===
+    0,
+  gitRead = (args) => {
+    const result = git(root, args);
+    return result.status === 0 ? result.stdout.trim() : '';
+  },
+  gitRun = (args) => git(root, args),
+} = {}) {
+  if (
+    !GIT_OBJECT_PATTERN.test(baseSha || '') ||
+    !GIT_OBJECT_PATTERN.test(sourceSha || '')
+  )
+    return false;
+
+  const fastFetch = gitRun([
+    'fetch',
+    '--no-tags',
+    '--no-write-fetch-head',
+    '--filter=blob:none',
+    `--depth=${MERGE_GROUP_PROTECTED_HISTORY_FAST_DEPTH}`,
+    'origin',
+    baseSha,
+  ]);
+  if (fastFetch.status !== 0) return false;
+  if (gitIsAncestor(sourceSha, baseSha)) return true;
+
+  // The fast depth is only an optimization. A retained protected source must
+  // not become invalid merely because the protected branch gains commits.
+  // Complete the commit graph without historical blobs, then prove ancestry
+  // against the authenticated merge-group base. A complete non-ancestor still
+  // fails closed.
+  if (gitRead(['rev-parse', '--is-shallow-repository']) !== 'true')
+    return false;
+  const completeFetch = gitRun([
+    'fetch',
+    '--no-tags',
+    '--no-write-fetch-head',
+    '--filter=blob:none',
+    '--unshallow',
+    'origin',
+    baseSha,
+  ]);
+  if (completeFetch.status !== 0) return false;
+  return gitIsAncestor(sourceSha, baseSha);
+}
 
 export function protectedSourceRetained({
   root = ROOT,
@@ -231,16 +282,8 @@ export function protectedSourceRetained({
     const result = git(root, args);
     return result.status === 0 ? result.stdout.trim() : '';
   },
-  hydrateMergeGroupBase = (baseSha) =>
-    git(root, [
-      'fetch',
-      '--no-tags',
-      '--no-write-fetch-head',
-      '--filter=blob:none',
-      `--depth=${MERGE_GROUP_PROTECTED_HISTORY_DEPTH}`,
-      'origin',
-      baseSha,
-    ]).status === 0,
+  recoverMergeGroupAncestry = ({ baseSha, sourceSha }) =>
+    recoverMergeGroupProtectedSource({ root, baseSha, sourceSha }),
 } = {}) {
   if (!GIT_OBJECT_PATTERN.test(sourceSha || '')) return false;
   if (gitIsAncestor(sourceSha, headSha)) return true;
@@ -248,13 +291,15 @@ export function protectedSourceRetained({
   // The reusable source job intentionally uses a depth-one checkout. Git then
   // reports false for ancestry that the protected merge-group base actually
   // retains. Only an authenticated event for this exact checkout may recover
-  // that proof, and the bounded fetch remains fail closed if the source falls
-  // outside the retained protected history.
+  // that proof, and the recovered commit graph remains fail closed when the
+  // source is not an ancestor of the protected base.
   const mergeGroup = githubMergeGroupCoordinates(env, readFile);
   if (!mergeGroup || gitRead(['rev-parse', headSha]) !== mergeGroup.headSha)
     return false;
-  if (!hydrateMergeGroupBase(mergeGroup.baseSha)) return false;
-  return gitIsAncestor(sourceSha, mergeGroup.baseSha);
+  return recoverMergeGroupAncestry({
+    baseSha: mergeGroup.baseSha,
+    sourceSha,
+  });
 }
 
 export function validateAdmissionFixture({ root = ROOT, passport, fixture }) {

--- a/scripts/check-incubation-passport.test.mjs
+++ b/scripts/check-incubation-passport.test.mjs
@@ -10,6 +10,7 @@ import {
   collectIssues,
   compareBaseline,
   protectedSourceRetained,
+  recoverMergeGroupProtectedSource,
   validateAdmissionFixture,
   validateRepository,
 } from './check-incubation-passport.mjs';
@@ -230,7 +231,7 @@ test('protected source accepts ordinary retained ancestry without recovery', () 
         return true;
       },
       gitRead: () => assert.fail('ordinary ancestry must not inspect an event'),
-      hydrateMergeGroupBase: () =>
+      recoverMergeGroupAncestry: () =>
         assert.fail('ordinary ancestry must not hydrate history'),
     }),
     true,
@@ -241,8 +242,7 @@ test('protected source recovers ancestry from the exact merge-group base', () =>
   const sourceSha = 'a'.repeat(40);
   const baseSha = 'b'.repeat(40);
   const headSha = 'c'.repeat(40);
-  const ancestryCalls = [];
-  const hydrated = [];
+  const recovered = [];
   assert.equal(
     protectedSourceRetained({
       sourceSha,
@@ -254,26 +254,19 @@ test('protected source recovers ancestry from the exact merge-group base', () =>
         JSON.stringify({
           merge_group: { base_sha: baseSha, head_sha: headSha },
         }),
-      gitIsAncestor: (ancestor, descendant) => {
-        ancestryCalls.push([ancestor, descendant]);
-        return descendant === baseSha;
-      },
+      gitIsAncestor: () => false,
       gitRead: (args) => {
         assert.deepEqual(args, ['rev-parse', 'HEAD']);
         return headSha;
       },
-      hydrateMergeGroupBase: (sha) => {
-        hydrated.push(sha);
+      recoverMergeGroupAncestry: (coordinates) => {
+        recovered.push(coordinates);
         return true;
       },
     }),
     true,
   );
-  assert.deepEqual(ancestryCalls, [
-    [sourceSha, 'HEAD'],
-    [sourceSha, baseSha],
-  ]);
-  assert.deepEqual(hydrated, [baseSha]);
+  assert.deepEqual(recovered, [{ baseSha, sourceSha }]);
 });
 
 test('protected source rejects mismatched or unretained merge-group evidence', () => {
@@ -296,7 +289,7 @@ test('protected source rejects mismatched or unretained merge-group evidence', (
       readFile,
       gitIsAncestor: () => false,
       gitRead: () => 'd'.repeat(40),
-      hydrateMergeGroupBase: () =>
+      recoverMergeGroupAncestry: () =>
         assert.fail('mismatched event must not hydrate history'),
     }),
     false,
@@ -308,10 +301,76 @@ test('protected source rejects mismatched or unretained merge-group evidence', (
       readFile,
       gitIsAncestor: () => false,
       gitRead: () => headSha,
-      hydrateMergeGroupBase: () => true,
+      recoverMergeGroupAncestry: () => false,
     }),
     false,
   );
+});
+
+test('merge-group recovery treats shallow depth as an optimization only', () => {
+  const sourceSha = 'a'.repeat(40);
+  const baseSha = 'b'.repeat(40);
+  const gitCalls = [];
+  let ancestryChecks = 0;
+  assert.equal(
+    recoverMergeGroupProtectedSource({
+      sourceSha,
+      baseSha,
+      gitRun: (args) => {
+        gitCalls.push(args);
+        return { status: 0 };
+      },
+      gitRead: (args) => {
+        assert.deepEqual(args, ['rev-parse', '--is-shallow-repository']);
+        return 'true';
+      },
+      gitIsAncestor: (ancestor, descendant) => {
+        assert.equal(ancestor, sourceSha);
+        assert.equal(descendant, baseSha);
+        ancestryChecks += 1;
+        return ancestryChecks === 2;
+      },
+    }),
+    true,
+  );
+  assert.deepEqual(gitCalls, [
+    [
+      'fetch',
+      '--no-tags',
+      '--no-write-fetch-head',
+      '--filter=blob:none',
+      '--depth=128',
+      'origin',
+      baseSha,
+    ],
+    [
+      'fetch',
+      '--no-tags',
+      '--no-write-fetch-head',
+      '--filter=blob:none',
+      '--unshallow',
+      'origin',
+      baseSha,
+    ],
+  ]);
+});
+
+test('merge-group recovery rejects a complete non-ancestor without refetching', () => {
+  const gitCalls = [];
+  assert.equal(
+    recoverMergeGroupProtectedSource({
+      sourceSha: 'a'.repeat(40),
+      baseSha: 'b'.repeat(40),
+      gitRun: (args) => {
+        gitCalls.push(args);
+        return { status: 0 };
+      },
+      gitRead: () => 'false',
+      gitIsAncestor: () => false,
+    }),
+    false,
+  );
+  assert.equal(gitCalls.length, 1);
 });
 
 test('a new tracked schema fails closed', () => {


### PR DESCRIPTION
## Summary

Repair the residual platform failures observed after protected landing `ce77c38825163576d13bdbafa0000915ec26cc14`:

- retain one bounded NNG publisher/subscriber probe pair across worker calls so Windows does not re-enter the slow-joiner window on every readiness attempt
- serialize access to persistent probe state and cancel any in-flight readiness wait before watcher shutdown joins its worker
- suppress only expected readiness-dial warnings so process-exit logger teardown cannot race a failed probe
- signal both the POSIX process group and child leader during coordinator shutdown so Linux does not leave the killed coordinator alive
- exercise addon-exit repeatedly and pin the persistent/cancellable probe lifecycle structurally
- keep admitted protected-source ancestry valid in merge-group shallow checkouts: a 128-commit blobless fetch is only the fast path, with blobless complete-history recovery before the same fail-closed ancestry proof

The protected CI failures being repaired are workflow `32550613715`, Linux job `96976692267`, and Windows job `96976692271`. Darwin passed in that same workflow.

This PR supersedes #3349 at identical intended watcher scope. #3349 governance job `96987674782` rejected its old first-parent topology because queue replay included obsolete history. This r3 branch is rooted directly at protected `ce77c38825163576d13bdbafa0000915ec26cc14`; local Project Cut admission qualified both watcher commits with `compositionChanged=false`.

The first #3354 merge-group attempt at synthetic head `d137c69ff0db09a25cf1bd4a20d2b20e806713cd` then exposed a separate delivery-topology defect: `kungfu.work-control-l3` protected source `b1fcf00ce6df6c2452e69eeda1741de7b9ff9591` was 67 first-parent commits behind base `be0959d5d5d340d5178fcb52be22b94050e55a18`, beyond the fixed 64-commit hydration window. The repair at `3916e492fcca10b3c9102c05cb23d182257f23f0` removes that correctness horizon without weakening the ancestry requirement.

## Related Assignment

Supplemental repair Assignment `2026-08-21-kungfu-windows-watcher-reconnect-reliability` under parent `2026-08-18-kungfu-mainline-quality-convergence`.

## Verification

Local watcher capture at ancestor `13f5c55037a49e606452a1cc1578bc2e6fa0787f` (not CI output; the successor changes only the passport gate and its tests):

- rebuilt native Core from that checkout: passed
- watcher runtime boundary suite against the rebuilt binding: 10 passed, 0 failed in four complete runs after the final test correction

Local exact-source validation at `3916e492fcca10b3c9102c05cb23d182257f23f0` (not CI output):

- focused passport suite: 13 passed, 0 failed
- real shallow-repository reproduction proves `b1fcf00c...` remains an ancestor of `be0959d5...` after blobless recovery
- `./shifu check:source`: passed through the final `build-free source gate passed` signal
- normal DCO pre-commit staged gate: passed
- fresh exact-head Atlas work admission: verified

Protected CI evidence for this PR will be supplied by GitHub required checks bound to the exact PR head; no local capture is represented as a CI artifact.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded bug fix hardens existing watcher readiness and coordinator shutdown behavior plus its fail-closed merge-group ancestry check, without changing public APIs, ABI, ownership, or architectural authority."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Regression coverage added for readiness cancellation, both failed platform boundaries, and merge-group ancestry hydration
