### PR TITLE
fix(core): notify watchers after coordinator deregistration

### DIFF
--- a/framework/core/src/libkungfu/src/runtime/live/coordinator.cpp
+++ b/framework/core/src/libkungfu/src/runtime/live/coordinator.cpp
@@ -61,6 +61,7 @@ void coordinator::on_exit() {
   state_service_.stop();
   notify_deregister_on_exit();
   notify_coordinator_deregister_on_exit();
+  on_notify();
 }
 
 void coordinator::notify_deregister_on_exit() {

--- a/framework/core/tests/watcher-runtime-boundary.test.js
+++ b/framework/core/tests/watcher-runtime-boundary.test.js
@@ -61,6 +61,15 @@ const signalSource = path.join(
   'util',
   'signal.cpp',
 );
+const coordinatorSource = path.join(
+  coreDir,
+  'src',
+  'libkungfu',
+  'src',
+  'runtime',
+  'live',
+  'coordinator.cpp',
+);
 const watcherProbeSource = fs.readFileSync(probe, 'utf8');
 const reconnectProbeSource = watcherProbeSource.slice(
   watcherProbeSource.indexOf('async function reconnectProbe()'),
@@ -119,6 +128,19 @@ test('watcher source does not reserve a libuv worker-pool job', () => {
     source,
     /"KungfuWatcherBridge", 1, 1/,
     'the native-to-Node bridge must remain single-slot and single-producer',
+  );
+});
+
+test('coordinator wakes watchers after publishing every exit deregistration', () => {
+  const source = fs.readFileSync(coordinatorSource, 'utf8');
+  const onExit = source.slice(
+    source.indexOf('void coordinator::on_exit()'),
+    source.indexOf('void coordinator::notify_deregister_on_exit()'),
+  );
+  assert.match(
+    onExit,
+    /notify_deregister_on_exit\(\);\s*notify_coordinator_deregister_on_exit\(\);\s*on_notify\(\);/,
+    'watchers must be notified only after peer and coordinator deregisters are written',
   );
 });
 


### PR DESCRIPTION
## Summary

Ensure watchers observe coordinator shutdown on every platform by notifying the runtime publisher after the ordered exit deregistration frames are written.

## Related issue

None.

## Changes

- notify the coordinator publisher only after peer and coordinator deregistration frames are written
- preserve the existing graceful RequestStop path and bounded forced Windows process-tree fallback
- add a fail-closed source contract that locks the deregister-before-notify ordering

## Verification

- `./shifu core:architecture --path framework/core/src/libkungfu/src/runtime/live/coordinator.cpp --json`
- `./shifu build:core`
- `node --test framework/core/tests/watcher-runtime-boundary.test.js` (11/11 passed, 0 skipped)
- `./shifu check:source` (1169 passed, 11 declared platform skips, 0 failed)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This runtime shutdown bugfix restores observable existing coordinator deregistration semantics without changing an architecture contract."
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation impact evaluated; no public documentation change is required for this runtime shutdown correction

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA4LTE4LWt1bmdmdS1tYWlubGluZS1xdWFsaXR5LWNvbnZlcmdlbmNlIiwiZGVsaXZlcnlDbGFzcyI6Im5hdGl2ZS1wcm9vZi1yZXF1aXJlZCIsImRldkhlYWQiOiJlZTljZWJiYWZkNDkyNWMyYTQyYjBiZGJkZDE0NTkxOTY3M2FmYjUzIiwicHVsbFJlcXVlc3RIZWFkIjoiNDQ5N2RmNzBmMWE2YWU2MTFhZmViMDk1YzU5YWQ4YmJmMDIzMTRjOCIsInJlcGxheWVkQ2FuZGlkYXRlIjoiZDhiMjJkNzgyZDYyODcwNGNlZGM4MDI0MTYyOWIyN2VmYzAzM2UzNSIsInJlcGxheWVkVHJlZSI6IjVhMGU1NWNiNTBjNzFlNWJjNzJiNWQ5YWVlNjIzOTRlZTU4M2I4ZTMiLCJxdWV1ZUF0dGVtcHQiOiI0NDk3ZGY3MGYxYTZhZTYxMWFmZWIwOTVjNTlhZDhiYmYwMjMxNGM4QGVlOWNlYmJhZmQ0OTI1YzJhNDJiMGJkYmRkMTQ1OTE5NjczYWZiNTMiLCJhZG1pc3Npb25Qcm9vZlJvb3QiOiJzaGEyNTY6YjYwYTlkNjA4OTgxZDdlM2JjODZhOTMyMTg3ODI2OTk2MzI5YzQ0YjFiNjgxNDVkMDdiNjUzYjBkZjE3ZWZmMiIsImFkbWlzc2lvblByb29mUm9vdHMiOlsic2hhMjU2OmI2MGE5ZDYwODk4MWQ3ZTNiYzg2YTkzMjE4NzgyNjk5NjMyOWM0NGIxYjY4MTQ1ZDA3YjY1M2IwZGYxN2VmZjIiLCJzaGEyNTY6YzA4YzNiMjk1OTQxZGM1ODIwNGIxZjQ4NzIwZTVjZDdhZDI3OTVlNmU2MzNjNjI0NTdhOWUzMjFjZWVmMDAzYyJdLCJzdGF0dXNDb250ZXh0IjoiUXVldWUgZmFtaWx5IGxlYXNlL2Q5OWYzYTkxNjY3MzllMGQiLCJsZWFzZVJvb3QiOiJzaGEyNTY6ODVmMjlmMmI5ODM2MGMzYzBkNjFhNDQ2YjJhZjU3NjZlOWVmYjJhNjQwYWI2MzUzMGRlZmVmN2ZhYWI2NWQyMSJ9 -->