### PR TITLE
fix(workspace): keep federation reads profile-neutral

### DIFF
--- a/framework/core/src/python/kungfu/workspace_federation.py
+++ b/framework/core/src/python/kungfu/workspace_federation.py
@@ -76,15 +76,7 @@ WorkspaceLoader = Callable[[WorkspaceIdentity], dict[str, Any]]
 def _load_parallel_component(identity: WorkspaceIdentity) -> dict[str, Any]:
     """Load one default component in an isolated POSIX reader process."""
 
-    from kungfu import work_control
-
-    return _safe_component(
-        identity,
-        lambda workspace: _load_component(
-            workspace,
-            relation_loader=work_control.assignment_relations,
-        ),
-    )
+    return _safe_component(identity, _load_component)
 
 
 def query_federation(
@@ -198,15 +190,6 @@ def query_federation(
             )
     else:
         component_loader = loader
-        if loader is _load_component:
-            from kungfu import work_control
-
-            assignment_relations = work_control.assignment_relations
-
-            def load_parallel_component(identity: WorkspaceIdentity) -> dict[str, Any]:
-                return _load_component(identity, relation_loader=assignment_relations)
-
-            component_loader = load_parallel_component
         with ThreadPoolExecutor(max_workers=max_workers) as component_executor:
             components = list(
                 component_executor.map(
@@ -755,11 +738,7 @@ def _safe_component(
         return _bind_component_envelope(result)
 
 
-def _load_component(
-    identity: WorkspaceIdentity,
-    *,
-    relation_loader: Callable[[str], list[dict[str, Any]]] | None = None,
-) -> dict[str, Any]:
+def _load_component(identity: WorkspaceIdentity) -> dict[str, Any]:
     """Read one component through the root-bound Fact material protocol.
 
     Work Control's high-level query correctly requires its exact active
@@ -857,11 +836,6 @@ def _load_component(
 
     from kungfu.storage import service as storage_service
 
-    if relation_loader is None:
-        from kungfu import work_control
-
-        relation_loader = work_control.assignment_relations
-
     materials = storage_service.fact_material_list(runtime_dir)
     if materials.get("schema") != "kungfu.facts.material-catalog/v1":
         raise ValueError("unsupported Fact material catalog")
@@ -871,6 +845,7 @@ def _load_component(
         raise ValueError("Fact material payload map is absent")
     initiatives: list[dict[str, Any]] = []
     assignments: list[dict[str, Any]] = []
+    stored_relations: dict[str, dict[str, Any]] = {}
     phase_by_assignment: dict[str, tuple[int, str]] = {}
     for fact in canonical_facts:
         surface = str(fact.get("fact_surface_id") or "")
@@ -897,6 +872,9 @@ def _load_component(
         elif surface == "kungfu.initiative-assignment.assignment":
             assignments.append(record)
         elif surface == "kungfu.initiative-assignment.completion-claim":
+            stored_relation = _material_relation(record)
+            if stored_relation is not None:
+                stored_relations[stored_relation["relation_root"]] = stored_relation
             links = payload.get("links")
             linked_assignment = (
                 str(links.get("assignment_id") or "")
@@ -963,11 +941,10 @@ def _load_component(
         )
         for row in assignments
     ]
-    stored_relations = relation_loader(runtime_dir)
     derived_relations = _material_relations(projected_assignments)
     relations = {
         str(row.get("relation_root") or ""): row
-        for row in [*stored_relations, *derived_relations]
+        for row in [*stored_relations.values(), *derived_relations]
         if row.get("relation_root")
     }
     profile_binding = _fact_profile_binding(materials)
@@ -1011,6 +988,29 @@ def _material_lifecycle(
         "globally_completed": phase == "continuation-decided",
         "projection": "root-bound-fact-material",
     }
+
+
+def _material_relation(record: Mapping[str, Any]) -> dict[str, Any] | None:
+    """Verify one relation event directly from root-bound Fact material."""
+
+    if record.get("claim_type") != "assignment-relation-event":
+        return None
+    relation = record.get("relation")
+    if not isinstance(relation, Mapping):
+        return None
+    verified = build_relation(
+        str(relation.get("relation_type") or ""),
+        relation.get("source") or {},
+        relation.get("target") or {},
+        evidence_roots=relation.get("evidence_roots") or [],
+        state=cast(
+            Literal["proposed", "accepted", "revoked"],
+            str(relation.get("state") or "accepted"),
+        ),
+    )
+    if verified["relation_root"] != relation.get("relation_root"):
+        raise ValueError("stored Assignment relation root does not verify")
+    return verified
 
 
 def _material_completion_phase(record: Mapping[str, Any]) -> str:

--- a/framework/core/tests/python/test_workspace_federation.py
+++ b/framework/core/tests/python/test_workspace_federation.py
@@ -5,12 +5,14 @@ import json
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+import kungfu
 import pytest
 
 from kungfu import assignment_graph
 from kungfu import workspace_federation as federation
 from kungfu import workspace_federation_projection as federation_projection
 from kungfu.workspace import (
+    WorkspaceIdentity,
     ensure_workspace_data_home,
     inspect_workspace,
     maintain_workspace_catalog,
@@ -75,6 +77,63 @@ def test_workspace_federation_preserves_extracted_read_model_exports():
         is federation_projection._retained_state_dominates
     )
     assert federation._compose_global_work is federation_projection._compose_global_work
+
+
+def test_default_component_reader_does_not_resolve_work_control_profile(monkeypatch):
+    identity = WorkspaceIdentity(
+        workspace_id="project:reader",
+        workspace_kind="project",
+        workspace_root="/missing-reader-fixture",
+        display_path="/missing-reader-fixture",
+        data_home="/missing-reader-fixture/.kungfu",
+        config_home="/missing-reader-fixture/.config",
+        identity_root=ROOT_A,
+        identity_state="qualified",
+        initialized=True,
+        resolution_reason="test",
+    )
+
+    original_getattr = kungfu.__getattr__
+
+    def fail_profile_resolution(name):
+        if name == "work_control":
+            raise AssertionError("federation reader resolved Work Control Profile")
+        return original_getattr(name)
+
+    monkeypatch.setattr(kungfu, "__getattr__", fail_profile_resolution)
+    component = federation._load_parallel_component(identity)
+
+    assert component["availability"] == "unavailable"
+    assert component["problems"] == [{"code": "workspace-unavailable", "locator": None}]
+
+
+def test_material_relation_verifies_without_work_control_profile():
+    relation = federation.build_relation(
+        "depends-on",
+        {
+            "schema": federation.WORK_REF_SCHEMA,
+            "workspace_identity_root": ROOT_A,
+            "object_kind": "assignment",
+            "subject": "kungfu:left",
+            "version_root": ROOT_B,
+            "cut_root": ROOT_C,
+        },
+        {
+            "schema": federation.WORK_REF_SCHEMA,
+            "workspace_identity_root": ROOT_A,
+            "object_kind": "assignment",
+            "subject": "kungfu:right",
+            "version_root": ROOT_C,
+            "cut_root": ROOT_D,
+        },
+    )
+
+    assert (
+        federation._material_relation(
+            {"claim_type": "assignment-relation-event", "relation": relation}
+        )
+        == relation
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Keep global Work History federation reads profile-neutral.
- Reconstruct stored Assignment relations from root-verified Fact material.
- Preserve unavailable and retired catalog evidence without mutation.

## Verification

- `./shifu check:source`
- `58 passed` in the focused Workspace Federation suite
- Source global query produced 173 current compatible component observations while retaining 360 unavailable locators

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Correct a Work History runtime profile-resolution bug without changing architecture authority."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)