### PR TITLE
fix(core): align watcher reconnect transition deadlines

### DIFF
--- a/framework/core/tests/fixtures/watcher-runtime-probe.js
+++ b/framework/core/tests/fixtures/watcher-runtime-probe.js
@@ -24,10 +24,14 @@ function createWatcher() {
 }
 const reconnectDeadlines = Object.freeze({
   coordinatorStartup: process.platform === 'win32' ? 30_000 : 15_000,
-  watcherConnect: process.platform === 'win32' ? 30_000 : 8_000,
+  // io_device_peer::setup() owns a bounded 60-second registration retry.
+  // Leave runner-scheduling margin around that native boundary instead of
+  // timing out the fixture while the bounded setup is still authoritative.
+  watcherConnect: process.platform === 'win32' ? 75_000 : 8_000,
   watcherDisconnect: process.platform === 'win32' ? 30_000 : 8_000,
-  watcherReconnect: process.platform === 'win32' ? 30_000 : 10_000,
+  watcherReconnect: process.platform === 'win32' ? 75_000 : 10_000,
   watcherStop: process.platform === 'win32' ? 15_000 : 5_000,
+  coordinatorExit: process.platform === 'win32' ? 15_000 : 10_000,
 });
 
 function printableStats() {
@@ -209,13 +213,13 @@ async function stopCoordinator(child) {
   } else {
     signalPosixProcessTree(child, 'SIGTERM');
   }
-  if (await waitForExitWithin(child, 3_000)) return;
+  if (await waitForExitWithin(child, reconnectDeadlines.coordinatorExit)) return;
   if (process.platform === 'win32') {
     child.kill();
   } else {
     signalPosixProcessTree(child, 'SIGKILL');
   }
-  if (!(await waitForExitWithin(child, 3_000))) {
+  if (!(await waitForExitWithin(child, reconnectDeadlines.coordinatorExit))) {
     throw new Error('coordinator did not exit after SIGKILL');
   }
 }

--- a/framework/core/tests/watcher-runtime-boundary.test.js
+++ b/framework/core/tests/watcher-runtime-boundary.test.js
@@ -60,7 +60,7 @@ function runProbe(mode, environment = {}) {
     encoding: 'utf8',
     timeout:
       mode === 'reconnect' && process.platform === 'win32'
-        ? 150_000
+        ? 240_000
         : mode === 'reconnect'
           ? 55_000
           : 10_000,
@@ -120,11 +120,22 @@ test('watcher dispatch bench follows and proves the load peer carrier', () => {
 test('watcher reconnect fixture sequences readiness, owns process trees, and bounds Windows transitions', () => {
   assert.match(
     watcherProbeSource,
-    /watcherConnect: process\.platform === 'win32' \? 30_000 : 8_000/,
+    /watcherConnect: process\.platform === 'win32' \? 75_000 : 8_000/,
   );
   assert.match(
     watcherProbeSource,
-    /watcherReconnect: process\.platform === 'win32' \? 30_000 : 10_000/,
+    /watcherReconnect: process\.platform === 'win32' \? 75_000 : 10_000/,
+  );
+  assert.match(
+    watcherProbeSource,
+    /coordinatorExit: process\.platform === 'win32' \? 15_000 : 10_000/,
+  );
+  assert.equal(
+    watcherProbeSource.match(
+      /waitForExitWithin\(child, reconnectDeadlines\.coordinatorExit\)/g,
+    )?.length,
+    2,
+    'graceful and forced coordinator exits share the bounded platform deadline',
   );
   assert.match(
     watcherProbeSource,


### PR DESCRIPTION
## Summary

Align the cross-platform watcher reconnect test fixture with the native registration and hosted-runner process-exit bounds observed after the watcher usability fix landed. This changes test orchestration only; production watcher behavior is unchanged.

Exact source head: 21afe945feba1f8b901b1fa7acea74aa8a7edf42.

## Related issue

Follow-up to failed post-merge qualification run 32588116585.

## Changes

- Allow Windows watcher connect/reconnect through the native 60-second registration retry window plus runner margin.
- Keep coordinator termination fail-closed with bounded 10-second POSIX and 15-second Windows deadlines.
- Extend the outer Windows reconnect probe timeout and lock the exact values/call sites in the source contract.

## Verification

- Focused source contract: 4/4 passed.
- Exact-source native watcher boundary suite: 10/10 passed.
- Five repeated focused native runs passed.
- Full ./shifu check:source passed.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Test-fixture deadline alignment does not alter a production architecture contract"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable; test orchestration only)