### PR TITLE
fix(core): serialize watcher usability probes

### DIFF
--- a/framework/core/src/libkungfu/src/runtime/io/io.cpp
+++ b/framework/core/src/libkungfu/src/runtime/io/io.cpp
@@ -21,7 +21,8 @@ using namespace kungfu::runtime::nanomsg;
 namespace kungfu::runtime {
 namespace {
 constexpr int USABILITY_PROBE_ATTEMPTS = 5;
-}
+std::mutex usability_probe_call_mutex;
+} // namespace
 
 class ipc_url_factory : public url_factory {
 public:
@@ -258,6 +259,7 @@ io_device_peer::io_device_peer(data::location_ptr home, bool low_latency)
     : io_device(std::move(home), low_latency, io_mapping_policy::peer()) {}
 
 bool io_device_peer::is_usable() {
+  std::lock_guard<std::mutex> call_guard(usability_probe_call_mutex);
   std::unique_lock<std::mutex> guard(usability_probe_mutex_);
   if (usability_probe_cancelled_.load()) {
     return false;
@@ -301,6 +303,7 @@ void io_device_peer::cancel_usability_probe() {
 }
 
 bool io_device_peer::setup() {
+  std::lock_guard<std::mutex> call_guard(usability_probe_call_mutex);
   {
     std::lock_guard<std::mutex> guard(usability_probe_mutex_);
     usability_probe_observer_.reset();

--- a/framework/core/tests/watcher-runtime-boundary.test.js
+++ b/framework/core/tests/watcher-runtime-boundary.test.js
@@ -187,10 +187,28 @@ test('peer usability persists one bounded handshake across slow-joiner retries',
     source.indexOf('bool io_device_peer::is_usable()'),
     source.indexOf('bool io_device_peer::setup()'),
   );
+  const peerCancellationSource = source.slice(
+    source.indexOf('void io_device_peer::cancel_usability_probe()'),
+    source.indexOf('bool io_device_peer::setup()'),
+  );
+  const peerSetupSource = source.slice(
+    source.indexOf('bool io_device_peer::setup()'),
+  );
   assert.match(source, /constexpr int USABILITY_PROBE_ATTEMPTS = 5;/);
   assert.match(
     peerUsabilitySource,
-    /std::unique_lock<std::mutex> guard\(usability_probe_mutex_\)/,
+    /std::lock_guard<std::mutex> call_guard\(usability_probe_call_mutex\);\s*std::unique_lock<std::mutex> guard\(usability_probe_mutex_\)/,
+    'one call-level lock must outlive waits that release the probe state lock',
+  );
+  assert.match(
+    peerSetupSource,
+    /std::lock_guard<std::mutex> call_guard\(usability_probe_call_mutex\);\s*\{\s*std::lock_guard<std::mutex> guard\(usability_probe_mutex_\)/,
+    'setup must follow the same call-lock then state-lock order',
+  );
+  assert.doesNotMatch(
+    peerCancellationSource,
+    /usability_probe_call_mutex/,
+    'cancellation must remain able to wake a probe while its call lock is held',
   );
   assert.match(
     peerUsabilitySource,
@@ -223,6 +241,7 @@ test('peer usability persists one bounded handshake across slow-joiner retries',
     /usability_probe_publisher_->is_usable\(\) and usability_probe_observer_->is_usable\(\)/,
   );
   assert.match(header, /std::mutex usability_probe_mutex_;/);
+  assert.match(source, /std::mutex usability_probe_call_mutex;/);
   assert.match(
     header,
     /std::atomic<bool> usability_probe_cancelled_\{false\};/,


### PR DESCRIPTION
## Summary

- serialize watcher usability probes across setup and readiness checks
- keep cancellation lock-free so a sleeping probe remains interruptible
- add a source boundary contract for probe serialization and lock ordering

## Validation

- watcher runtime boundary: 10/10
- native peer transport: repeated clean runs
- full check:source

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This runtime safety repair does not alter an architecture decision."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)