### PR TITLE
fix(check): retain bounded passport ancestry

### DIFF
--- a/scripts/check-incubation-passport.mjs
+++ b/scripts/check-incubation-passport.mjs
@@ -216,7 +216,10 @@ function git(root, args) {
   return spawnSync('git', args, { cwd: root, encoding: 'utf8' });
 }
 
-const MERGE_GROUP_PROTECTED_HISTORY_DEPTH = 64;
+// Admission receipts intentionally outlive short delivery bursts. Keep the
+// shallow merge-group checkout bounded, but retain enough protected history
+// for a receipt to survive more than 64 first-parent deliveries.
+const MERGE_GROUP_PROTECTED_HISTORY_DEPTH = 128;
 
 export function protectedSourceRetained({
   root = ROOT,

--- a/scripts/check-incubation-passport.test.mjs
+++ b/scripts/check-incubation-passport.test.mjs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -274,6 +276,56 @@ test('protected source recovers ancestry from the exact merge-group base', () =>
     [sourceSha, baseSha],
   ]);
   assert.deepEqual(hydrated, [baseSha]);
+});
+
+test('protected source hydrates receipts beyond 64 protected deliveries', () => {
+  const temporaryRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-passport-history-'),
+  );
+  const source = path.join(temporaryRoot, 'source');
+  const checkout = path.join(temporaryRoot, 'checkout');
+  const git = (cwd, ...args) =>
+    execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+
+  try {
+    fs.mkdirSync(source);
+    git(source, 'init', '--initial-branch=main');
+    git(source, 'config', 'user.name', 'Kungfu Test');
+    git(source, 'config', 'user.email', 'test@kungfu.invalid');
+    fs.writeFileSync(path.join(source, 'history.txt'), '0\n');
+    git(source, 'add', 'history.txt');
+    git(source, 'commit', '-m', 'source receipt');
+    const sourceSha = git(source, 'rev-parse', 'HEAD');
+    for (let index = 1; index <= 67; index += 1) {
+      fs.appendFileSync(path.join(source, 'history.txt'), `${index}\n`);
+      git(source, 'add', 'history.txt');
+      git(source, 'commit', '-m', `delivery ${index}`);
+    }
+    const baseSha = git(source, 'rev-parse', 'HEAD');
+    execFileSync(
+      'git',
+      ['clone', '--depth=1', '--no-local', source, checkout],
+      { encoding: 'utf8' },
+    );
+
+    assert.equal(
+      protectedSourceRetained({
+        root: checkout,
+        sourceSha,
+        env: {
+          GITHUB_EVENT_NAME: 'merge_group',
+          GITHUB_EVENT_PATH: '/event.json',
+        },
+        readFile: () =>
+          JSON.stringify({
+            merge_group: { base_sha: baseSha, head_sha: baseSha },
+          }),
+      }),
+      true,
+    );
+  } finally {
+    fs.rmSync(temporaryRoot, { recursive: true, force: true });
+  }
 });
 
 test('protected source rejects mismatched or unretained merge-group evidence', () => {


### PR DESCRIPTION
## Summary

Prevent false merge-group rejection when a valid protected-source admission receipt is more than 64 first-parent deliveries behind the current protected base.

## Related issue

Unblocks the normal protected merge queue for independently qualified PRs, including storage responsibility convergence, without bypassing any Gate.

## Changes

- Increase the bounded merge-group protected-history hydration window from 64 to 128 commits.
- Add a real shallow-clone regression proving a receipt remains retained after 67 protected deliveries.
- Keep the fail-closed exact-base and ancestry checks unchanged.

## Verification

- node --test scripts/check-incubation-passport.test.mjs (12 passed)
- ./shifu check:staged (passed)
- ./shifu check:source at e18090084db367d2d9913ff98a04f5de6f08908d (passed; 1167 total, 1156 passed, 11 skipped, 0 failed)
- ./shifu project-cut:queue-admission -- --base be0959d5d5d340d5178fcb52be22b94050e55a18 --head e18090084db367d2d9913ff98a04f5de6f08908d (qualified; compositionChanged=false)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded checker correction preserves existing admission authority and product/runtime behavior."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Boundary: source-acceptance receipt ancestry readback only. No authority, receipt format, workflow permissions, release bytes, or product surface changed.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable; regression is executable and behavior remains the intended retained-ancestry contract)