### PR TITLE
fix(core): stabilize watcher reconnect qualification

### DIFF
--- a/framework/core/src/libkungfu/include/kungfu/runtime/nanomsg/socket.h
+++ b/framework/core/src/libkungfu/include/kungfu/runtime/nanomsg/socket.h
@@ -30,6 +30,12 @@ static_assert(kungfu::yijinjing::PUBLISH_NONBLOCK == NNG_FLAG_NONBLOCK,
 namespace kungfu::runtime::nanomsg {
 enum class protocol : int { UNKNOWN = -1, REPLY, REQUEST, PUSH, PULL, PUBLISH, SUBSCRIBE };
 
+#if defined(_WIN32)
+inline constexpr int DEFAULT_QUIET_DIAL_FLAGS = NNG_FLAG_NONBLOCK;
+#else
+inline constexpr int DEFAULT_QUIET_DIAL_FLAGS = 0;
+#endif
+
 inline std::string get_protocol_name(protocol p) {
   switch (p) {
   case protocol::REPLY:
@@ -117,7 +123,9 @@ public:
 
   int dial(const std::string &path, int flags = 0);
 
-  int dial_quietly(const std::string &path, int flags = 0);
+  // Windows named pipes may still be inside the coordinator slow-joiner
+  // window. NNG owns the readiness-probe retry after an asynchronous attempt.
+  int dial_quietly(const std::string &path, int flags = DEFAULT_QUIET_DIAL_FLAGS);
 
   void close();
 

--- a/framework/core/tests/fixtures/watcher-runtime-probe.js
+++ b/framework/core/tests/fixtures/watcher-runtime-probe.js
@@ -13,6 +13,7 @@ const binding = require(path.join(coreDir, 'dist', 'kungfu', 'kungfu_node.node')
 const temporaryRoot = process.platform === 'win32' ? os.tmpdir() : '/tmp';
 const home = fs.mkdtempSync(path.join(temporaryRoot, 'kfwr.'));
 let watcher = null;
+let coordinatorRuntime = null;
 
 function createWatcher() {
   return new binding.Watcher(
@@ -68,24 +69,64 @@ function waitFor(predicate, timeoutMs, message, context = () => ({})) {
   });
 }
 
-function startCoordinator() {
-  const outputPath = path.join(home, 'coordinator.out');
-  const logOffset = fs.existsSync(outputPath) ? fs.statSync(outputPath).size : 0;
-  const output = fs.openSync(outputPath, 'a');
+function coordinatorEnvironment() {
   const environment = { ...process.env };
-  environment.PATH =
-    environment.SHIFU_UV_ORIGINAL_PATH || environment.PATH;
+  environment.PATH = environment.SHIFU_UV_ORIGINAL_PATH || environment.PATH || '';
   delete environment.SHIFU_UV_ADAPTER_MANIFEST;
   delete environment.UV_PROJECT_ENVIRONMENT;
   delete environment.UV_PROJECT;
   delete environment.UV_FROZEN;
   delete environment.VIRTUAL_ENV;
-  const child = spawn(
+  delete environment.PYTHONHOME;
+  delete environment.PYTHONPATH;
+  return environment;
+}
+
+function resolveCoordinatorRuntime(environment) {
+  if (coordinatorRuntime !== null) return coordinatorRuntime;
+  const resolved = spawnSync(
     'uv',
+    ['run', '--frozen', 'python', '-c', 'import sys; print(sys.executable)'],
+    {
+      cwd: coreDir,
+      env: environment,
+      encoding: 'utf8',
+      windowsHide: true,
+    },
+  );
+  if (resolved.error) {
+    throw new Error(`failed to resolve coordinator Python: ${resolved.error.message}`);
+  }
+  if (resolved.status !== 0) {
+    throw new Error(
+      `failed to resolve coordinator Python (${resolved.status}): ${resolved.stderr.trim()}`,
+    );
+  }
+  const python = resolved.stdout.trim().split(/\r?\n/).at(-1) || '';
+  if (!path.isAbsolute(python) || !fs.existsSync(python)) {
+    throw new Error(`resolved coordinator Python is invalid: ${python}`);
+  }
+  coordinatorRuntime = {
+    python,
+    pythonDirectory: path.dirname(python),
+    virtualEnvironment: path.dirname(path.dirname(python)),
+  };
+  return coordinatorRuntime;
+}
+
+function startCoordinator() {
+  const outputPath = path.join(home, 'coordinator.out');
+  const logOffset = fs.existsSync(outputPath) ? fs.statSync(outputPath).size : 0;
+  const environment = coordinatorEnvironment();
+  const runtime = resolveCoordinatorRuntime(environment);
+  environment.VIRTUAL_ENV = runtime.virtualEnvironment;
+  environment.PATH = environment.PATH
+    ? `${runtime.pythonDirectory}${path.delimiter}${environment.PATH}`
+    : runtime.pythonDirectory;
+  const output = fs.openSync(outputPath, 'a');
+  const child = spawn(
+    runtime.python,
     [
-      'run',
-      '--frozen',
-      'python',
       '.devtools/kungfu_cli.py',
       '-H',
       home,

--- a/framework/core/tests/watcher-runtime-boundary.test.js
+++ b/framework/core/tests/watcher-runtime-boundary.test.js
@@ -42,6 +42,16 @@ const ioHeader = path.join(
   'runtime',
   'io.h',
 );
+const nanomsgSocketHeader = path.join(
+  coreDir,
+  'src',
+  'libkungfu',
+  'include',
+  'kungfu',
+  'runtime',
+  'nanomsg',
+  'socket.h',
+);
 const watcherProbeSource = fs.readFileSync(probe, 'utf8');
 const reconnectProbeSource = watcherProbeSource.slice(
   watcherProbeSource.indexOf('async function reconnectProbe()'),
@@ -143,6 +153,29 @@ test('watcher reconnect fixture sequences readiness, owns process trees, and bou
   );
   assert.match(
     watcherProbeSource,
+    /const resolved = spawnSync\(\s*'uv',[\s\S]*?'--frozen'[\s\S]*?'import sys; print\(sys\.executable\)'/,
+  );
+  assert.match(watcherProbeSource, /resolved\.status !== 0/);
+  assert.match(
+    watcherProbeSource,
+    /!path\.isAbsolute\(python\) \|\| !fs\.existsSync\(python\)/,
+  );
+  assert.match(
+    watcherProbeSource,
+    /environment\.VIRTUAL_ENV = runtime\.virtualEnvironment/,
+  );
+  assert.match(
+    watcherProbeSource,
+    /environment\.PATH = environment\.PATH[\s\S]*?runtime\.pythonDirectory/,
+  );
+  assert.match(watcherProbeSource, /const child = spawn\(\s*runtime\.python,/);
+  assert.doesNotMatch(
+    watcherProbeSource,
+    /const child = spawn\(\s*'uv'/,
+    'the owned child PID must be the coordinator, not the uv launcher',
+  );
+  assert.match(
+    watcherProbeSource,
     /signalPosixProcessTree\(child, 'SIGTERM'\)/,
   );
   assert.match(
@@ -215,6 +248,20 @@ test('peer usability persists one bounded handshake across slow-joiner retries',
     peerSetupSource,
     /std::lock_guard<std::mutex> call_guard\(usability_probe_call_mutex\);\s*\{\s*std::lock_guard<std::mutex> guard\(usability_probe_mutex_\)/,
     'setup must follow the same call-lock then state-lock order',
+  );
+  const socketHeader = fs.readFileSync(nanomsgSocketHeader, 'utf8');
+  assert.match(
+    socketHeader,
+    /#if defined\(_WIN32\)\s*inline constexpr int DEFAULT_QUIET_DIAL_FLAGS = NNG_FLAG_NONBLOCK;\s*#else\s*inline constexpr int DEFAULT_QUIET_DIAL_FLAGS = 0;/,
+  );
+  assert.match(
+    socketHeader,
+    /int dial\(const std::string &path, int flags = 0\)/,
+  );
+  assert.match(
+    socketHeader,
+    /int dial_quietly\(const std::string &path, int flags = DEFAULT_QUIET_DIAL_FLAGS\)/,
+    'Windows readiness probes must let NNG retain and retry an asynchronous dialer',
   );
   assert.doesNotMatch(
     peerCancellationSource,


### PR DESCRIPTION
## Summary

Make watcher reconnect qualification own the exact coordinator process and preserve Windows slow-joiner readiness without widening normal dial behavior.

Exact source head: 5b291c22962140f6a740d78fdf0eed337e646958.

## Related issue

Follow-up to deterministic Linux and Windows failures in post-merge qualification run 32595594845 (including rerun jobs 97092482709 and 97092482758).

## Changes

- Resolve the uv-managed Python interpreter once, then spawn and own the actual coordinator process directly.
- Sanitize inherited uv/Python environment state and bind the resolved virtual environment explicitly.
- Use an asynchronous first dial only for Windows quiet readiness probes so NNG can retain slow named-pipe connection attempts; normal dial and non-Windows defaults remain unchanged.
- Lock coordinator ownership and platform-specific quiet-dial behavior into the watcher boundary source contract.

## Verification

- Full `./shifu rebuild:core` passed.
- Five consecutive focused native watcher boundary runs passed (10/10 each).
- `git diff --check`, Biome, C++ format, complexity, changed-function-risk, architecture, and affected-native checks passed.
- Full `./shifu check:source` passed with tracked and untracked zero-write roots unchanged.
- Exact-head work admission verified before push; pre-push reported `admitted`.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Bounded watcher readiness and test-process ownership repair does not alter a production architecture contract"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable; bounded bugfix covered by source contracts)
