### PR TITLE
fix(runtime): recover legacy completion context roots

### DIFF
--- a/framework/core/src/python/kungfu/agent/action_loop.py
+++ b/framework/core/src/python/kungfu/agent/action_loop.py
@@ -570,8 +570,10 @@ def review_completion(
             "evidenceEpisodeIds": list(completion.get("evidenceEpisodeIds") or []),
             "goSet": list(completion.get("goSet") or [completion["goalId"]]),
             "acceptanceRoot": completion.get("acceptanceRoot") or "",
-            "inputAtlasRoot": completion.get("inputAtlasRoot") or "",
-            "resultAtlasRoot": payload["envelope"]["roles"]["atlas"]["root"],
+            "inputContextRoot": completion.get("inputContextRoot")
+            or completion.get("inputAtlasRoot")
+            or "",
+            "resultContextRoot": payload["envelope"]["roles"]["atlas"]["root"],
             "projectCutRoot": completion.get("projectCutRoot") or "",
             "projectCutReceiptRoot": completion.get("projectCutReceiptRoot") or "",
             "gitCommit": completion.get("gitCommit") or "",

--- a/framework/core/src/python/kungfu/agent/action_loop.py
+++ b/framework/core/src/python/kungfu/agent/action_loop.py
@@ -550,10 +550,25 @@ def _mission_action(
     ).authorize(intent_id, values, "action-loop")
 
 
+def _completion_input_context_root(completion: dict[str, Any]) -> Any:
+    if (
+        "inputContextRoot" in completion
+        and "inputAtlasRoot" in completion
+        and completion["inputContextRoot"] != completion["inputAtlasRoot"]
+    ):
+        raise ValueError(
+            "completion inputContextRoot conflicts with legacy inputAtlasRoot"
+        )
+    if "inputContextRoot" in completion:
+        return completion["inputContextRoot"] or ""
+    return completion.get("inputAtlasRoot") or ""
+
+
 def review_completion(
     runtime_dir: str | Path, payload: dict[str, Any]
 ) -> dict[str, Any]:
     completion = payload.get("completion") or {}
+    input_context_root = _completion_input_context_root(completion)
     common = {
         "missionId": completion["missionId"],
         "goalId": completion["goalId"],
@@ -570,9 +585,7 @@ def review_completion(
             "evidenceEpisodeIds": list(completion.get("evidenceEpisodeIds") or []),
             "goSet": list(completion.get("goSet") or [completion["goalId"]]),
             "acceptanceRoot": completion.get("acceptanceRoot") or "",
-            "inputContextRoot": completion.get("inputContextRoot")
-            or completion.get("inputAtlasRoot")
-            or "",
+            "inputContextRoot": input_context_root,
             "resultContextRoot": payload["envelope"]["roles"]["atlas"]["root"],
             "projectCutRoot": completion.get("projectCutRoot") or "",
             "projectCutReceiptRoot": completion.get("projectCutReceiptRoot") or "",

--- a/framework/core/src/python/kungfu/assignment_runtime/authority.py
+++ b/framework/core/src/python/kungfu/assignment_runtime/authority.py
@@ -159,6 +159,29 @@ def _validate_command_arguments(command: Mapping[str, Any]) -> None:
         )
 
 
+def _normalize_completion_context_roots(
+    operation: str, arguments: Mapping[str, Any]
+) -> dict[str, Any]:
+    normalized = dict(arguments)
+    if operation != "claim-completion":
+        return normalized
+    for legacy, canonical in (
+        ("inputAtlasRoot", "inputContextRoot"),
+        ("resultAtlasRoot", "resultContextRoot"),
+    ):
+        if legacy not in normalized:
+            continue
+        if canonical in normalized and normalized[canonical] != normalized[legacy]:
+            raise LocalRuntimeError(
+                "invalid-command",
+                f"Conflicting {legacy} and {canonical} values",
+                details={"fields": [legacy, canonical]},
+            )
+        normalized.setdefault(canonical, normalized[legacy])
+        normalized.pop(legacy)
+    return normalized
+
+
 def _interrupted_command_rejection(
     pending: Mapping[str, Any], error: LocalRuntimeError
 ) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -215,13 +238,14 @@ class WorkControlAuthority:
     ) -> dict[str, Any]:
         from kungfu import profile_sdk
 
+        adapter_values = _normalize_completion_context_roots(operation, values)
         try:
             return profile_sdk.invoke_member_adapter(
                 self._profile_source(),
                 self.runtime_dir,
                 "work-control-actions",
                 operation,
-                dict(values),
+                adapter_values,
                 authorized_action=write,
             )
         except profile_sdk.ProfileSdkError as error:

--- a/framework/core/tests/python/test_action_loop_adapter.py
+++ b/framework/core/tests/python/test_action_loop_adapter.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
+
 from kungfu.agent import action_loop
 
 
@@ -125,3 +127,46 @@ def test_completion_claim_emits_canonical_context_roots(monkeypatch, tmp_path):
     assert claim_values["resultContextRoot"] == _root("4")
     assert "inputAtlasRoot" not in claim_values
     assert "resultAtlasRoot" not in claim_values
+
+
+@pytest.mark.parametrize(
+    ("canonical", "legacy"),
+    [(_root("6"), _root("7")), ("", _root("7"))],
+)
+def test_completion_claim_rejects_conflicting_context_roots_before_action(
+    monkeypatch, tmp_path, canonical, legacy
+):
+    calls = []
+    monkeypatch.setattr(
+        action_loop,
+        "_mission_action",
+        lambda *args: calls.append(args),
+    )
+    payload = {
+        "envelope": {"roles": {"atlas": {"root": _root("4")}}},
+        "completion": {
+            "missionId": "initiative-a",
+            "goalId": "assignment-a",
+            "statement": "Compatibility is proven.",
+            "reviewer": "independent-reviewer",
+            "reviewerSource": _root("5"),
+            "inputContextRoot": canonical,
+            "inputAtlasRoot": legacy,
+        },
+    }
+
+    with pytest.raises(ValueError, match="inputContextRoot conflicts"):
+        action_loop.review_completion(tmp_path, payload)
+
+    assert calls == []
+
+
+def test_completion_context_root_accepts_equal_canonical_and_legacy_values():
+    root = _root("6")
+
+    assert (
+        action_loop._completion_input_context_root(
+            {"inputContextRoot": root, "inputAtlasRoot": root}
+        )
+        == root
+    )

--- a/framework/core/tests/python/test_action_loop_adapter.py
+++ b/framework/core/tests/python/test_action_loop_adapter.py
@@ -83,3 +83,45 @@ def test_same_root_first_atlas_refresh_binds_receipt_then_replays(
     assert replay["writeOccurred"] is False
     assert replay["receipt"] == first["receipt"]
     assert len(calls) == 1
+
+
+def test_completion_claim_emits_canonical_context_roots(monkeypatch, tmp_path):
+    calls = []
+
+    def mission_action(_runtime_dir, intent_id, values):
+        calls.append((intent_id, values))
+        if intent_id == "claim-completion":
+            return {"receipt": {"payload_hash": _root("e")}}
+        if intent_id == "review-completion":
+            return {
+                "review": {"review_id": "review-a", "verdict": "fit"},
+                "review_root": _root("f"),
+                "continuation_plan_root": _root("1"),
+            }
+        assert intent_id == "decide-continuation"
+        return {"receipt": {"payload_hash": _root("2")}}
+
+    monkeypatch.setattr(action_loop, "_mission_action", mission_action)
+    payload = {
+        "loopId": "loop:completion",
+        "loopRoot": _root("3"),
+        "idempotencyKey": "completion",
+        "envelope": {"roles": {"atlas": {"root": _root("4")}}},
+        "completion": {
+            "missionId": "initiative-a",
+            "goalId": "assignment-a",
+            "statement": "Compatibility is proven.",
+            "reviewer": "independent-reviewer",
+            "reviewerSource": _root("5"),
+            "inputAtlasRoot": _root("6"),
+        },
+    }
+
+    result = action_loop.review_completion(tmp_path, payload)
+
+    assert result["status"] == "accepted"
+    claim_values = calls[0][1]
+    assert claim_values["inputContextRoot"] == _root("6")
+    assert claim_values["resultContextRoot"] == _root("4")
+    assert "inputAtlasRoot" not in claim_values
+    assert "resultAtlasRoot" not in claim_values

--- a/framework/core/tests/python/test_assignment_runtime.py
+++ b/framework/core/tests/python/test_assignment_runtime.py
@@ -639,6 +639,85 @@ def test_work_control_authority_strips_runtime_only_routing_ids(tmp_path, monkey
     assert result["authorityReceipt"]["result"]["coreReceipt"]["status"] == "imported"
 
 
+def test_work_control_authority_normalizes_legacy_completion_context_roots(
+    tmp_path, monkeypatch
+):
+    authority = WorkControlAuthority(tmp_path, source=PROFILE_SOURCE)
+    captured = {}
+
+    def invoke(_source, _runtime, member, operation, values, *, authorized_action):
+        captured.update(
+            member=member,
+            operation=operation,
+            values=values,
+            write=authorized_action,
+        )
+        return {"result": {"coreReceipt": {"status": "admitted"}}}
+
+    monkeypatch.setattr(authority, "_profile_source", lambda: str(PROFILE_SOURCE))
+    monkeypatch.setattr(profile_sdk, "invoke_member_adapter", invoke)
+    command = {
+        "type": "assignment.completion.claim",
+        "target": {
+            "initiativeId": "initiative-a",
+            "assignmentId": "assignment-a",
+        },
+        "arguments": {
+            "inputAtlasRoot": ROOT_A,
+            "resultAtlasRoot": ROOT_B,
+        },
+    }
+
+    authority.apply(command)
+
+    assert command["arguments"] == {
+        "inputAtlasRoot": ROOT_A,
+        "resultAtlasRoot": ROOT_B,
+    }
+    assert captured == {
+        "member": "work-control-actions",
+        "operation": "claim-completion",
+        "values": {
+            "initiativeId": "initiative-a",
+            "assignmentId": "assignment-a",
+            "inputContextRoot": ROOT_A,
+            "resultContextRoot": ROOT_B,
+        },
+        "write": True,
+    }
+
+
+def test_work_control_authority_rejects_conflicting_completion_context_roots(
+    tmp_path, monkeypatch
+):
+    authority = WorkControlAuthority(tmp_path, source=PROFILE_SOURCE)
+    invoked = False
+
+    def invoke(*_args, **_kwargs):
+        nonlocal invoked
+        invoked = True
+        return {}
+
+    monkeypatch.setattr(profile_sdk, "invoke_member_adapter", invoke)
+
+    with pytest.raises(LocalRuntimeError, match="Conflicting inputAtlasRoot"):
+        authority.apply(
+            {
+                "type": "assignment.completion.claim",
+                "target": {
+                    "initiativeId": "initiative-a",
+                    "assignmentId": "assignment-a",
+                },
+                "arguments": {
+                    "inputAtlasRoot": ROOT_A,
+                    "inputContextRoot": ROOT_B,
+                },
+            }
+        )
+
+    assert invoked is False
+
+
 def test_work_control_authority_snapshot_avoids_atlas_parity(tmp_path, monkeypatch):
     authority = WorkControlAuthority(tmp_path, source=PROFILE_SOURCE)
     operations = []
@@ -1051,6 +1130,133 @@ def test_restart_deterministically_recovers_durable_interrupted_commands(
         )
         assert inspected["result"]["command"]["recovered"] is True
         assert len(authority._read()["effects"]) == 1
+    finally:
+        recovered.close()
+
+
+def test_restart_recovers_legacy_completion_roots_without_rewriting_command_identity(
+    tmp_path, monkeypatch
+):
+    runtime_dir = tmp_path / "legacy-completion-roots" / ".kungfu" / "runtime"
+    authority = WorkControlAuthority(runtime_dir, source=PROFILE_SOURCE)
+    native_state = {"phase": "stage-ready"}
+    claim_values = []
+
+    def invoke(
+        _source,
+        _runtime,
+        _member,
+        operation,
+        values,
+        *,
+        authorized_action=False,
+    ):
+        if operation == "portfolio":
+            return {
+                "result": {
+                    "assignments": [
+                        {
+                            "initiative_id": "initiative-a",
+                            "assignment_id": "assignment-a",
+                            "status": native_state["phase"],
+                        }
+                    ]
+                },
+                "profileSuiteRoot": ROOT_A,
+                "memberRoot": ROOT_B,
+            }
+        if operation == "assignment-status":
+            return {
+                "result": {
+                    "phase": native_state["phase"],
+                    "execution_claims": [],
+                    "active_lease": None,
+                }
+            }
+        if operation == "runtime-authority-status":
+            return {
+                "result": {
+                    "authority": {
+                        "state": "native-only",
+                        "write_authority": "kungfu-native",
+                    }
+                }
+            }
+        assert operation == "claim-completion"
+        assert authorized_action is True
+        claim_values.append(copy.deepcopy(values))
+        native_state["phase"] = "completion-claimed"
+        return {"result": {"coreReceipt": {"status": "admitted"}}}
+
+    monkeypatch.setattr(authority, "_profile_source", lambda: str(PROFILE_SOURCE))
+    monkeypatch.setattr(profile_sdk, "invoke_member_adapter", invoke)
+    runtime = EmbeddedLocalAssignmentRuntime(
+        runtime_dir,
+        realm_id=REALM["realmId"],
+        generation=REALM["generation"],
+        authority=authority,
+        contract=ASSIGNMENT_RUNTIME_CONTRACT,
+        request_schema=ENVELOPE_SCHEMA,
+    ).start()
+    snapshot = _handle(
+        runtime, _request("assignment.snapshot", "assignment.snapshot.read")
+    )
+    command = _command(
+        snapshot["revision"],
+        command_id="command.legacy.completion",
+        idempotency_key="idem.legacy.completion",
+        command_type="assignment.completion.claim",
+    )
+    command["arguments"] = {
+        "inputAtlasRoot": ROOT_A,
+        "resultAtlasRoot": ROOT_B,
+    }
+    original_command = copy.deepcopy(command)
+    command_root = _root(command)
+    runtime._state["pending"] = {
+        "commandRoot": command_root,
+        "command": command,
+        "beforeRevision": snapshot["revision"],
+        "requestId": "legacy.completion",
+    }
+    runtime._save_state()
+    runtime.close()
+
+    persisted = json.loads(
+        (runtime_dir / "assignment-runtime" / "local-v1" / "state.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert persisted["pending"]["command"] == original_command
+
+    recovered = EmbeddedLocalAssignmentRuntime(
+        runtime_dir,
+        realm_id=REALM["realmId"],
+        generation=REALM["generation"],
+        authority=authority,
+        contract=ASSIGNMENT_RUNTIME_CONTRACT,
+        request_schema=ENVELOPE_SCHEMA,
+    ).start()
+    try:
+        assert recovered._state["pending"] is None
+        record = recovered._state["commands"]["idem.legacy.completion"]
+        assert record["commandRoot"] == command_root
+        assert record["recovered"] is True
+        assert command == original_command
+        assert claim_values == [
+            {
+                "initiativeId": "initiative-a",
+                "assignmentId": "assignment-a",
+                "inputContextRoot": ROOT_A,
+                "resultContextRoot": ROOT_B,
+            }
+        ]
+        readback = _handle(
+            recovered,
+            _request("assignment.snapshot", "assignment.snapshot.read"),
+        )
+        assert readback["status"] == "ok"
+        assert readback["result"]["assignments"][0]["phase"] == ("completion-claimed")
     finally:
         recovered.close()
 

--- a/framework/core/tests/python/test_work_control_profile.py
+++ b/framework/core/tests/python/test_work_control_profile.py
@@ -519,6 +519,29 @@ def test_native_work_control_receipts_do_not_leak_compatibility_vocabulary(
     assert status["phase"] == "admitted"
 
 
+def test_public_work_control_adapter_rejects_legacy_completion_root_names(tmp_path):
+    runtime = tmp_path / "runtime"
+    _activate(SOURCE, runtime)
+    _materialize_contract(SOURCE, runtime)
+
+    with pytest.raises(profile_sdk.ProfileSdkError) as raised:
+        profile_sdk.invoke_member_adapter(
+            SOURCE,
+            runtime,
+            "work-control-actions",
+            "claim-completion",
+            {
+                "initiativeId": "initiative-a",
+                "assignmentId": "assignment-a",
+                "inputAtlasRoot": "sha256:legacy-input",
+                "resultAtlasRoot": "sha256:legacy-result",
+            },
+            authorized_action=True,
+        )
+
+    assert raised.value.diagnosis["code"] == "member-adapter-invoke-failed"
+
+
 def test_native_initiative_bundle_roundtrip(tmp_path):
     source = tmp_path / "source-runtime"
     destination = tmp_path / "destination-runtime"


### PR DESCRIPTION
## Summary

- normalize legacy `inputAtlasRoot` / `resultAtlasRoot` only at the private Work Control claim-completion authority boundary
- keep durable pending command bytes and command roots unchanged while allowing current runtimes to replay pre-migration completion claims
- keep the public Work Control adapter strict and make canonical/legacy root conflicts fail closed before any mission action
- preserve public CLI, persistence, Work schemas, and all cross-language boundaries

This compatibility repair unblocks authoritative recovery of an already durable completion claim created by an older installed runtime. It does not edit or bypass native Assignment state.

## Verification

- focused Assignment runtime/action-loop compatibility tests — passed, including legacy-only replay, equal roots, canonical/legacy conflicts, empty-canonical conflicts, result-root conflicts, and zero mission actions on invalid input
- exact-head changed-code risk ratchet — 5 changed paths, 10 fast extractions, 2,625 full-path extractions, 0 blocking findings
- exact-head Python structure — `sha256:bc5372...`, 0 blocking issues
- exact-head semantic amplification — 7 families, 103 surfaces, 0 issues
- exact queue replay against protected `f81e4555814a07219c34d7e3b38e93285e82d87d` — qualified; candidate `5d2062c6...`, candidate tree exact to HEAD, replayed 2, `compositionChanged=false`
- exact-head full `./shifu check:source` — passed; Node source corpus, runtime upgrade, desktop adapter, Ruff, mypy (256 sources), formatting, and zero-write checks green
- independent exact review — 0 blocking findings
- fresh Atlas/Kungfu work admission — verified at `d0fd3eab30db5345e6d9ca9b087a18d4d1b71dd9`, binding `sha256:cb3b854e0dcb8e1682021c3cf98cf68ee94fc779438574b1cea01959b7d6583d`

## Compatibility and scope

- no watcher, GUI/TUI, C++ runtime, Node binding, dependency, or lockfile change
- no public import, CLI parameter, persistence-format, schema, or native-binding change
- the public adapter remains strict; compatibility is confined to the private authority invocation path

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This private Work Control replay compatibility repair preserves public APIs, CLI behavior, persistence formats, authority semantics, and cross-language contracts."
}
-->