### PR TITLE
fix(profile): preserve safe authority narrowing readback

### DIFF
--- a/framework/core/src/python/kungfu/profile_composition.py
+++ b/framework/core/src/python/kungfu/profile_composition.py
@@ -563,7 +563,26 @@ def contract_materialization_plan(
     )
     _validate_contract_material(inspection["profile"], composed, artifact)
     current = storage_service.fact_type_list(runtime_dir)
-    operations = contract_operations(artifact, current, fail=_fail, root=_root)
+    fact_state = storage_service.fact_state(runtime_dir)
+    admitted_sources: dict[tuple[str, str, str], set[str]] = {}
+    for row in fact_state.get("observation_history") or []:
+        if row.get("outcome") != "admitted":
+            continue
+        key = (
+            str(row.get("fact_surface_id") or ""),
+            str(row.get("schema_owner_root") or ""),
+            str(row.get("contract_world_id") or ""),
+        )
+        source_id = str(row.get("source_id") or "")
+        if all(key) and source_id:
+            admitted_sources.setdefault(key, set()).add(source_id)
+    operations = contract_operations(
+        artifact,
+        current,
+        fail=_fail,
+        root=_root,
+        admitted_sources=admitted_sources,
+    )
     identity = {
         "source": str(Path(source).resolve()),
         "catalogRoot": composed["catalogRoot"],

--- a/framework/core/src/python/kungfu/profile_sdk_kfd3.py
+++ b/framework/core/src/python/kungfu/profile_sdk_kfd3.py
@@ -788,6 +788,7 @@ def contract_operations(
     *,
     fail: Callable[..., NoReturn],
     root: Callable[[Any], str],
+    admitted_sources: Mapping[tuple[str, str, str], set[str]],
 ) -> list[dict[str, str]]:
     world = artifact["contractWorld"]
     same_world = [
@@ -854,10 +855,9 @@ def contract_operations(
         if same:
             row = same[0]
             contract = row.get("contract_world") or {}
+            schema_root = root(surface["schema"])
             if (
-                sorted(row.get("source_authorities") or [])
-                != sorted(surface["sourceAuthorities"])
-                or row.get("schema_owner_root") != root(surface["schema"])
+                row.get("schema_owner_root") != schema_root
                 or contract.get("id") != world["id"]
                 or contract.get("version") != world["version"]
             ):
@@ -865,6 +865,31 @@ def contract_operations(
                     "fact-surface-incompatible",
                     "existing fact surface differs from the Profile declaration",
                     factSurface=surface["id"],
+                )
+            declared_authorities = set(surface["sourceAuthorities"])
+            existing_authorities = set(row.get("source_authorities") or [])
+            if declared_authorities == existing_authorities:
+                continue
+            # Fact-surface declarations are immutable evidence. A later Profile may
+            # retire an unused writer, but it must not reinterpret facts that writer
+            # already admitted or widen the durable authority boundary in place.
+            if not declared_authorities < existing_authorities:
+                fail(
+                    "fact-surface-incompatible",
+                    "existing fact surface differs from the Profile declaration",
+                    factSurface=surface["id"],
+                )
+            observed_authorities = admitted_sources.get(
+                (surface["id"], schema_root, world["id"]),
+                set(),
+            )
+            retired_with_facts = sorted(observed_authorities - declared_authorities)
+            if retired_with_facts:
+                fail(
+                    "fact-surface-authority-migration-required",
+                    "removed source authorities retain admitted facts and require an explicit migration",
+                    factSurface=surface["id"],
+                    admittedSourceAuthorities=retired_with_facts,
                 )
         else:
             operations.append(

--- a/framework/core/tests/python/test_profile_composition.py
+++ b/framework/core/tests/python/test_profile_composition.py
@@ -298,6 +298,28 @@ def _activate(source, runtime):
         profile_sdk.lifecycle_apply(runtime, plan, f"test:{action}")
 
 
+def _upgrade(source, runtime):
+    for action in ["upgrade", "qualify", "activate"]:
+        plan = profile_sdk.lifecycle_plan(runtime, action, source)["corePlan"]
+        profile_sdk.lifecycle_apply(runtime, plan, f"test:{action}")
+
+
+def _set_work_item_authorities(source, authorities):
+    profile_path = source / "profile.json"
+    profile = json.loads(profile_path.read_text())
+    world_path = source / "contracts" / "world.json"
+    world = json.loads(world_path.read_text())
+    world["factSurfaces"][0]["sourceAuthorities"] = authorities
+    _write_artifact(
+        source,
+        profile,
+        "contracts/world.json",
+        world,
+        profile["kfd1"]["contractWorld"],
+    )
+    profile_path.write_text(json.dumps(profile, indent=2, sort_keys=True) + "\n")
+
+
 def test_catalog_joins_exact_profile_artifacts_without_new_authority(tmp_path):
     source = _source(tmp_path)
     result = profile_composition.catalog(source, tmp_path / "runtime")
@@ -883,3 +905,75 @@ def test_installed_cli_assessment_plan_decide_and_run(tmp_path):
     assert json.loads(executed.output)["assessment"]["assessment_key"].startswith(
         "sha256:"
     )
+
+
+def test_contract_accepts_authority_narrowing_without_retired_source_facts(tmp_path):
+    source = _dynamic_source(tmp_path)
+    runtime = tmp_path / "runtime"
+    _set_work_item_authorities(source, ["retired-owner", "workspace-owner"])
+    _activate(source, runtime)
+    contract = profile_composition.contract_materialization_plan(source, runtime)
+    profile_composition.authorized_contract_materialize(
+        runtime,
+        contract,
+        profile_sdk.answer_decision(contract["decisionCard"], "approve", "test-owner"),
+    )
+    written = storage_service.fact_material_put(
+        runtime,
+        {
+            "type_id": "work-item",
+            "type_version": "1",
+            "source_id": "workspace-owner",
+            "subject_key": "week-1",
+            "payload": {"status": "active"},
+            "observation_id": "week-1-active",
+            "action": "assert",
+            "valid_until": 0,
+        },
+    )
+    assert written["receipt"]["admission"]["outcome"] == "admitted"
+
+    _set_work_item_authorities(source, ["workspace-owner"])
+    _upgrade(source, runtime)
+
+    assert (
+        profile_composition.contract_materialization_plan(source, runtime)["operations"]
+        == []
+    )
+
+
+def test_contract_rejects_authority_narrowing_with_retired_source_facts(tmp_path):
+    source = _dynamic_source(tmp_path)
+    runtime = tmp_path / "runtime"
+    _set_work_item_authorities(source, ["retired-owner", "workspace-owner"])
+    _activate(source, runtime)
+    contract = profile_composition.contract_materialization_plan(source, runtime)
+    profile_composition.authorized_contract_materialize(
+        runtime,
+        contract,
+        profile_sdk.answer_decision(contract["decisionCard"], "approve", "test-owner"),
+    )
+    written = storage_service.fact_material_put(
+        runtime,
+        {
+            "type_id": "work-item",
+            "type_version": "1",
+            "source_id": "retired-owner",
+            "subject_key": "week-1",
+            "payload": {"status": "active"},
+            "observation_id": "week-1-retired",
+            "action": "assert",
+            "valid_until": 0,
+        },
+    )
+    assert written["receipt"]["admission"]["outcome"] == "admitted"
+
+    _set_work_item_authorities(source, ["workspace-owner"])
+    _upgrade(source, runtime)
+
+    with pytest.raises(profile_sdk.ProfileSdkError) as raised:
+        profile_composition.contract_materialization_plan(source, runtime)
+    assert raised.value.diagnosis["code"] == (
+        "fact-surface-authority-migration-required"
+    )
+    assert raised.value.diagnosis["admittedSourceAuthorities"] == ["retired-owner"]

--- a/framework/spec/generated/authority.json
+++ b/framework/spec/generated/authority.json
@@ -47,7 +47,7 @@
     "sources": [
       {
         "path": "framework/format/kungfu-portable-format-authority.contract.json",
-        "root": "sha256:d6be3712e8f3a191024d3742120927e12186dd1a5ca6a7b8c72f95498512c975"
+        "root": "sha256:382655b514b0d5a0e60dcc70d70e7356ab5a3c752e6130055638b9dda23541f4"
       },
       {
         "path": "framework/spec/spec.meta.json",

--- a/framework/spec/generated/compatibility.json
+++ b/framework/spec/generated/compatibility.json
@@ -48,7 +48,7 @@
     "sources": [
       {
         "path": "framework/format/kungfu-portable-format-authority.contract.json",
-        "root": "sha256:d6be3712e8f3a191024d3742120927e12186dd1a5ca6a7b8c72f95498512c975"
+        "root": "sha256:382655b514b0d5a0e60dcc70d70e7356ab5a3c752e6130055638b9dda23541f4"
       },
       {
         "path": "framework/format/kungfu-required-reader.contract.json",

--- a/framework/spec/generated/registry.json
+++ b/framework/spec/generated/registry.json
@@ -67,9 +67,9 @@
       "compatibility_owner": "libkungfu",
       "identity_domain": "workspace-relative storage role, not semantic object identity",
       "protocol_id": "kungfu.workspace.episode-layout/v1",
-      "source": "framework/core/src/libkungfu/include/kungfu/runtime/storage/service.h",
+      "source": "framework/core/src/libkungfu/include/kungfu/runtime/storage/service_layout.h",
       "source_role": "workspace-path-and-persistence-class-inventory",
-      "source_root": "sha256:0494977ad8ee1b2526282d5c23aac16092c5ec1e932393df652df18c74f7ed85",
+      "source_root": "sha256:2b56f80027ee3e407544f657f177eb10853a6e992ab30a54e2ce9eb06d1a7e42",
       "version_axis": "workspace layout version"
     },
     {
@@ -117,7 +117,7 @@
     "sources": [
       {
         "path": "framework/format/kungfu-portable-format-authority.contract.json",
-        "root": "sha256:d6be3712e8f3a191024d3742120927e12186dd1a5ca6a7b8c72f95498512c975"
+        "root": "sha256:382655b514b0d5a0e60dcc70d70e7356ab5a3c752e6130055638b9dda23541f4"
       },
       {
         "path": "framework/fact/kungfu-fact-cut-kernel.contract.json",
@@ -144,8 +144,8 @@
         "root": "sha256:a4654f4b61ccc3527e3f61da4369c126bf5ccbe398b8c78913c5907abdf08037"
       },
       {
-        "path": "framework/core/src/libkungfu/include/kungfu/runtime/storage/service.h",
-        "root": "sha256:0494977ad8ee1b2526282d5c23aac16092c5ec1e932393df652df18c74f7ed85"
+        "path": "framework/core/src/libkungfu/include/kungfu/runtime/storage/service_layout.h",
+        "root": "sha256:2b56f80027ee3e407544f657f177eb10853a6e992ab30a54e2ce9eb06d1a7e42"
       },
       {
         "path": "framework/core/architecture/layered-api-encoding-boundary.contract.json",


### PR DESCRIPTION
## Summary

Preserve immutable Fact-surface evidence when a current profile intentionally retires an unused writer authority. Safe strict narrowing is accepted only when no removed authority appears anywhere in the immutable observation history; authority expansion, replacement, schema/world drift, or removal of an authority that admitted a Fact remains fail-closed.

The generated portable authority projections were already deterministically stale on the protected baseline, so they are refreshed in a separate commit without changing the repair semantics.

## Related issue

None.

## Changes

- Collect admitted Fact source authorities from the full immutable observation history.
- Allow only strict authority narrowing when every removed source is unused.
- Return `fact-surface-authority-migration-required` when a removed source has authored historical evidence.
- Add positive and negative profile-composition coverage.
- Refresh the deterministic generated authority, compatibility, and registry projections.

## Verification

- `./shifu fix`
- Profile SDK focused suite: 76 passed (2 unrelated immutable cleanup warnings)
- `./shifu test:kfx-profile-suite`
- `./shifu check`
- `./shifu check:source` with the frozen lock and a Tsinghua PyPI transport mirror: 1,155 source fixtures passed, 11 platform skips, 0 failures; Agent Work 40 passed; runtime upgrade 134 passed; desktop update 73 passed; mypy passed across 253 source files; zero-write roots matched
- Real Atlas parent realm replay completed with the exact Assignment/work-definition roots and no journal mutation

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This compatibility repair preserves immutable Fact evidence and permits only retirement of writer authorities that never authored a Fact; it does not add, replace, or reinterpret architecture authority"
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The generated spec projections are deterministic release/provenance inputs. Repository generation, full source checks, and zero-write root comparison verify that the refresh matches the protected source contract.

## Checklist

- [x] Commits are signed off (DCO)
- [ ] Documentation updated if behavior changed

No user-facing documentation changes are required; the externally visible contract remains fail-closed and the repair is covered by executable compatibility tests.
