### PR TITLE
fix(core): publish watcher coordinator stop

### DIFF
--- a/framework/core/src/bindings/node/binding/watcher.cpp
+++ b/framework/core/src/bindings/node/binding/watcher.cpp
@@ -190,10 +190,17 @@ Napi::Value Watcher::RequestStop(const Napi::CallbackInfo &info) {
   // Stop the coordinator through its per-peer command channel.
   if (app_location->role == location_role::SYSTEM &&
       runtime::live::is_coordinator_wire_namespace(app_location->namespace_)) {
+    std::lock_guard<std::mutex> guard(feed_mutex_);
     if (not has_writer(get_coordinator_command_uid())) {
       return Napi::Boolean::New(info.Env(), false);
     }
-    get_writer(get_coordinator_command_uid())->mark(now(), RequestStop::tag);
+    auto writer = get_writer(get_coordinator_command_uid());
+    writer->mark(now(), RequestStop::tag);
+    writer->get_current_page()->flush();
+    // A Windows peer in low-latency mode cannot rely on notify(), and the
+    // coordinator must observe this frame before the fixture's forced-exit
+    // fallback can run. Publish only after the command page is visible.
+    get_io_device()->get_publisher()->publish("{}", 0);
     return Napi::Boolean::New(info.Env(), true);
   }
 

--- a/framework/core/tests/watcher-runtime-boundary.test.js
+++ b/framework/core/tests/watcher-runtime-boundary.test.js
@@ -169,6 +169,24 @@ test('coordinator flushes exit deregistrations before a blocking shutdown notice
   );
 });
 
+test('watcher flushes a coordinator stop before its blocking notice', () => {
+  const source = fs.readFileSync(watcherSource, 'utf8');
+  const requestStop = source.slice(
+    source.indexOf('Napi::Value Watcher::RequestStop'),
+    source.indexOf('Napi::Value Watcher::PublishState'),
+  );
+  assert.match(
+    requestStop,
+    /std::lock_guard<std::mutex> guard\(feed_mutex_\);[\s\S]*?auto writer = get_writer\(get_coordinator_command_uid\(\)\);/,
+    'the Node thread must serialize the coordinator command with the native step thread',
+  );
+  assert.match(
+    requestStop,
+    /writer->mark\(now\(\), RequestStop::tag\);\s*writer->get_current_page\(\)->flush\(\);\s*[\s\S]*?get_io_device\(\)->get_publisher\(\)->publish\("\{\}", 0\);/,
+    'Windows must see the stop frame before the blocking coordinator notice',
+  );
+});
+
 test('watcher dispatch bench follows and proves the load peer carrier', () => {
   const peer = fs.readFileSync(watcherBench, 'utf8');
   const driver = fs.readFileSync(watcherBenchDriver, 'utf8');


### PR DESCRIPTION
## Summary

Make a Node-issued coordinator stop visible on every platform by serializing the coordinator command writer, flushing the RequestStop frame, and issuing one blocking publisher notice.

This is a new exact-head repair after PR #3387 merged and its Windows post-merge advisory exposed that the sender-side stop frame could remain invisible until the fixture forced coordinator termination. No admission, review, or Warrant from PR #3387 or the superseded conflicting PR #3391 is reused.

## Related issue

None.

## Changes

- serialize coordinator command writes with the watcher native step thread
- flush the RequestStop journal page before notifying the coordinator
- bypass the intentional low-latency notify no-op with one blocking publish
- add a fail-closed source contract for serialize, mark, flush, then publish ordering

## Verification

- ./shifu rebuild:core
- ./shifu test:node-watcher-runtime-boundary (12/12 passed, including real reconnect)
- ./shifu test:agent-session-peer-transport:native (4/4 passed)
- ./shifu check:source (1180 tests: 1169 passed, 11 declared platform skips, 0 failed; build-free source gate passed)
- pre-commit staged gate passed

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This runtime shutdown bugfix restores observable existing coordinator stop semantics without changing an architecture contract."
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation impact evaluated; no public documentation change is required for this runtime shutdown correction
