### PR TITLE
fix(core): preserve coordinator deregistration on Windows

### DIFF
--- a/framework/core/tests/fixtures/watcher-runtime-probe.js
+++ b/framework/core/tests/fixtures/watcher-runtime-probe.js
@@ -15,6 +15,12 @@ const home = fs.realpathSync.native(
   fs.mkdtempSync(path.join(temporaryRoot, 'kfwr.')),
 );
 const runtimeDir = path.join(home, 'runtime');
+const coordinatorStopLocation = Object.freeze({
+  mode: 'live',
+  role: 'system',
+  namespace: 'master',
+  name: 'master',
+});
 let watcher = null;
 let coordinatorRuntime = null;
 
@@ -261,28 +267,41 @@ function signalPosixProcessTree(child, signal) {
   }
 }
 
+function requestCoordinatorStop() {
+  if (watcher === null || !watcher.isLive()) return false;
+  return watcher.requestStop(coordinatorStopLocation);
+}
+
+function forceWindowsProcessTree(child) {
+  const terminated = spawnSync(
+    'taskkill',
+    ['/pid', String(child.pid), '/T', '/F'],
+    { encoding: 'utf8', windowsHide: true },
+  );
+  if (terminated.error) {
+    throw new Error(`taskkill failed to launch: ${terminated.error.message}`);
+  }
+  if (terminated.status !== 0 && child.exitCode === null) {
+    throw new Error(
+      `taskkill failed (${terminated.status}): ${terminated.stderr.trim()}`,
+    );
+  }
+}
+
 async function stopCoordinator(child) {
   if (child.exitCode !== null || child.signalCode !== null) return;
   if (process.platform === 'win32') {
-    const terminated = spawnSync(
-      'taskkill',
-      ['/pid', String(child.pid), '/T', '/F'],
-      { encoding: 'utf8', windowsHide: true },
-    );
-    if (terminated.error) {
-      throw new Error(`taskkill failed to launch: ${terminated.error.message}`);
-    }
-    if (terminated.status !== 0 && child.exitCode === null) {
-      throw new Error(
-        `taskkill failed (${terminated.status}): ${terminated.stderr.trim()}`,
-      );
-    }
+    // A forced Windows process-tree exit cannot publish the coordinator's
+    // Deregister frame. Prefer the existing command channel so the watcher
+    // observes the lifecycle boundary, then retain taskkill as a bounded
+    // fallback for a missing or unresponsive coordinator.
+    if (!requestCoordinatorStop()) forceWindowsProcessTree(child);
   } else {
     signalPosixProcessTree(child, 'SIGTERM');
   }
   if (await waitForExitWithin(child, reconnectDeadlines.coordinatorExit)) return;
   if (process.platform === 'win32') {
-    child.kill();
+    forceWindowsProcessTree(child);
   } else {
     signalPosixProcessTree(child, 'SIGKILL');
   }

--- a/framework/core/tests/watcher-runtime-boundary.test.js
+++ b/framework/core/tests/watcher-runtime-boundary.test.js
@@ -168,6 +168,16 @@ test('watcher reconnect fixture sequences readiness, owns process trees, and bou
     watcherProbeSource,
     /coordinatorExit: process\.platform === 'win32' \? 15_000 : 10_000/,
   );
+  assert.match(
+    watcherProbeSource,
+    /const coordinatorStopLocation = Object\.freeze\(\{\s*mode: 'live',\s*role: 'system',\s*namespace: 'master',\s*name: 'master',\s*\}\);/,
+    'the graceful stop request must target the exact coordinator wire',
+  );
+  assert.match(
+    watcherProbeSource,
+    /function requestCoordinatorStop\(\) \{\s*if \(watcher === null \|\| !watcher\.isLive\(\)\) return false;\s*return watcher\.requestStop\(coordinatorStopLocation\);\s*\}/,
+    'Windows must use the coordinator command channel when the watcher is live',
+  );
   assert.equal(
     watcherProbeSource.match(
       /waitForExitWithin\(child, reconnectDeadlines\.coordinatorExit\)/g,
@@ -178,6 +188,28 @@ test('watcher reconnect fixture sequences readiness, owns process trees, and bou
   assert.match(
     watcherProbeSource,
     /\['\/pid', String\(child\.pid\), '\/T', '\/F'\]/,
+  );
+  const stopCoordinatorSource = watcherProbeSource.slice(
+    watcherProbeSource.indexOf('async function stopCoordinator('),
+    watcherProbeSource.indexOf('function runChildProbe('),
+  );
+  const gracefulStopRequest = stopCoordinatorSource.indexOf(
+    'requestCoordinatorStop()',
+  );
+  const forcedTreeStop = stopCoordinatorSource.indexOf(
+    'forceWindowsProcessTree(child)',
+  );
+  assert.ok(
+    gracefulStopRequest >= 0,
+    'Windows requests graceful coordinator stop',
+  );
+  assert.ok(
+    forcedTreeStop >= 0,
+    'Windows retains a forced process-tree fallback',
+  );
+  assert.ok(
+    gracefulStopRequest < forcedTreeStop,
+    'the coordinator must publish deregistration before the forced fallback',
   );
   assert.match(
     watcherProbeSource,


### PR DESCRIPTION
## Summary

Restore the Windows watcher reconnect qualification boundary by requesting an orderly coordinator stop before using the bounded forced process-tree fallback.

## Related issue

None.

## Changes

- target the exact live system master coordinator wire through the existing watcher command channel
- allow the coordinator to publish its Deregister frame before asserting watcher reconnect behavior
- retain bounded taskkill fallback for an unavailable or unresponsive coordinator
- add source-contract coverage for the exact target and graceful-before-force ordering

## Verification

- `./shifu build:core`
- `./shifu test:node-watcher-runtime-boundary` (10/10 passed)
- `node --test scripts/readonly-agent-bootstrap.test.mjs` (1/1 passed after one transient full-gate timeout)
- `./shifu check:source` (1169 passed, 11 declared skips, 0 failed)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This test-fixture bugfix restores the existing Windows watcher lifecycle qualification without changing an architecture contract."
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation impact evaluated; no public documentation change is required for this qualification-fixture correction
