### PR TITLE
fix(core): preserve watcher host child reaping

### DIFF
--- a/framework/core/src/libkungfu/src/runtime/util/signal.cpp
+++ b/framework/core/src/libkungfu/src/runtime/util/signal.cpp
@@ -163,6 +163,17 @@ static LONG WINAPI kf_top_level_filter(EXCEPTION_POINTERS *ep) {
 }
 #endif // _WIN32
 
+static void install_os_signal_handler(int signum) {
+#ifndef _WIN32
+  // The embedding host owns child reaping. Replacing Node/libuv's SIGCHLD
+  // handler prevents ChildProcess from observing and reaping an exited child.
+  if (signum == SIGCHLD) {
+    return;
+  }
+#endif // _WIN32
+  signal(signum, kf_os_signal_handler);
+}
+
 void handle_os_signals(void *reactor) {
   if (reactor_instance != nullptr) {
     throw yijinjing_error("kungfu can only have one reactor instance per process");
@@ -186,7 +197,7 @@ void handle_os_signals(void *reactor) {
 #endif // _WIN32
 
   for (int s = 1; s < NSIG; s++) {
-    signal(s, kf_os_signal_handler);
+    install_os_signal_handler(s);
   }
 }
 

--- a/framework/core/tests/fixtures/watcher-runtime-probe.js
+++ b/framework/core/tests/fixtures/watcher-runtime-probe.js
@@ -82,8 +82,31 @@ function coordinatorEnvironment() {
   return environment;
 }
 
+function projectCoordinatorRuntime() {
+  const virtualEnvironment = path.resolve(
+    coreDir,
+    process.env.UV_PROJECT_ENVIRONMENT || '.venv',
+  );
+  const python = path.join(
+    virtualEnvironment,
+    process.platform === 'win32' ? 'Scripts' : 'bin',
+    process.platform === 'win32' ? 'python.exe' : 'python',
+  );
+  if (!fs.existsSync(python)) return null;
+  return {
+    python,
+    pythonDirectory: path.dirname(python),
+    virtualEnvironment,
+  };
+}
+
 function resolveCoordinatorRuntime(environment) {
   if (coordinatorRuntime !== null) return coordinatorRuntime;
+  const projectRuntime = projectCoordinatorRuntime();
+  if (projectRuntime !== null) {
+    coordinatorRuntime = projectRuntime;
+    return coordinatorRuntime;
+  }
   const resolved = spawnSync(
     'uv',
     ['run', '--frozen', 'python', '-c', 'import sys; print(sys.executable)'],

--- a/framework/core/tests/watcher-runtime-boundary.test.js
+++ b/framework/core/tests/watcher-runtime-boundary.test.js
@@ -52,6 +52,15 @@ const nanomsgSocketHeader = path.join(
   'nanomsg',
   'socket.h',
 );
+const signalSource = path.join(
+  coreDir,
+  'src',
+  'libkungfu',
+  'src',
+  'runtime',
+  'util',
+  'signal.cpp',
+);
 const watcherProbeSource = fs.readFileSync(probe, 'utf8');
 const reconnectProbeSource = watcherProbeSource.slice(
   watcherProbeSource.indexOf('async function reconnectProbe()'),
@@ -155,6 +164,24 @@ test('watcher reconnect fixture sequences readiness, owns process trees, and bou
     watcherProbeSource,
     /const resolved = spawnSync\(\s*'uv',[\s\S]*?'--frozen'[\s\S]*?'import sys; print\(sys\.executable\)'/,
   );
+  assert.match(
+    watcherProbeSource,
+    /process\.env\.UV_PROJECT_ENVIRONMENT \|\| '\.venv'/,
+    'the exact Core project environment must be usable without uv on PATH',
+  );
+  assert.match(
+    watcherProbeSource,
+    /process\.platform === 'win32' \? 'Scripts' : 'bin'/,
+  );
+  assert.match(
+    watcherProbeSource,
+    /process\.platform === 'win32' \? 'python\.exe' : 'python'/,
+  );
+  assert.match(
+    watcherProbeSource,
+    /const projectRuntime = projectCoordinatorRuntime\(\);[\s\S]*?if \(projectRuntime !== null\)[\s\S]*?return coordinatorRuntime;[\s\S]*?const resolved = spawnSync/,
+    'the project interpreter must be preferred before the uv fallback',
+  );
   assert.match(watcherProbeSource, /resolved\.status !== 0/);
   assert.match(
     watcherProbeSource,
@@ -221,6 +248,16 @@ test('watcher reconnect fixture sequences readiness, owns process trees, and bou
     'coordinator exit state is rechecked after listener installation',
   );
   assert.match(exitWaitSource, /let settled = false;/);
+  const hostSignalSource = fs.readFileSync(signalSource, 'utf8');
+  const signalInstaller = hostSignalSource.slice(
+    hostSignalSource.indexOf('static void install_os_signal_handler'),
+    hostSignalSource.indexOf('void handle_os_signals'),
+  );
+  assert.match(
+    signalInstaller,
+    /if \(signum == SIGCHLD\) \{\s*return;\s*\}[\s\S]*?signal\(signum, kf_os_signal_handler\)/,
+    'the native reactor must preserve the embedding host child-reaping handler',
+  );
 });
 
 test('peer usability persists one bounded handshake across slow-joiner retries', () => {


### PR DESCRIPTION
## Summary

Restore exact cross-platform watcher reconnect qualification by preserving the embedding host child-reaping signal handler and resolving the coordinator from the exact Core project environment before the uv fallback.

## Related issue

None.

## Changes

- leave SIGCHLD ownership with Node/libuv when Core is embedded, so ChildProcess observes and reaps coordinator exit on Linux
- resolve the fixture coordinator from the exact Core virtual environment, including the Windows Scripts/python.exe layout
- retain uv as a compatibility fallback and add source-contract coverage for both boundaries

## Verification

- ./shifu rebuild:core
- ./shifu test:node-watcher-runtime-boundary (10/10 passed, 0 skipped)
- watcher boundary with uv absent from PATH (10/10 passed, 0 skipped)
- ./shifu check:source (1169 passed, 11 declared skips, 0 failed)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix restores existing embedding-host signal ownership and cross-platform qualification fixture resolution without changing an architecture contract."
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation impact evaluated; no public documentation change is required for this internal runtime and qualification-fixture correction
