### PR TITLE
refactor(gui): converge shell orchestration complexity

### DIFF
--- a/framework/gui/src/agent-work-lab.test.ts
+++ b/framework/gui/src/agent-work-lab.test.ts
@@ -359,7 +359,7 @@ test('the GUI shell uses the shared startup surface policy', () => {
   );
   assert.match(
     source,
-    /!initialOnboardingOpen && initialProjectsOpen && !initialFocusedProjectPath/,
+    /initialShellSurface\(\{[\s\S]*onboardingOpen: initialOnboardingOpen,[\s\S]*projectsOpen: initialProjectsOpen,[\s\S]*focusedProjectPath: initialFocusedProjectPath/,
   );
   assert.match(source, /projectPath: initialFocusedProjectPath/);
   assert.match(

--- a/framework/gui/src/navigation.ts
+++ b/framework/gui/src/navigation.ts
@@ -7,6 +7,141 @@ import type {
   ProfileManifest,
   ShellState,
 } from '@kungfu-tech/kfx';
+import type { ShellNavigateRequest } from './sandbox/channels';
+
+export type ShellSurface =
+  | 'onboarding'
+  | 'projects'
+  | 'agent-work-lab'
+  | 'core-work'
+  | 'kfx';
+
+export type ShellSurfaceFlags = {
+  onboardingOpen: boolean;
+  projectsOpen: boolean;
+  labOpen: boolean;
+  coreWorkOpen: boolean;
+};
+
+export type CoreShellSurface = 'projects' | 'agent-work-lab' | 'core-work';
+
+const CORE_SURFACE: Partial<Record<ShellSurface, CoreShellSurface>> = {
+  projects: 'projects',
+  'agent-work-lab': 'agent-work-lab',
+  'core-work': 'core-work',
+};
+
+const PROJECT_SEARCH_SURFACE: Record<ShellSurface, ShellSurface> = {
+  onboarding: 'onboarding',
+  projects: 'projects',
+  'agent-work-lab': 'projects',
+  'core-work': 'projects',
+  kfx: 'projects',
+};
+
+const FIXED_SURFACE_TITLE: Partial<Record<ShellSurface, string>> = {
+  onboarding: 'Getting Started',
+  projects: 'Projects',
+  'agent-work-lab': 'Agent Work Lab',
+};
+
+const FIXED_SURFACE_VIEW_ID: Partial<Record<ShellSurface, string>> = {
+  onboarding: 'onboarding',
+  projects: 'projects',
+  'agent-work-lab': 'agent-work-lab',
+};
+
+export type ShellNavigationActions = Record<
+  ShellNavigateRequest['target'],
+  (request: ShellNavigateRequest) => void
+>;
+
+export function createShellNavigationHandler(actions: ShellNavigationActions) {
+  const routes = Object.assign(
+    Object.create(null) as ShellNavigationActions,
+    actions,
+  );
+  return (_event: unknown, request: unknown) => {
+    const target = Reflect.get(Object(request), 'target');
+    if (typeof target !== 'string') return;
+    const action = routes[target as ShellNavigateRequest['target']];
+    if (typeof action === 'function') action(request as ShellNavigateRequest);
+  };
+}
+
+export function initialShellSurface({
+  onboardingOpen,
+  projectsOpen,
+  focusedProjectPath,
+  agentWorkLabOpen,
+}: {
+  onboardingOpen: boolean;
+  projectsOpen: boolean;
+  focusedProjectPath: string;
+  agentWorkLabOpen: boolean;
+}): ShellSurface {
+  if (onboardingOpen) return 'onboarding';
+  if (projectsOpen) return focusedProjectPath ? 'core-work' : 'projects';
+  if (agentWorkLabOpen) return 'agent-work-lab';
+  return 'core-work';
+}
+
+export function shellSurfaceFlags(surface: ShellSurface): ShellSurfaceFlags {
+  return {
+    onboardingOpen: surface === 'onboarding',
+    projectsOpen: surface === 'projects',
+    labOpen: surface === 'agent-work-lab',
+    coreWorkOpen: surface === 'core-work',
+  };
+}
+
+export function visibleCoreSurface(
+  surface: ShellSurface,
+): CoreShellSurface | undefined {
+  return CORE_SURFACE[surface];
+}
+
+export function projectSearchSurface(surface: ShellSurface): ShellSurface {
+  return PROJECT_SEARCH_SURFACE[surface];
+}
+
+export function shellSurfaceTitle({
+  surface,
+  projectWorkOpen,
+  currentProjectDisplayName,
+  activeKfxTitle,
+}: {
+  surface: ShellSurface;
+  projectWorkOpen: boolean;
+  currentProjectDisplayName: string;
+  activeKfxTitle?: string;
+}): string {
+  const fixedTitle = FIXED_SURFACE_TITLE[surface];
+  if (fixedTitle) return fixedTitle;
+  if (surface === 'kfx') return activeKfxTitle ?? 'Kungfu Episodes';
+  return projectWorkOpen
+    ? `Project · ${currentProjectDisplayName}`
+    : 'All Work';
+}
+
+export function shellSurfaceActiveViewId({
+  surface,
+  projectWorkOpen,
+  activeKfxId,
+  workEntryId,
+}: {
+  surface: ShellSurface;
+  projectWorkOpen: boolean;
+  activeKfxId?: string;
+  workEntryId?: string;
+}): string | undefined {
+  const fixedViewId = FIXED_SURFACE_VIEW_ID[surface];
+  if (fixedViewId) return fixedViewId;
+  if (projectWorkOpen) return 'current-project';
+  if (surface === 'core-work' || activeKfxId === workEntryId)
+    return 'core-work';
+  return activeKfxId;
+}
 
 export type NavigationEntry = {
   id: string;

--- a/framework/gui/src/product-search.test.ts
+++ b/framework/gui/src/product-search.test.ts
@@ -3,6 +3,16 @@
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
+import {
+  createShellNavigationHandler,
+  initialShellSurface,
+  projectSearchSurface,
+  shellSurfaceActiveViewId,
+  shellSurfaceFlags,
+  shellSurfaceTitle,
+  visibleCoreSurface,
+} from './navigation.ts';
+import type { ShellNavigateRequest } from './sandbox/channels.ts';
 
 const source = readFileSync(
   new URL('./renderer/src/main.tsx', import.meta.url),
@@ -30,6 +40,146 @@ const profileManagerSource = readFileSync(
   ),
   'utf8',
 );
+
+test('one shell surface preserves startup priority and exclusive visibility', () => {
+  assert.equal(
+    initialShellSurface({
+      onboardingOpen: true,
+      projectsOpen: true,
+      focusedProjectPath: '/projects/current',
+      agentWorkLabOpen: true,
+    }),
+    'onboarding',
+  );
+  assert.equal(
+    initialShellSurface({
+      onboardingOpen: false,
+      projectsOpen: true,
+      focusedProjectPath: '',
+      agentWorkLabOpen: true,
+    }),
+    'projects',
+  );
+  assert.equal(
+    initialShellSurface({
+      onboardingOpen: false,
+      projectsOpen: true,
+      focusedProjectPath: '/projects/current',
+      agentWorkLabOpen: true,
+    }),
+    'core-work',
+  );
+  assert.equal(
+    initialShellSurface({
+      onboardingOpen: false,
+      projectsOpen: false,
+      focusedProjectPath: '',
+      agentWorkLabOpen: true,
+    }),
+    'agent-work-lab',
+  );
+  assert.equal(
+    initialShellSurface({
+      onboardingOpen: false,
+      projectsOpen: false,
+      focusedProjectPath: '',
+      agentWorkLabOpen: false,
+    }),
+    'core-work',
+  );
+  assert.deepEqual(shellSurfaceFlags('projects'), {
+    onboardingOpen: false,
+    projectsOpen: true,
+    labOpen: false,
+    coreWorkOpen: false,
+  });
+  assert.deepEqual(shellSurfaceFlags('kfx'), {
+    onboardingOpen: false,
+    projectsOpen: false,
+    labOpen: false,
+    coreWorkOpen: false,
+  });
+  assert.equal(visibleCoreSurface('agent-work-lab'), 'agent-work-lab');
+  assert.equal(visibleCoreSurface('core-work'), 'core-work');
+  assert.equal(visibleCoreSurface('onboarding'), undefined);
+  assert.equal(visibleCoreSurface('kfx'), undefined);
+});
+
+test('shell surface projection preserves title and active navigation semantics', () => {
+  assert.equal(
+    shellSurfaceTitle({
+      surface: 'core-work',
+      projectWorkOpen: true,
+      currentProjectDisplayName: 'Alpha',
+    }),
+    'Project · Alpha',
+  );
+  assert.equal(
+    shellSurfaceTitle({
+      surface: 'kfx',
+      projectWorkOpen: true,
+      currentProjectDisplayName: 'Alpha',
+      activeKfxTitle: 'Work',
+    }),
+    'Work',
+  );
+  assert.equal(
+    shellSurfaceActiveViewId({
+      surface: 'kfx',
+      projectWorkOpen: true,
+      activeKfxId: 'work',
+      workEntryId: 'work',
+    }),
+    'current-project',
+  );
+  assert.equal(
+    shellSurfaceActiveViewId({
+      surface: 'kfx',
+      projectWorkOpen: false,
+      activeKfxId: 'work',
+      workEntryId: 'work',
+    }),
+    'core-work',
+  );
+  assert.equal(
+    shellSurfaceActiveViewId({
+      surface: 'kfx',
+      projectWorkOpen: false,
+      activeKfxId: 'settings',
+      workEntryId: 'work',
+    }),
+    'settings',
+  );
+});
+
+test('shell navigation dispatches each request through one typed route', () => {
+  const calls: string[] = [];
+  const navigate = createShellNavigationHandler({
+    settings: () => calls.push('settings'),
+    onboarding: () => calls.push('onboarding'),
+    'profile-home': () => calls.push('profile-home'),
+    view: (request) =>
+      calls.push(
+        `view:${(request as Extract<ShellNavigateRequest, { target: 'view' }>).kfxId}`,
+      ),
+  });
+  navigate({}, { target: 'settings' });
+  navigate({}, { target: 'onboarding' });
+  navigate({}, { target: 'profile-home' });
+  navigate({}, { target: 'view', kfxId: 'work' });
+  navigate({}, { target: 'unknown' } as unknown as ShellNavigateRequest);
+  navigate({}, { target: '__proto__' } as unknown as ShellNavigateRequest);
+  navigate({}, { target: 'constructor' } as unknown as ShellNavigateRequest);
+  navigate({}, null as unknown as ShellNavigateRequest);
+  navigate({}, undefined as unknown as ShellNavigateRequest);
+  navigate({}, {} as ShellNavigateRequest);
+  assert.deepEqual(calls, [
+    'settings',
+    'onboarding',
+    'profile-home',
+    'view:work',
+  ]);
+});
 
 test('the title-bar search shares Help, Command, Work, and view sources', () => {
   assert.match(source, /SYSTEM_HELP_DOCUMENTS/);
@@ -105,7 +255,7 @@ test('Work activation reaches the declared Work view and selects the exact resul
 test('Core Work remains a first-class shell surface without an admitted Work KFX', () => {
   assert.match(
     source,
-    /coreWorkOpen \|\| activeKfx\?\.id === workEntry\?\.id[\s\S]*\? 'core-work'/,
+    /shellSurfaceActiveViewId\(\{[\s\S]*activeKfxId: activeKfx\?\.id,[\s\S]*workEntryId: workEntry\?\.id/,
   );
   assert.match(source, /onOpenAllWork=\{\(\) => openWorkSurface\(\)\}/);
   assert.match(
@@ -118,12 +268,15 @@ test('Core Work remains a first-class shell surface without an admitted Work KFX
   );
   assert.match(
     source,
-    /coreWorkOpen[\s\S]*currentProjectName[\s\S]*'All Work'/,
+    /shellSurfaceTitle\(\{[\s\S]*projectWorkOpen,[\s\S]*currentProjectDisplayName/,
   );
 });
 
 test('visited core product surfaces stay mounted while hidden', () => {
-  assert.match(source, /useRetainedCoreSurfaces\(\{/);
+  assert.match(
+    source,
+    /useRetainedCoreSurfaces\(\s*visibleRetainedCoreSurface/,
+  );
   assert.match(
     projectsPanelSource,
     /visible === 'projects' \|\| retained\.has\('projects'\)/,
@@ -164,14 +317,23 @@ test('Project navigation preserves the current Project while the catalog is expl
   assert.match(source, /title: 'All Projects'[\s\S]*id: 'current-project'/);
   assert.match(
     source,
-    /onOpenProjects=\{\(\) => \{[\s\S]*setFocusedProjectPath\(''\)[\s\S]*setProjectsOpen\(true\)/,
+    /onOpenProjects=\{\(\) => \{[\s\S]*setFocusedProjectPath\(''\)[\s\S]*setShellSurface\('projects'\)/,
   );
 });
 
-test('Lab and workspace transitions close Core Work explicitly', () => {
+test('cached Project search preserves onboarding priority', () => {
+  assert.equal(projectSearchSurface('onboarding'), 'onboarding');
+  assert.equal(projectSearchSurface('projects'), 'projects');
+  assert.equal(projectSearchSurface('core-work'), 'projects');
+  assert.equal(projectSearchSurface('agent-work-lab'), 'projects');
+  assert.equal(projectSearchSurface('kfx'), 'projects');
+  assert.match(source, /setShellSurface\(projectSearchSurface\)/);
+});
+
+test('Lab and workspace transitions select one shell surface explicitly', () => {
   assert.match(
     source,
-    /onOpenLab=\{\(\) => \{[\s\S]*setCoreWorkOpen\(false\)[\s\S]*setLabOpen\(true\)/,
+    /onOpenLab=\{\(\) => setShellSurface\('agent-work-lab'\)\}/,
   );
   assert.match(source, /onOpenWork=\{\(\) => openWorkSurface\(\)\}/);
 });

--- a/framework/gui/src/renderer/src/main.tsx
+++ b/framework/gui/src/renderer/src/main.tsx
@@ -44,10 +44,17 @@ import type { SessionWindowLaunchAuthorization } from '../../main/session-window
 import {
   accessibleEntries,
   availableProfiles,
+  createShellNavigationHandler,
   focusedProfile,
+  initialShellSurface,
   primaryNavigation,
   productRoleEntry,
   profileHomeId,
+  projectSearchSurface,
+  shellSurfaceActiveViewId,
+  shellSurfaceFlags,
+  shellSurfaceTitle,
+  visibleCoreSurface,
 } from '../../navigation';
 import {
   type RuntimeStatusResult,
@@ -246,6 +253,94 @@ function SandboxSlot({
     // stable for a given runtime
   }, [entry.id, entry.bundlePath]);
   return <div ref={ref} style={{ width: '100%', height: '100%' }} />;
+}
+
+const WORKSPACE_RECOVERY_STATES: ReadonlySet<string | undefined> = new Set([
+  'uninitialized',
+  'shadow-only',
+  'evidence-degraded',
+  'unavailable',
+]);
+
+function ActiveKfxSurface({
+  runtime,
+  activeKfx,
+  caps,
+  shell,
+  active,
+  entryCount,
+  discoveredKfxCount,
+  failures,
+}: {
+  runtime: Runtime;
+  activeKfx: KfxEntry | null;
+  caps: KfxCapabilities | null;
+  shell: Shell;
+  active: string;
+  entryCount: number;
+  discoveredKfxCount: number;
+  failures: Array<{ dir: string; error: string }>;
+}) {
+  if (!runtime.ok) {
+    const workspaceNeedsRecovery = WORKSPACE_RECOVERY_STATES.has(
+      window.process.env.KF_WORKSPACE_STATE,
+    );
+    return (
+      <div
+        style={{
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        {workspaceNeedsRecovery ? (
+          <WorkspacePanel />
+        ) : (
+          <RuntimeFailurePanel message={runtime.message} />
+        )}
+      </div>
+    );
+  }
+
+  if (activeKfx?.tier === 'sandboxed-ipc') {
+    return (
+      <KfxErrorBoundary kfxId={activeKfx.id}>
+        <SandboxSlot
+          key={activeKfx.id}
+          entry={activeKfx}
+          caps={sandboxSubset(runtime, activeKfx)}
+        />
+      </KfxErrorBoundary>
+    );
+  }
+
+  if (activeKfx && caps) {
+    return (
+      <KfxErrorBoundary kfxId={activeKfx.id}>
+        <activeKfx.View caps={caps} shell={shell} />
+      </KfxErrorBoundary>
+    );
+  }
+
+  return (
+    <section style={panelStyle}>
+      <div style={{ ...mono, color: '#f48771' }}>
+        no kfx available
+        {entryCount === 0
+          ? ` — ${unavailableKfxMessage(discoveredKfxCount)}`
+          : ` for view "${active}"`}
+      </div>
+      {failures.map((failure) => (
+        <div
+          key={failure.dir}
+          style={{ ...mono, color: '#858585', marginTop: 4 }}
+        >
+          {failure.dir}: {failure.error}
+        </div>
+      ))}
+    </section>
+  );
 }
 
 type ElectronChromeStyle = React.CSSProperties & {
@@ -915,28 +1010,23 @@ function App() {
     () => actionableKfxFailures(loaded.failures, kfxDescriptor !== null),
     [kfxDescriptor, loaded.failures],
   );
-  const [labOpen, setLabOpen] = React.useState(() =>
+  const initialAgentWorkLabOpen =
     initialProjectsOpen || initialOnboardingOpen || initialCoreWorkOpen
       ? false
-      : shouldOpenAgentWorkLab(startupSurface, loaded.entries.length),
+      : shouldOpenAgentWorkLab(startupSurface, loaded.entries.length);
+  const [shellSurface, setShellSurface] = React.useState(() =>
+    initialShellSurface({
+      onboardingOpen: initialOnboardingOpen,
+      projectsOpen: initialProjectsOpen,
+      focusedProjectPath: initialFocusedProjectPath,
+      agentWorkLabOpen: initialAgentWorkLabOpen,
+    }),
   );
-  const [onboardingOpen, setOnboardingOpen] = React.useState(
-    initialOnboardingOpen,
+  const { onboardingOpen, coreWorkOpen } = shellSurfaceFlags(shellSurface);
+  const visibleRetainedCoreSurface = visibleCoreSurface(shellSurface);
+  const retainedCoreSurfaces = useRetainedCoreSurfaces(
+    visibleRetainedCoreSurface,
   );
-  const [projectsOpen, setProjectsOpen] = React.useState(
-    !initialOnboardingOpen && initialProjectsOpen && !initialFocusedProjectPath,
-  );
-  const [coreWorkOpen, setCoreWorkOpen] = React.useState(
-    initialCoreWorkOpen ||
-      (!initialOnboardingOpen &&
-        initialProjectsOpen &&
-        Boolean(initialFocusedProjectPath)),
-  );
-  const retainedCoreSurfaces = useRetainedCoreSurfaces({
-    projectsOpen,
-    labOpen,
-    coreWorkOpen,
-  });
   const [focusedProjectPath, setFocusedProjectPath] = React.useState(
     initialFocusedProjectPath,
   );
@@ -1270,10 +1360,7 @@ function App() {
 
   const openKfx = React.useCallback(
     (kfxId: string, nextParams?: Record<string, string>) => {
-      setOnboardingOpen(false);
-      setLabOpen(false);
-      setProjectsOpen(false);
-      setCoreWorkOpen(false);
+      setShellSurface('kfx');
       setParams(nextParams ?? {});
       setActive(kfxId);
     },
@@ -1331,20 +1418,15 @@ function App() {
       ipc = null;
     }
     if (!ipc) return;
-    const navigate = (_event: unknown, request: ShellNavigateRequest) => {
-      if (request.target === 'settings') {
-        setSettingsOpen(true);
-      } else if (request.target === 'onboarding') {
-        setLabOpen(false);
-        setProjectsOpen(false);
-        setCoreWorkOpen(false);
-        setOnboardingOpen(true);
-      } else if (request.target === 'profile-home') {
-        openKfx(profileHomeId(profile, enabled));
-      } else if (request.target === 'view') {
-        openKfx(request.kfxId);
-      }
-    };
+    const navigate = createShellNavigationHandler({
+      settings: () => setSettingsOpen(true),
+      onboarding: () => setShellSurface('onboarding'),
+      'profile-home': () => openKfx(profileHomeId(profile, enabled)),
+      view: (request) =>
+        openKfx(
+          (request as Extract<ShellNavigateRequest, { target: 'view' }>).kfxId,
+        ),
+    });
     ipc.on(SHELL_NAVIGATE_CHANNEL, navigate);
     return () => ipc?.removeListener(SHELL_NAVIGATE_CHANNEL, navigate);
   }, [enabled, openKfx, profile]);
@@ -1624,11 +1706,8 @@ function App() {
     enabled.find((entry) => entry.id === profileHomeId(profile, enabled));
   const openCoreWork = React.useCallback(
     (nextParams: Record<string, string>) => {
-      setOnboardingOpen(false);
-      setLabOpen(false);
-      setProjectsOpen(false);
       setParams(nextParams);
-      setCoreWorkOpen(true);
+      setShellSurface('core-work');
     },
     [],
   );
@@ -1735,9 +1814,7 @@ function App() {
         openWorkSurface({ workId: result.action.workId });
       } else if (result.action.kind === 'open-project') {
         setFocusedProjectPath(result.action.projectPath);
-        setLabOpen(false);
-        setCoreWorkOpen(false);
-        setProjectsOpen(true);
+        setShellSurface(projectSearchSurface);
       } else {
         showNotification({
           level: 'info',
@@ -2183,36 +2260,22 @@ function App() {
     <div style={appStyle}>
       <ShellTitleBar
         chrome={windowChrome}
-        activeTitle={
-          onboardingOpen
-            ? 'Getting Started'
-            : labOpen
-              ? 'Agent Work Lab'
-              : projectsOpen
-                ? 'Projects'
-                : coreWorkOpen
-                  ? projectWorkOpen
-                    ? `Project · ${currentProjectDisplayName}`
-                    : 'All Work'
-                  : (activeKfx?.title ?? 'Kungfu Episodes')
-        }
+        activeTitle={shellSurfaceTitle({
+          surface: shellSurface,
+          projectWorkOpen,
+          currentProjectDisplayName,
+          activeKfxTitle: activeKfx?.title,
+        })}
         searchText={searchText}
         searchResults={searchResults}
         searchStatus={searchCatalogStatus}
         settingsOpen={settingsOpen}
-        activeViewId={
-          onboardingOpen
-            ? 'onboarding'
-            : labOpen
-              ? 'agent-work-lab'
-              : projectsOpen
-                ? 'projects'
-                : projectWorkOpen
-                  ? 'current-project'
-                  : coreWorkOpen || activeKfx?.id === workEntry?.id
-                    ? 'core-work'
-                    : activeKfx?.id
-        }
+        activeViewId={shellSurfaceActiveViewId({
+          surface: shellSurface,
+          projectWorkOpen,
+          activeKfxId: activeKfx?.id,
+          workEntryId: workEntry?.id,
+        })}
         advancedItems={advancedNav}
         failures={visibleKfxFailures}
         onSearchChange={setSearchText}
@@ -2230,18 +2293,10 @@ function App() {
             : undefined
         }
         onOpenProjects={() => {
-          setOnboardingOpen(false);
-          setLabOpen(false);
-          setCoreWorkOpen(false);
           setFocusedProjectPath('');
-          setProjectsOpen(true);
+          setShellSurface('projects');
         }}
-        onOpenLab={() => {
-          setOnboardingOpen(false);
-          setProjectsOpen(false);
-          setCoreWorkOpen(false);
-          setLabOpen(true);
-        }}
+        onOpenLab={() => setShellSurface('agent-work-lab')}
         onOpenView={(id) => shell.open(id)}
         onWindowControl={controlWindow}
       />
@@ -2261,13 +2316,9 @@ function App() {
                 entry={agentFirstEntry}
                 onPersist={persistOnboarding}
                 onInstallCli={installOnboardingCli}
-                onOpenLab={() => {
-                  setOnboardingOpen(false);
-                  setLabOpen(true);
-                }}
+                onOpenLab={() => setShellSurface('agent-work-lab')}
                 onOpenTour={() => {
-                  setOnboardingOpen(false);
-                  setLabOpen(true);
+                  setShellSurface('agent-work-lab');
                   showNotification({
                     level: 'info',
                     title: 'Guided Project Tour',
@@ -2276,29 +2327,20 @@ function App() {
                   });
                 }}
                 onContinue={() => {
-                  setOnboardingOpen(false);
                   if (initialFocusedProjectPath) {
                     openWorkSurface({
                       projectPath: initialFocusedProjectPath,
                       projectSection: 'files',
                     });
                   } else {
-                    setProjectsOpen(true);
+                    setShellSurface('projects');
                   }
                 }}
               />
             ) : (
               <>
                 <RetainedCoreSurfaceStack
-                  visible={
-                    projectsOpen
-                      ? 'projects'
-                      : labOpen
-                        ? 'agent-work-lab'
-                        : coreWorkOpen
-                          ? 'core-work'
-                          : undefined
-                  }
+                  visible={visibleRetainedCoreSurface}
                   retained={retainedCoreSurfaces}
                   projects={projects}
                   focusedPath={focusedProjectPath}
@@ -2309,11 +2351,7 @@ function App() {
                   lab={agentWorkLab}
                   startup={startup}
                   onOpenWork={() => openWorkSurface()}
-                  onOpenLabExistingProject={() => {
-                    setLabOpen(false);
-                    setCoreWorkOpen(false);
-                    setProjectsOpen(true);
-                  }}
+                  onOpenLabExistingProject={() => setShellSurface('projects')}
                   onLabComplete={labOnboarding.completeLab}
                   onOpenStarterProject={labOnboarding.openStarterProject}
                   work={
@@ -2326,61 +2364,17 @@ function App() {
                     ) : null
                   }
                 />
-                {!projectsOpen && !labOpen && !coreWorkOpen ? (
-                  runtime.ok ? (
-                    activeKfx && activeKfx.tier === 'sandboxed-ipc' ? (
-                      // isolated third-party view: embedded, not mounted here
-                      <KfxErrorBoundary kfxId={activeKfx.id}>
-                        <SandboxSlot
-                          key={activeKfx.id}
-                          entry={activeKfx}
-                          caps={sandboxSubset(runtime, activeKfx)}
-                        />
-                      </KfxErrorBoundary>
-                    ) : activeKfx && caps ? (
-                      <KfxErrorBoundary kfxId={activeKfx.id}>
-                        <activeKfx.View caps={caps} shell={shell} />
-                      </KfxErrorBoundary>
-                    ) : (
-                      <section style={panelStyle}>
-                        <div style={{ ...mono, color: '#f48771' }}>
-                          no kfx available
-                          {loaded.entries.length === 0
-                            ? ` — ${unavailableKfxMessage(loaded.discoveredKfxCount)}`
-                            : ` for view "${active}"`}
-                        </div>
-                        {visibleKfxFailures.map((failure) => (
-                          <div
-                            key={failure.dir}
-                            style={{ ...mono, color: '#858585', marginTop: 4 }}
-                          >
-                            {failure.dir}: {failure.error}
-                          </div>
-                        ))}
-                      </section>
-                    )
-                  ) : (
-                    <div
-                      style={{
-                        height: '100%',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                      }}
-                    >
-                      {window.process.env.KF_WORKSPACE_STATE ===
-                        'uninitialized' ||
-                      window.process.env.KF_WORKSPACE_STATE === 'shadow-only' ||
-                      window.process.env.KF_WORKSPACE_STATE ===
-                        'evidence-degraded' ||
-                      window.process.env.KF_WORKSPACE_STATE ===
-                        'unavailable' ? (
-                        <WorkspacePanel />
-                      ) : (
-                        <RuntimeFailurePanel message={runtime.message} />
-                      )}
-                    </div>
-                  )
+                {shellSurface === 'kfx' ? (
+                  <ActiveKfxSurface
+                    runtime={runtime}
+                    activeKfx={activeKfx}
+                    caps={caps}
+                    shell={shell}
+                    active={active}
+                    entryCount={loaded.entries.length}
+                    discoveredKfxCount={loaded.discoveredKfxCount}
+                    failures={visibleKfxFailures}
+                  />
                 ) : null}
               </>
             )}

--- a/framework/gui/src/renderer/src/projects-panel/index.tsx
+++ b/framework/gui/src/renderer/src/projects-panel/index.tsx
@@ -23,45 +23,216 @@ import { createAgentSessionProxy } from '../agent-session-proxy';
 import { AgentWorkLabPanel } from '../agent-work-lab';
 import { guiKungfuCliArgs } from '../runtime';
 
-export function openRendererProjects() {
-  type ExecFile = (
+type ProcessOptions = {
+  env: Record<string, string | undefined>;
+  maxBuffer: number;
+};
+
+type RendererChild = {
+  stdin: {
+    end: (input: string) => void;
+    once: (event: 'error', listener: (reason: Error) => void) => void;
+  };
+  stdout: {
+    on: (event: 'data', listener: (chunk: unknown) => void) => void;
+  };
+  stderr: {
+    on: (event: 'data', listener: (chunk: unknown) => void) => void;
+  };
+  once: (
+    event: 'error' | 'close',
+    listener: (value: Error | number | null) => void,
+  ) => void;
+  kill: () => void;
+};
+
+type RendererChildProcess = {
+  execFile: (
     file: string,
     args: string[],
-    options: {
-      encoding: 'utf8';
-      env: Record<string, string | undefined>;
-      maxBuffer: number;
-    },
+    options: ProcessOptions & { encoding: 'utf8' },
     callback: (error: Error | null, stdout: string, stderr: string) => void,
   ) => void;
-  type Spawn = (
+  spawn: (
     file: string,
     args: string[],
     options: {
       env: Record<string, string | undefined>;
       stdio: ['ignore' | 'pipe', 'pipe', 'pipe'];
     },
-  ) => {
-    stdin: {
-      end: (input: string) => void;
-      once: (event: 'error', listener: (reason: Error) => void) => void;
-    };
-    stdout: {
-      on: (event: 'data', listener: (chunk: unknown) => void) => void;
-    };
-    stderr: {
-      on: (event: 'data', listener: (chunk: unknown) => void) => void;
-    };
-    once: (
-      event: 'error' | 'close',
-      listener: (value: Error | number | null) => void,
-    ) => void;
-    kill: () => void;
-  };
-  const childProcess = window.require('node:child_process') as {
-    execFile: ExecFile;
-    spawn: Spawn;
-  };
+  ) => RendererChild;
+};
+
+type RendererProcessContext = {
+  childProcess: RendererChildProcess;
+  args: (values: string[]) => string[];
+};
+
+type RendererProcessRequest = {
+  file: string;
+  values: string[];
+  options: ProcessOptions;
+};
+
+type RendererExecRequest = RendererProcessRequest & {
+  options: ProcessOptions & { encoding: 'utf8' };
+};
+
+type RendererInputRequest = RendererProcessRequest & { input: string };
+
+type RendererEventsRequest = RendererProcessRequest & {
+  onLine: (line: string) => void;
+};
+
+type RendererProcessRun<Request> = {
+  process: RendererProcessContext;
+  request: Request;
+};
+
+type RendererRunClose = {
+  code: number | null;
+  failureMessage: string;
+  resolve: (stdout: string) => void;
+};
+
+class RendererProjectRun {
+  stdout = '';
+  stderr = '';
+  size = 0;
+  settled = false;
+
+  constructor(
+    readonly child: RendererChild,
+    readonly maxBuffer: number,
+    readonly overflowMessage: string,
+    readonly reject: (reason: Error) => void,
+  ) {}
+
+  fail(reason: Error) {
+    if (this.settled) return;
+    this.settled = true;
+    this.child.kill();
+    this.reject(reason);
+  }
+
+  append(stream: 'stdout' | 'stderr', chunk: unknown) {
+    const text = String(chunk);
+    this.size += text.length;
+    if (this.size > this.maxBuffer) {
+      this.fail(new Error(this.overflowMessage));
+      return false;
+    }
+    this[stream] += text;
+    return true;
+  }
+
+  receiveLines(chunk: unknown, onLine: (line: string) => void) {
+    if (!this.append('stdout', chunk)) return;
+    const lines = this.stdout.split(/\r?\n/);
+    this.stdout = lines.pop() ?? '';
+    for (const line of lines) if (line.trim()) onLine(line);
+  }
+
+  receiveError(reason: unknown) {
+    this.fail(reason instanceof Error ? reason : new Error(String(reason)));
+  }
+
+  close({ code, failureMessage, resolve }: RendererRunClose) {
+    if (this.settled) return;
+    if (code !== 0) {
+      this.fail(new Error(this.stderr.trim() || failureMessage));
+      return;
+    }
+    this.settled = true;
+    resolve(this.stdout);
+  }
+}
+
+function runRendererExecFile(run: RendererProcessRun<RendererExecRequest>) {
+  const { childProcess, args } = run.process;
+  const { file, values, options } = run.request;
+  return new Promise<string>((resolve, reject) => {
+    childProcess.execFile(
+      file,
+      args(values),
+      options,
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(stderr.trim() || stdout.trim() || error.message));
+        } else resolve(stdout);
+      },
+    );
+  });
+}
+
+function runRendererInput(run: RendererProcessRun<RendererInputRequest>) {
+  const { childProcess, args } = run.process;
+  const { file, values, input, options } = run.request;
+  return new Promise<string>((resolve, reject) => {
+    const child = childProcess.spawn(file, args(values), {
+      env: options.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const processRun = new RendererProjectRun(
+      child,
+      options.maxBuffer,
+      'Project Work capture output exceeded maxBuffer',
+      reject,
+    );
+    child.stdout.on('data', (chunk) => {
+      processRun.append('stdout', chunk);
+    });
+    child.stderr.on('data', (chunk) => {
+      processRun.append('stderr', chunk);
+    });
+    child.stdin.once('error', (reason) => processRun.fail(reason));
+    child.once('error', (reason) => processRun.receiveError(reason));
+    child.once('close', (code) =>
+      processRun.close({
+        code: code as number | null,
+        failureMessage: `kungfu capture exited ${code}`,
+        resolve,
+      }),
+    );
+    child.stdin.end(input);
+  });
+}
+
+function runRendererEvents(run: RendererProcessRun<RendererEventsRequest>) {
+  const { childProcess, args } = run.process;
+  const { file, values, options, onLine } = run.request;
+  return new Promise<void>((resolve, reject) => {
+    const child = childProcess.spawn(file, args(values), {
+      env: options.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const processRun = new RendererProjectRun(
+      child,
+      options.maxBuffer,
+      'Work activity stream exceeded maxBuffer',
+      reject,
+    );
+    child.stdout.on('data', (chunk) => processRun.receiveLines(chunk, onLine));
+    child.stderr.on('data', (chunk) => {
+      processRun.stderr += String(chunk);
+    });
+    child.once('error', (reason) => processRun.receiveError(reason));
+    child.once('close', (code) => {
+      if (processRun.settled) return;
+      if (processRun.stdout.trim()) onLine(processRun.stdout);
+      processRun.close({
+        code: code as number | null,
+        failureMessage: `kungfu run exited ${code}`,
+        resolve: () => resolve(),
+      });
+    });
+  });
+}
+
+function createRendererProjects() {
+  const childProcess = window.require(
+    'node:child_process',
+  ) as RendererChildProcess;
   const electron = window.require('electron') as {
     ipcRenderer: {
       invoke: (channel: string, payload: unknown) => Promise<unknown>;
@@ -76,119 +247,28 @@ export function openRendererProjects() {
     env.KUNGFU_BIN ||
     (window.process.platform === 'win32' ? 'kungfu.exe' : 'kungfu');
   const args = (values: string[]) => guiKungfuCliArgs(env, values);
+  const process = { childProcess, args };
   return capability.openProjects({
     bin,
     env,
     agentSessionClient: 'gui',
     agentSession: createAgentSessionProxy(electron.ipcRenderer),
     execFile: (file, values, options) =>
-      new Promise<string>((resolve, reject) => {
-        childProcess.execFile(
-          file,
-          args(values),
-          options,
-          (error, stdout, stderr) => {
-            if (error) {
-              reject(
-                new Error(stderr.trim() || stdout.trim() || error.message),
-              );
-            } else resolve(stdout);
-          },
-        );
-      }),
+      runRendererExecFile({ process, request: { file, values, options } }),
     execFileInput: (file, values, input, options) =>
-      new Promise<string>((resolve, reject) => {
-        const child = childProcess.spawn(file, args(values), {
-          env: options.env,
-          stdio: ['pipe', 'pipe', 'pipe'],
-        });
-        let stdout = '';
-        let stderr = '';
-        let size = 0;
-        let settled = false;
-        const fail = (reason: Error) => {
-          if (settled) return;
-          settled = true;
-          child.kill();
-          reject(reason);
-        };
-        const append = (current: string, chunk: unknown) => {
-          const text = String(chunk);
-          size += text.length;
-          if (size > options.maxBuffer) {
-            fail(new Error('Project Work capture output exceeded maxBuffer'));
-            return current;
-          }
-          return current + text;
-        };
-        child.stdout.on('data', (chunk) => {
-          stdout = append(stdout, chunk);
-        });
-        child.stderr.on('data', (chunk) => {
-          stderr = append(stderr, chunk);
-        });
-        child.stdin.once('error', fail);
-        child.once('error', (reason) =>
-          fail(reason instanceof Error ? reason : new Error(String(reason))),
-        );
-        child.once('close', (code) => {
-          if (settled) return;
-          if (code !== 0) {
-            fail(new Error(stderr.trim() || `kungfu capture exited ${code}`));
-            return;
-          }
-          settled = true;
-          resolve(stdout);
-        });
-        child.stdin.end(input);
+      runRendererInput({
+        process,
+        request: { file, values, input, options },
       }),
     execFileEvents: (file, values, options, onLine) =>
-      new Promise<void>((resolve, reject) => {
-        const child = childProcess.spawn(file, args(values), {
-          env: options.env,
-          stdio: ['ignore', 'pipe', 'pipe'],
-        });
-        let stdout = '';
-        let stderr = '';
-        let size = 0;
-        let settled = false;
-        const fail = (reason: Error) => {
-          if (settled) return;
-          settled = true;
-          child.kill();
-          reject(reason);
-        };
-        child.stdout.on('data', (chunk) => {
-          const text = String(chunk);
-          size += text.length;
-          if (size > options.maxBuffer) {
-            fail(new Error('Work activity stream exceeded maxBuffer'));
-            return;
-          }
-          stdout += text;
-          const lines = stdout.split(/\r?\n/);
-          stdout = lines.pop() ?? '';
-          for (const line of lines) if (line.trim()) onLine(line);
-        });
-        child.stderr.on('data', (chunk) => {
-          stderr += String(chunk);
-        });
-        child.once('error', (reason) =>
-          fail(reason instanceof Error ? reason : new Error(String(reason))),
-        );
-        child.once('close', (code) => {
-          if (settled) return;
-          if (stdout.trim()) onLine(stdout);
-          if (code !== 0) {
-            fail(new Error(stderr.trim() || `kungfu run exited ${code}`));
-            return;
-          }
-          settled = true;
-          resolve();
-        });
+      runRendererEvents({
+        process,
+        request: { file, values, options, onLine },
       }),
   });
 }
+
+export const openRendererProjects = createRendererProjects;
 
 type WorkspaceSelection = {
   workspace_id: string;
@@ -212,6 +292,16 @@ type CreatePlan = {
   planRoot: string;
   effects: string[];
   skippedEffects: string[];
+};
+
+type RuntimeRecoveryResult = {
+  ok?: boolean;
+  canceled?: boolean;
+  error?: string;
+};
+
+type RuntimeRecoveryIpc = {
+  invoke: (channel: string, payload: unknown) => Promise<RuntimeRecoveryResult>;
 };
 
 const buttonStyle: React.CSSProperties = {
@@ -833,33 +923,35 @@ export function WorkspacePanel() {
   );
 }
 
-export function RuntimeFailurePanel({ message }: { message: string }) {
+async function requestRuntimeRecovery(message: string) {
+  const ipcRenderer = (
+    window.require('electron') as { ipcRenderer: RuntimeRecoveryIpc }
+  ).ipcRenderer;
+  const result = await ipcRenderer.invoke(RUNTIME_BACKUP_RESET_CHANNEL, {
+    message,
+  });
+  if (!result.ok && !result.canceled)
+    return result.error || 'runtime recovery failed';
+  return '';
+}
+
+function useRuntimeRecovery(message: string) {
   const [busy, setBusy] = React.useState(false);
   const [error, setError] = React.useState('');
-  const resettable = isResettableRuntimeFailure(message);
-  const backupAndReset = () => {
+  const backupAndReset = React.useCallback(() => {
     setBusy(true);
     setError('');
-    const ipcRenderer = (
-      window.require('electron') as {
-        ipcRenderer: {
-          invoke: (
-            channel: string,
-            payload: unknown,
-          ) => Promise<{ ok?: boolean; canceled?: boolean; error?: string }>;
-        };
-      }
-    ).ipcRenderer;
-    void ipcRenderer
-      .invoke(RUNTIME_BACKUP_RESET_CHANNEL, { message })
-      .then((result) => {
-        if (!result.ok && !result.canceled) {
-          setError(result.error || 'runtime recovery failed');
-        }
-      })
+    void requestRuntimeRecovery(message)
+      .then(setError)
       .catch((reason) => setError((reason as Error).message))
       .finally(() => setBusy(false));
-  };
+  }, [message]);
+  return { busy, error, backupAndReset };
+}
+
+function RuntimeFailureSurface({ message }: { message: string }) {
+  const { busy, error, backupAndReset } = useRuntimeRecovery(message);
+  const resettable = isResettableRuntimeFailure(message);
   return (
     <section style={{ ...panelStyle, width: 'min(680px, 100%)' }}>
       <h2 style={{ margin: '0 0 8px', fontSize: 15 }}>
@@ -896,6 +988,8 @@ export function RuntimeFailurePanel({ message }: { message: string }) {
   );
 }
 
+export const RuntimeFailurePanel = RuntimeFailureSurface;
+
 // One failing kfx renders its error panel; it never takes the shell down.
 export class KfxErrorBoundary extends React.Component<
   { kfxId: string; children: React.ReactNode },
@@ -929,36 +1023,18 @@ export class KfxErrorBoundary extends React.Component<
 
 export type CoreSurfaceId = 'projects' | 'agent-work-lab' | 'core-work';
 
-export function useRetainedCoreSurfaces({
-  projectsOpen,
-  labOpen,
-  coreWorkOpen,
-}: {
-  projectsOpen: boolean;
-  labOpen: boolean;
-  coreWorkOpen: boolean;
-}): ReadonlySet<CoreSurfaceId> {
+export function useRetainedCoreSurfaces(
+  visible?: CoreSurfaceId,
+): ReadonlySet<CoreSurfaceId> {
   const [retained, setRetained] = React.useState<ReadonlySet<CoreSurfaceId>>(
-    () =>
-      new Set([
-        ...(projectsOpen ? (['projects'] as const) : []),
-        ...(labOpen ? (['agent-work-lab'] as const) : []),
-        ...(coreWorkOpen ? (['core-work'] as const) : []),
-      ]),
+    () => new Set(visible ? [visible] : []),
   );
   React.useEffect(() => {
-    const visible = projectsOpen
-      ? 'projects'
-      : labOpen
-        ? 'agent-work-lab'
-        : coreWorkOpen
-          ? 'core-work'
-          : undefined;
     if (!visible) return;
     setRetained((current) =>
       current.has(visible) ? current : new Set([...current, visible]),
     );
-  }, [coreWorkOpen, labOpen, projectsOpen]);
+  }, [visible]);
   return retained;
 }
 


### PR DESCRIPTION
## Summary

Deliver the clean-linear successor to #3353. It converges the GUI shell and renderer project-process orchestration without changing user behavior, public APIs, IPC contracts, persisted state, or rendered output.

## Related issue

Assignment: `2026-08-22-kungfu-gui-monolith-complexity-convergence-r2`

Supersedes #3353 after Project Cut correctly rejected its accumulated merge topology as non-replayable. The reviewed implementation bytes are unchanged.

## Changes

- replace four competing shell-open booleans with one typed shell surface while retaining already-visited core surfaces
- centralize guarded shell IPC navigation and preserve malformed-target no-op behavior, including prototype-like targets
- preserve cached Project search behavior while onboarding remains active
- split renderer child-process buffering, line delivery, completion, and recovery state into bounded responsibilities in the existing GUI owner
- keep `openRendererProjects` and `RuntimeFailurePanel` public exports and call signatures unchanged
- declare the recovery-state set input type explicitly so an absent workspace environment value retains its existing false membership result

## Clean-linear identity

- protected base: `2fe53420da3c9d14ac4ae2faf0002b02f2402af5`
- head: `0941182bf539e7c544283b79afb22ba1fd420527`
- topology: one DCO-signed commit with exact protected base as its single parent
- stable patch-id: `ea3c06b040c834ad0e511f689e84c15d8c02d056`, identical to the independently accepted implementation in #3353
- all five changed blobs match the accepted implementation byte-for-byte
- Project Cut queue admission: `qualified`, replayed commit count `1`, `compositionChanged=false`, no diagnostics

## Verification

- native function-risk/current policy: functions `136 -> 141`, lines `4640 -> 4472`, cyclomatic `820 -> 767`, cognitive `1431 -> 1238`, baseRisk `4262 -> 3843` (-419), changeRisk `4297 -> 4132` (-165)
- complete AST/common-policy: functions `444 -> 458`, lines `13134 -> 13107`, cyclomatic `2221 -> 2197`, cognitive `3565 -> 3393`, baseRisk `11166 -> 10853` (-313), changeRisk `11273 -> 11261` (-12)
- independent exact-head review: ACCEPT with no blocking findings; confirmed clean-linear identity, non-wrapper-only extraction, and behavior/API/IPC/persistence/visual equivalence
- the native wrapper advisory is a reviewed false positive caused by exact-map collision between two retained same-path/same-symbol `refresh` functions; both owner aggregates and complete-AST risks strictly decline
- exact changed-GUI TypeScript: 5/5
- focused GUI behavior tests: 31/31
- full GUI tests: 147/147
- Biome: 5 changed files
- `./shifu build:app`
- `./shifu project-cut:queue-admission -- --base 2fe53420da3c9d14ac4ae2faf0002b02f2402af5 --head 0941182bf539e7c544283b79afb22ba1fd420527`
- generated-report authority/parity oracle: Node 22/22 and Python 6/6 on the byte-identical accepted GUI source tree and unchanged analysis authority
- commit staged gate, including Production Graph, Shifu contracts, documentation, invariant, schema, and Biome checks
- `git diff --check`
- exact Atlas work-admission: `sha256:9969f2f1e0541c24847f207fe7e0273ffc0ecf9b48fb4b0794c1121eb085c4ff`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded GUI refactor preserves architecture contracts, public APIs, IPC, persistence, and user-visible behavior."
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable; behavior is preserved)
