### PR TITLE
refactor(tui): simplify project input orchestration

### DIFF
--- a/framework/tui/src/projects-view.test.ts
+++ b/framework/tui/src/projects-view.test.ts
@@ -4,6 +4,45 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+import { resolveProjectsInput } from './projects-view/index.js';
+
+test('Projects input resolves browse aliases and gives modals precedence', () => {
+  const cases = [
+    ['q', 'browse', 'quit'],
+    ['\u0003', 'browse', 'quit'],
+    ['j', 'browse', 'move-down'],
+    ['\u001b[B', 'browse', 'move-down'],
+    ['k', 'browse', 'move-up'],
+    ['\u001b[A', 'browse', 'move-up'],
+    ['\r', 'browse', 'open-project'],
+    ['y', 'confirmation', 'confirm'],
+    ['n', 'confirmation', 'cancel'],
+    ['\u001b', 'confirmation', 'cancel'],
+    ['\r', 'confirmation', 'confirm'],
+    ['project path', 'import-path', 'append:project path'],
+    ['\u007f', 'import-path', 'delete'],
+    ['\b', 'import-path', 'delete'],
+    ['\r', 'import-path', 'confirm'],
+    ['\u001b', 'import-path', 'cancel'],
+  ] as const;
+  for (const [value, mode, expected] of cases)
+    assert.equal(resolveProjectsInput(value, mode), expected);
+});
+
+test('Projects actions retain cancellation copy and refresh settlement order', () => {
+  const source = readFileSync(
+    new URL('./projects-view/index.tsx', import.meta.url),
+    'utf8',
+  );
+  assert.match(source, /Project removal cancelled; no locator changed\./);
+  assert.match(source, /Project creation cancelled; no files were written\./);
+  assert.match(source, /Open Project cancelled; nothing changed\./);
+  assert.match(
+    source,
+    /async \(\) => \{[\s\S]*?setRemovePlan\(undefined\);[\s\S]*?await refresh\(\);[\s\S]*?\},/,
+  );
+});
+
 test('Projects exposes only New, Open, and safe removal on the first layer', () => {
   const source = readFileSync(
     new URL('./projects-view/index.tsx', import.meta.url),

--- a/framework/tui/src/projects-view/index.tsx
+++ b/framework/tui/src/projects-view/index.tsx
@@ -126,6 +126,48 @@ export type ProjectsActionRequest = {
   action: ProjectsQuickAction;
 };
 
+type ProjectsInputMode = 'browse' | 'confirmation' | 'import-path';
+
+const BROWSE_PROJECTS_INPUT = new Map<string, string>([
+  ['q', 'quit'],
+  ['\u0003', 'quit'],
+  ['a', 'open-lab'],
+  ['r', 'refresh'],
+  ['j', 'move-down'],
+  ['\u001b[B', 'move-down'],
+  ['k', 'move-up'],
+  ['\u001b[A', 'move-up'],
+  ['n', 'plan-create'],
+  ['o', 'begin-import'],
+  ['d', 'plan-remove'],
+  ['\r', 'open-project'],
+]);
+const CONFIRMATION_PROJECTS_INPUT = new Map<string, string>([
+  ['y', 'confirm'],
+  ['\r', 'confirm'],
+  ['n', 'cancel'],
+  ['\u001b', 'cancel'],
+]);
+const IMPORT_PATH_PROJECTS_INPUT = new Map<string, string>([
+  ['\u001b', 'cancel'],
+  ['\r', 'confirm'],
+  ['\u007f', 'delete'],
+  ['\b', 'delete'],
+]);
+const PROJECTS_INPUT_BY_MODE = {
+  browse: BROWSE_PROJECTS_INPUT,
+  confirmation: CONFIRMATION_PROJECTS_INPUT,
+  'import-path': IMPORT_PATH_PROJECTS_INPUT,
+} satisfies Record<ProjectsInputMode, Map<string, string>>;
+
+export function resolveProjectsInput(value: string, mode: ProjectsInputMode) {
+  const action = PROJECTS_INPUT_BY_MODE[mode].get(value);
+  if (action) return action;
+  if (mode === 'import-path' && /^[\x20-\x7e]+$/u.test(value))
+    return `append:${value}`;
+  return 'none';
+}
+
 export function ProjectsHost({
   projects,
   dimensions,
@@ -171,12 +213,28 @@ export function ProjectsHost({
     onSearchDocumentsRef.current = onSearchDocuments;
   }, [onSearchDocuments]);
 
+  const runProjectAction = React.useCallback(
+    <Result,>(
+      message: string,
+      operation: () => Promise<Result>,
+      onSuccess: (result: Result) => void | Promise<void>,
+    ) => {
+      setBusy(true);
+      setMessage(message);
+      return operation()
+        .then(onSuccess)
+        .catch((error) =>
+          setMessage(error instanceof Error ? error.message : String(error)),
+        )
+        .finally(() => setBusy(false));
+    },
+    [],
+  );
   const refresh = React.useCallback(() => {
-    setBusy(true);
-    setMessage('Refreshing machine-local project locators…');
-    return projects
-      .list()
-      .then((result) => {
+    return runProjectAction(
+      'Refreshing machine-local project locators…',
+      () => projects.list(),
+      (result) => {
         setCatalog(result);
         onSearchDocumentsRef.current(result);
         setSelected((current) =>
@@ -189,12 +247,9 @@ export function ProjectsHost({
               } available`
             : 'No Projects yet · create one or open an existing directory',
         );
-      })
-      .catch((error) =>
-        setMessage(error instanceof Error ? error.message : String(error)),
-      )
-      .finally(() => setBusy(false));
-  }, [projects]);
+      },
+    );
+  }, [projects, runProjectAction]);
 
   React.useEffect(() => dimensions.subscribe(setSize), [dimensions]);
   React.useEffect(() => {
@@ -210,16 +265,12 @@ export function ProjectsHost({
     return () => onInputModeChange(false);
   }, [inputModeActive, onInputModeChange]);
   const planProject = React.useCallback(() => {
-    setBusy(true);
-    setMessage('Planning a new Project under ~/Documents/Kungfu…');
-    void projects
-      .planCreate(undefined, 'kungfu.blank-project')
-      .then((plan) => setCreatePlan(plan as unknown as CreatePlan))
-      .catch((error) =>
-        setMessage(error instanceof Error ? error.message : String(error)),
-      )
-      .finally(() => setBusy(false));
-  }, [projects]);
+    void runProjectAction(
+      'Planning a new Project under ~/Documents/Kungfu…',
+      () => projects.planCreate(undefined, 'kungfu.blank-project'),
+      (plan) => setCreatePlan(plan as unknown as CreatePlan),
+    );
+  }, [projects, runProjectAction]);
   const beginImport = React.useCallback(() => {
     setImportPath('');
     setMessage('Type an existing project directory and press Enter.');
@@ -230,16 +281,12 @@ export function ProjectsHost({
       setMessage('Select a Project before removing it from Kungfu.');
       return;
     }
-    setBusy(true);
-    setMessage(`Planning removal of ${project.name} from Kungfu…`);
-    void projects
-      .planRemove(project.id)
-      .then(setRemovePlan)
-      .catch((error) =>
-        setMessage(error instanceof Error ? error.message : String(error)),
-      )
-      .finally(() => setBusy(false));
-  }, [catalog, projects, selected]);
+    void runProjectAction(
+      `Planning removal of ${project.name} from Kungfu…`,
+      () => projects.planRemove(project.id),
+      setRemovePlan,
+    );
+  }, [catalog, projects, runProjectAction, selected]);
   React.useEffect(() => {
     if (!actionRequest) return;
     if (actionRequest.action === 'project-new') {
@@ -258,16 +305,11 @@ export function ProjectsHost({
     planSelectedRemoval,
   ]);
   React.useEffect(() => {
-    const onData = (chunk: Buffer | string) => {
+    const handleProjectsInput = (chunk: Buffer | string) => {
       const value = String(chunk);
       const mouseEvents = decodeTerminalMouseInput(value);
       if (mouseEvents.length > 0) {
-        if (
-          importPath === undefined &&
-          !importPlan &&
-          !removePlan &&
-          !createPlan
-        ) {
+        if (!inputModeActive) {
           for (const event of mouseEvents) {
             if (
               event.kind !== 'wheel' ||
@@ -292,159 +334,121 @@ export function ProjectsHost({
         return;
       }
       if (isInputCaptured()) return;
-      if (importPath !== undefined) {
-        if (value === '\u001b') {
-          setImportPath(undefined);
-          setMessage('Open Project cancelled; nothing changed.');
-        } else if (value === '\r') {
-          if (!importPath.trim()) return;
-          setBusy(true);
-          setMessage('Inspecting the existing project without changing it…');
-          void projects
-            .planImport(importPath.trim())
-            .then((plan) => {
-              setImportPath(undefined);
-              setImportPlan(plan);
-            })
-            .catch((error) =>
-              setMessage(
-                error instanceof Error ? error.message : String(error),
-              ),
-            )
-            .finally(() => setBusy(false));
-        } else if (value === '\u007f' || value === '\b') {
-          setImportPath((current) => current?.slice(0, -1) ?? '');
-        } else if (/^[\x20-\x7e]+$/u.test(value)) {
-          setImportPath((current) => `${current ?? ''}${value}`);
-        }
+      const mode: ProjectsInputMode =
+        importPath !== undefined
+          ? 'import-path'
+          : importPlan || removePlan || createPlan
+            ? 'confirmation'
+            : 'browse';
+      const intent = resolveProjectsInput(value, mode);
+      if (intent === 'none') return;
+      if (intent === 'cancel') {
+        if (importPath !== undefined) setImportPath(undefined);
+        else if (importPlan) setImportPlan(undefined);
+        else if (removePlan) setRemovePlan(undefined);
+        else setCreatePlan(undefined);
+        setMessage(
+          importPath !== undefined || importPlan
+            ? 'Open Project cancelled; nothing changed.'
+            : removePlan
+              ? 'Project removal cancelled; no locator changed.'
+              : createPlan
+                ? 'Project creation cancelled; no files were written.'
+                : 'Open Project cancelled; nothing changed.',
+        );
         return;
       }
-      if (importPlan) {
-        if (value === 'y' || value === '\r') {
-          setBusy(true);
-          setMessage('Retaining the machine-local project locator…');
-          void projects
-            .importProject(importPlan.project.path, importPlan.planRoot)
-            .then((receipt) => {
+      if (intent === 'delete')
+        return setImportPath((current) => current?.slice(0, -1) ?? '');
+      if (intent.startsWith('append:'))
+        return setImportPath((current) => `${current ?? ''}${intent.slice(7)}`);
+      if (intent === 'confirm') {
+        const path = importPath?.trim();
+        if (importPath !== undefined) {
+          if (!path) return;
+          return runProjectAction(
+            'Inspecting the existing project without changing it…',
+            () => projects.planImport(path),
+            (plan) => {
+              setImportPath(undefined);
+              setImportPlan(plan);
+            },
+          );
+        }
+        if (importPlan)
+          return runProjectAction(
+            'Retaining the machine-local project locator…',
+            () =>
+              projects.importProject(
+                importPlan.project.path,
+                importPlan.planRoot,
+              ),
+            (receipt) => {
               setImportPlan(undefined);
               onOpenProject(
                 (receipt as unknown as ProjectSelectionReceipt).workspace,
               );
-            })
-            .catch((error) =>
-              setMessage(
-                error instanceof Error ? error.message : String(error),
-              ),
-            )
-            .finally(() => setBusy(false));
-        } else if (value === 'n' || value === '\u001b') {
-          setImportPlan(undefined);
-          setMessage('Open Project cancelled; nothing changed.');
-        }
-        return;
-      }
-      if (removePlan) {
-        if (value === 'y' || value === '\r') {
-          setBusy(true);
-          setMessage(`Removing ${removePlan.project.name} from Kungfu…`);
-          void projects
-            .remove(removePlan.project.id, removePlan.planRoot)
-            .then(() => {
+            },
+          );
+        if (removePlan)
+          return runProjectAction(
+            `Removing ${removePlan.project.name} from Kungfu…`,
+            () => projects.remove(removePlan.project.id, removePlan.planRoot),
+            async () => {
               setRemovePlan(undefined);
               setMessage(
                 `${removePlan.project.name} was removed from Kungfu. Its files remain untouched.`,
               );
-              return refresh();
-            })
-            .catch((error) =>
-              setMessage(
-                error instanceof Error ? error.message : String(error),
-              ),
-            )
-            .finally(() => setBusy(false));
-        } else if (value === 'n' || value === '\u001b') {
-          setRemovePlan(undefined);
-          setMessage('Project removal cancelled; no locator changed.');
-        }
-        return;
-      }
-      if (createPlan) {
-        if (value === 'y' || value === '\r') {
-          setBusy(true);
-          setMessage('Creating the Project and its local Kungfu instructions…');
-          void projects
-            .create(
+              await refresh();
+            },
+          );
+        if (!createPlan) return;
+        return runProjectAction(
+          'Creating the Project and its local Kungfu instructions…',
+          () =>
+            projects.create(
               createPlan.destination,
               createPlan.planRoot,
               createPlan.templateId,
-            )
-            .then((receipt) => {
-              const selectedReceipt = receipt as ProjectSelectionReceipt;
-              setCreatePlan(undefined);
-              onOpenProject(selectedReceipt.workspace);
-            })
-            .catch((error) =>
-              setMessage(
-                error instanceof Error ? error.message : String(error),
-              ),
-            )
-            .finally(() => setBusy(false));
-        } else if (value === 'n' || value === '\u001b') {
-          setCreatePlan(undefined);
-          setMessage('Project creation cancelled; no files were written.');
-        }
-        return;
-      }
-      if (value === 'q' || value === '\u0003') return exit();
-      if (value === 'a') return onOpenLab();
-      if (value === 'r') return refresh();
-      if (value === 'j' || value === '\u001b[B') {
-        setSelected((current) =>
-          boundedIndex(current, 1, catalog?.projects.length ?? 0),
+            ),
+          (receipt) => {
+            setCreatePlan(undefined);
+            onOpenProject((receipt as ProjectSelectionReceipt).workspace);
+          },
         );
-        return;
       }
-      if (value === 'k' || value === '\u001b[A') {
-        setSelected((current) =>
-          boundedIndex(current, -1, catalog?.projects.length ?? 0),
+      if (intent === 'quit') return exit();
+      if (intent === 'open-lab') return onOpenLab();
+      if (intent === 'refresh') return refresh();
+      if (intent === 'move-down' || intent === 'move-up')
+        return setSelected((current) =>
+          boundedIndex(
+            current,
+            intent === 'move-down' ? 1 : -1,
+            catalog?.projects.length ?? 0,
+          ),
         );
-        return;
-      }
-      if (value === 'n') {
-        planProject();
-        return;
-      }
-      if (value === 'o') {
-        beginImport();
-        return;
-      }
-      if (value === 'd') {
-        planSelectedRemoval();
-        return;
-      }
-      if (value !== '\r') return;
+      if (intent === 'plan-create') return planProject();
+      if (intent === 'begin-import') return beginImport();
+      if (intent === 'plan-remove') return planSelectedRemoval();
       const project = catalog?.projects[selected];
       if (!project?.available) {
         setMessage('This project is unavailable on this machine.');
         return;
       }
-      setBusy(true);
-      setMessage(`Opening ${project.name}…`);
-      void projects
-        .select(project.path)
-        .then((receipt) => {
+      runProjectAction(
+        `Opening ${project.name}…`,
+        () => projects.select(project.path),
+        (receipt) => {
           const workspace = (receipt as ProjectSelectionReceipt).workspace;
           setMessage(`${project.name} is open. Loading its Work…`);
           onOpenProject(workspace);
-        })
-        .catch((error) =>
-          setMessage(error instanceof Error ? error.message : String(error)),
-        )
-        .finally(() => setBusy(false));
+        },
+      );
     };
-    process.stdin.on('data', onData);
+    process.stdin.on('data', handleProjectsInput);
     return () => {
-      process.stdin.off('data', onData);
+      process.stdin.off('data', handleProjectsInput);
     };
   }, [
     catalog,
@@ -453,6 +457,7 @@ export function ProjectsHost({
     exit,
     importPath,
     importPlan,
+    inputModeActive,
     isInputCaptured,
     onOpenLab,
     onOpenProject,
@@ -462,6 +467,7 @@ export function ProjectsHost({
     projects,
     refresh,
     removePlan,
+    runProjectAction,
     selected,
     size,
   ]);


### PR DESCRIPTION
## Summary

- replace the Projects view monolithic input branch tree with explicit mode-specific input resolution
- centralize project action busy/message/refresh sequencing without changing IPC calls or persisted state
- add focused regression coverage for modal precedence, cancel/confirm copy, and refresh settlement order

## Clean-linear successor

This pull request supersedes #3351 after Project Cut queue admission rejected that published branch's accumulated protected-base merge topology as a deterministic `merge-conflict`. It starts directly from protected `ab87882078ed839aa2915e10315ec56769e5404b` and contains one implementation commit.

The implementation patch and both changed file blobs are byte-identical to the independently reviewed #3351 head. The old pull request and remote branch remain audit evidence. No candidate, approval, source proof, Warrant, or queue receipt is reused; this successor must qualify on its own exact head.

## Behavior invariants

- terminal input aliases and modal ownership are unchanged
- cancellation and confirmation messages are unchanged
- project IPC calls, state persistence, and refresh Promise ordering are unchanged
- JSX and terminal rendering output are unchanged
- no watcher, C++ runtime, core, GUI, or dependency files are modified

## Complexity evidence

Repository-native owner `framework/tui`, protected base `ab87882078ed839aa2915e10315ec56769e5404b` to clean-linear head `d54ccac3b533f018db4fabde094fad16223968ea`:

- functions: 60 -> 61
- lines: 1952 -> 1916
- cyclomatic: 602 -> 588
- cognitive: 985 -> 941
- baseRisk: 2837 -> 2738
- changeRisk: 3000 -> 2907

The transition-aware complete AST scan, which supplements repository-native misses without changing the fixed policy baseline, also decreases:

- functions: 379 -> 381
- lines: 15102 -> 15032
- cyclomatic: 3302 -> 3263
- cognitive: 6367 -> 6228
- baseRisk: 17684 -> 17372
- changeRisk: 17856 -> 17777

The former `onData` hotspot (`184 lines / cyclomatic 63 / cognitive 129 / baseRisk 329 / changeRisk 329`) is replaced by three cohesive responsibilities with a conservative combined result of `162 / 52 / 87 / 241 / 250`. This is an aggregate and hotspot reduction, not a wrapper-only file move.

## Validation

- targeted Projects view tests: 8/8 pass
- Biome on both changed files: pass
- `./shifu maintainability:complexity --json`: pass
- `./shifu maintainability:function-risk --json`: 0 blocking findings; owner and hotspot risks decrease as reported above
- `./shifu project-cut:queue-admission -- --base ab87882078ed839aa2915e10315ec56769e5404b --head d54ccac3b533f018db4fabde094fad16223968ea`: qualified; one replayed commit; no composition change
- exact-head Atlas work admission: issued and verified; managed pre-commit/commit-msg/pre-push hooks have parity

The earlier #3351 exact implementation tree passed protected Source Acceptance on run 32578156648, but this successor does not reuse that proof and requires fresh protected CI for `d54ccac3b533f018db4fabde094fad16223968ea`.

The local whole-source retry on the earlier byte-identical implementation was boundedly interrupted after 15 minutes during cold Python toolchain preparation; it is not reported as green. The available macOS `./shifu build:cli` check also reproduced the same pre-existing TS2739 at `framework/tui/src/main.tsx:223` on both the change and its protected baseline. Protected CI remains authoritative.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This change only converges TUI input and project action orchestration complexity; it does not alter an architecture contract."
}
-->

Signed-off-by: Keren Dong <keren.dong+cx@kungfu.link>
