### PR TITLE
fix(product): converge single-go runtime routing

### DIFF
--- a/framework/core/src/python/kungfu/profile_sdk_kfd3.py
+++ b/framework/core/src/python/kungfu/profile_sdk_kfd3.py
@@ -810,13 +810,32 @@ def contract_operations(
             existingVersions=sorted(str(row.get("version")) for row in other_world),
             requestedVersion=world["version"],
         )
-    if same_world and set(same_world[0].get("fact_surface_ids") or []) != set(
-        world["factSurfaceIds"]
-    ):
-        fail(
-            "contract-world-incompatible",
-            "existing contract world has another fact-surface register",
-        )
+    if same_world:
+        existing_surface_ids = set(same_world[0].get("fact_surface_ids") or [])
+        declared_surface_ids = set(world["factSurfaceIds"])
+        if existing_surface_ids != declared_surface_ids:
+            # Contract-world declarations are immutable evidence. A later
+            # Profile may retire a surface that never admitted a fact, but it
+            # must not expand or replace the durable register in place.
+            if not declared_surface_ids < existing_surface_ids:
+                fail(
+                    "contract-world-incompatible",
+                    "existing contract world has another fact-surface register",
+                )
+            retired_with_facts = sorted(
+                surface_id
+                for surface_id in existing_surface_ids - declared_surface_ids
+                if any(
+                    key[0] == surface_id and key[2] == world["id"] and sources
+                    for key, sources in admitted_sources.items()
+                )
+            )
+            if retired_with_facts:
+                fail(
+                    "contract-world-surface-migration-required",
+                    "removed fact surfaces retain admitted facts and require an explicit migration",
+                    admittedFactSurfaces=retired_with_facts,
+                )
     operations = []
     if not same_world:
         operations.append(

--- a/framework/core/tests/python/test_profile_composition.py
+++ b/framework/core/tests/python/test_profile_composition.py
@@ -320,6 +320,57 @@ def _set_work_item_authorities(source, authorities):
     profile_path.write_text(json.dumps(profile, indent=2, sort_keys=True) + "\n")
 
 
+def _set_retired_fact_surface(source, *, present):
+    profile_path = source / "profile.json"
+    profile = json.loads(profile_path.read_text())
+    facts_path = source / "contracts" / "facts.json"
+    facts = json.loads(facts_path.read_text())
+    world_path = source / "contracts" / "world.json"
+    world = json.loads(world_path.read_text())
+    surface_id = "retired-item"
+    facts["surfaces"] = [row for row in facts["surfaces"] if row["id"] != surface_id]
+    world["contractWorld"]["factSurfaceIds"] = [
+        item for item in world["contractWorld"]["factSurfaceIds"] if item != surface_id
+    ]
+    world["factSurfaces"] = [
+        row for row in world["factSurfaces"] if row["id"] != surface_id
+    ]
+    if present:
+        facts["surfaces"].append(
+            {"id": surface_id, "schema": "example.retired-item/v1"}
+        )
+        world["contractWorld"]["factSurfaceIds"].append(surface_id)
+        world["factSurfaces"].append(
+            {
+                "id": surface_id,
+                "version": "1",
+                "contractWorldId": "example.week-day",
+                "sourceAuthorities": ["workspace-owner"],
+                "schema": {
+                    "type": "object",
+                    "properties": {"status": {"type": "string"}},
+                    "required": ["status"],
+                    "additionalProperties": False,
+                },
+            }
+        )
+    _write_artifact(
+        source,
+        profile,
+        "contracts/facts.json",
+        facts,
+        profile["kfd1"]["factSurfaces"][0],
+    )
+    _write_artifact(
+        source,
+        profile,
+        "contracts/world.json",
+        world,
+        profile["kfd1"]["contractWorld"],
+    )
+    profile_path.write_text(json.dumps(profile, indent=2, sort_keys=True) + "\n")
+
+
 def test_catalog_joins_exact_profile_artifacts_without_new_authority(tmp_path):
     source = _source(tmp_path)
     result = profile_composition.catalog(source, tmp_path / "runtime")
@@ -977,3 +1028,80 @@ def test_contract_rejects_authority_narrowing_with_retired_source_facts(tmp_path
         "fact-surface-authority-migration-required"
     )
     assert raised.value.diagnosis["admittedSourceAuthorities"] == ["retired-owner"]
+
+
+def test_contract_accepts_surface_narrowing_without_retired_surface_facts(tmp_path):
+    source = _dynamic_source(tmp_path)
+    runtime = tmp_path / "runtime"
+    _set_retired_fact_surface(source, present=True)
+    _activate(source, runtime)
+    contract = profile_composition.contract_materialization_plan(source, runtime)
+    profile_composition.authorized_contract_materialize(
+        runtime,
+        contract,
+        profile_sdk.answer_decision(contract["decisionCard"], "approve", "test-owner"),
+    )
+
+    _set_retired_fact_surface(source, present=False)
+    _upgrade(source, runtime)
+
+    assert (
+        profile_composition.contract_materialization_plan(source, runtime)["operations"]
+        == []
+    )
+
+
+def test_contract_rejects_surface_register_expansion(tmp_path):
+    source = _dynamic_source(tmp_path)
+    runtime = tmp_path / "runtime"
+    _activate(source, runtime)
+    contract = profile_composition.contract_materialization_plan(source, runtime)
+    profile_composition.authorized_contract_materialize(
+        runtime,
+        contract,
+        profile_sdk.answer_decision(contract["decisionCard"], "approve", "test-owner"),
+    )
+
+    _set_retired_fact_surface(source, present=True)
+    _upgrade(source, runtime)
+
+    with pytest.raises(profile_sdk.ProfileSdkError) as raised:
+        profile_composition.contract_materialization_plan(source, runtime)
+    assert raised.value.diagnosis["code"] == "contract-world-incompatible"
+
+
+def test_contract_rejects_surface_narrowing_with_retired_surface_facts(tmp_path):
+    source = _dynamic_source(tmp_path)
+    runtime = tmp_path / "runtime"
+    _set_retired_fact_surface(source, present=True)
+    _activate(source, runtime)
+    contract = profile_composition.contract_materialization_plan(source, runtime)
+    profile_composition.authorized_contract_materialize(
+        runtime,
+        contract,
+        profile_sdk.answer_decision(contract["decisionCard"], "approve", "test-owner"),
+    )
+    written = storage_service.fact_material_put(
+        runtime,
+        {
+            "type_id": "retired-item",
+            "type_version": "1",
+            "source_id": "workspace-owner",
+            "subject_key": "retired-1",
+            "payload": {"status": "retained"},
+            "observation_id": "retired-1-retained",
+            "action": "assert",
+            "valid_until": 0,
+        },
+    )
+    assert written["receipt"]["admission"]["outcome"] == "admitted"
+
+    _set_retired_fact_surface(source, present=False)
+    _upgrade(source, runtime)
+
+    with pytest.raises(profile_sdk.ProfileSdkError) as raised:
+        profile_composition.contract_materialization_plan(source, runtime)
+    assert raised.value.diagnosis["code"] == (
+        "contract-world-surface-migration-required"
+    )
+    assert raised.value.diagnosis["admittedFactSurfaces"] == ["retired-item"]

--- a/framework/gui/resources/cli/kungfu
+++ b/framework/gui/resources/cli/kungfu
@@ -27,4 +27,6 @@ export KUNGFU_DIR="$runtime"
 export KUNGFU_INSTALL_SOURCE=desktop-companion
 export KUNGFU_UPGRADE_MANIFEST="$here/../upgrade/kungfu-release-manifest.json"
 export KF_BUNDLED_EXTENSION_ROOT="$here/../extensions"
+export KUNGFU_AGENT_SESSION_EXECUTABLE="$runtime/kungfu"
+export KUNGFU_NATIVE_AGENT_SESSION_ENTRY="$here/../tui/native-agent-session.mjs"
 exec "$runtime/kungfu" "$@"

--- a/product/scripts/cli-launcher.test.mjs
+++ b/product/scripts/cli-launcher.test.mjs
@@ -61,6 +61,14 @@ test('desktop companion delegates bytecode cache ownership to the native trunk',
     launcher,
     /export KF_BUNDLED_EXTENSION_ROOT="\$here\/\.\.\/extensions"/u,
   );
+  assert.match(
+    launcher,
+    /export KUNGFU_AGENT_SESSION_EXECUTABLE="\$runtime\/kungfu"/u,
+  );
+  assert.match(
+    launcher,
+    /export KUNGFU_NATIVE_AGENT_SESSION_ENTRY="\$here\/\.\.\/tui\/native-agent-session\.mjs"/u,
+  );
   assert.ok(
     launcher.indexOf('export KUNGFU_UPGRADE_MANIFEST=') <
       launcher.indexOf('exec "$runtime/kungfu" "$@"'),


### PR DESCRIPTION
## Summary

Deliver fix(product): converge single-go runtime routing from fix/single-go-runtime-convergence-r1 into dev/v4/v4.0 through the kungfu-systems dual-account PR flow.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This maintenance delivery does not alter an architecture decision."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)