### PR TITLE
fix(core): canonicalize watcher probe runtime paths

### DIFF
--- a/framework/core/tests/fixtures/watcher-runtime-probe.js
+++ b/framework/core/tests/fixtures/watcher-runtime-probe.js
@@ -11,13 +11,16 @@ const mode = process.argv[2];
 const coreDir = path.resolve(__dirname, '..', '..');
 const binding = require(path.join(coreDir, 'dist', 'kungfu', 'kungfu_node.node'));
 const temporaryRoot = process.platform === 'win32' ? os.tmpdir() : '/tmp';
-const home = fs.mkdtempSync(path.join(temporaryRoot, 'kfwr.'));
+const home = fs.realpathSync.native(
+  fs.mkdtempSync(path.join(temporaryRoot, 'kfwr.')),
+);
+const runtimeDir = path.join(home, 'runtime');
 let watcher = null;
 let coordinatorRuntime = null;
 
 function createWatcher() {
   return new binding.Watcher(
-    path.join(home, 'runtime'),
+    runtimeDir,
     `runtime_${mode}`,
     true,
     2,
@@ -158,7 +161,7 @@ function startCoordinator() {
       '--home',
       home,
       '--runtime-dir',
-      path.join(home, 'runtime'),
+      runtimeDir,
       '--low-latency',
     ],
     {

--- a/framework/core/tests/watcher-runtime-boundary.test.js
+++ b/framework/core/tests/watcher-runtime-boundary.test.js
@@ -139,6 +139,25 @@ test('watcher dispatch bench follows and proves the load peer carrier', () => {
 test('watcher reconnect fixture sequences readiness, owns process trees, and bounds Windows transitions', () => {
   assert.match(
     watcherProbeSource,
+    /const home = fs\.realpathSync\.native\(\s*fs\.mkdtempSync\(/,
+    'the watcher and Python coordinator must share the native-canonical temp root',
+  );
+  assert.match(
+    watcherProbeSource,
+    /const runtimeDir = path\.join\(home, 'runtime'\);/,
+  );
+  assert.equal(
+    watcherProbeSource.match(/path\.join\(home, 'runtime'\)/g)?.length,
+    1,
+    'the fixture must derive its runtime path once',
+  );
+  assert.match(
+    watcherProbeSource,
+    /function createWatcher\(\) \{\s*return new binding\.Watcher\(\s*runtimeDir,/,
+  );
+  assert.match(watcherProbeSource, /'--runtime-dir',\s*runtimeDir,/);
+  assert.match(
+    watcherProbeSource,
     /watcherConnect: process\.platform === 'win32' \? 75_000 : 8_000/,
   );
   assert.match(


### PR DESCRIPTION
## Summary

Restore exact Windows watcher startup qualification by canonicalizing the fixture temporary root once and sharing one runtime directory between the Node watcher and Python coordinator.

## Related issue

None.

## Changes

- canonicalize the freshly-created probe home with `fs.realpathSync.native`
- derive one `runtimeDir` from that canonical home and pass it to both runtime peers
- add source-contract coverage that prevents path derivation from diverging again

## Verification

- `./shifu build:core`
- `./shifu test:node-watcher-runtime-boundary` (10/10 passed twice)
- `./shifu check:source` (1169 passed, 11 declared skips, 0 failed)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix restores the existing watcher qualification boundary on Windows without changing an architecture contract."
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation impact evaluated; no public documentation change is required for this qualification-fixture correction
