### PR TITLE
feat(kfx): adopt runtime warrants in product hosts

### DIFF
--- a/.buildchain/kfd/kfd-2/claims/cross-language-authority-membrane.json
+++ b/.buildchain/kfd/kfd-2/claims/cross-language-authority-membrane.json
@@ -61,7 +61,7 @@
       "pointer": {
         "kind": "file",
         "path": "docs/adr/KF-ADR-019f8c53-6105-71e5-8f34-53f2a81ee61c.md",
-        "sha256": "413f530bb52a299c481150b18cdaf5b6536934014176c1af8c9aadf60f0d7a9b"
+        "sha256": "1d89fcf741abd3b597ea531719881121eadfc0bdb33ff3c13bfcfc1ab7d74297"
       },
       "description": "Accepted one-native-owner and four-language projection decision with explicit non-claims."
     }
@@ -92,7 +92,7 @@
       },
       {
         "path": "docs/adr/KF-ADR-019f8c53-6105-71e5-8f34-53f2a81ee61c.md",
-        "sha256": "413f530bb52a299c481150b18cdaf5b6536934014176c1af8c9aadf60f0d7a9b"
+        "sha256": "1d89fcf741abd3b597ea531719881121eadfc0bdb33ff3c13bfcfc1ab7d74297"
       }
     ],
     "artifactSha256": [

--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.3",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.3",
-    "sourceSha": "5abb2905f695f3c6f666b3d0a13ae85eb26dd067"
+    "sourceSha": "7da2b72c20d680349e031ce2ff15796b46c762df"
   },
   "claims": [
     {
@@ -360,7 +360,7 @@
           "pointer": {
             "kind": "file",
             "path": "docs/adr/KF-ADR-019f8c53-6105-71e5-8f34-53f2a81ee61c.md",
-            "sha256": "413f530bb52a299c481150b18cdaf5b6536934014176c1af8c9aadf60f0d7a9b"
+            "sha256": "1d89fcf741abd3b597ea531719881121eadfc0bdb33ff3c13bfcfc1ab7d74297"
           },
           "description": "Accepted one-native-owner and four-language projection decision with explicit non-claims."
         }

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "5abb2905f695f3c6f666b3d0a13ae85eb26dd067",
+    "sourceSha": "7da2b72c20d680349e031ce2ff15796b46c762df",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:1da3f77d18ac159f14f16275fd77d1e094164324f73ddb67dfcc0bfe9d9a9554"
   },

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -542,7 +542,7 @@
         "evidenceRoots": [
           {
             "path": "framework/kfx/evidence/kfd-10/runtime-warrant-adopter.json",
-            "sha256": "sha256:621faa1c11c0670d95db01c17ad00fca44d22c89f0b65299664c9a20da981d06"
+            "sha256": "sha256:633260fba51ddf10b83050cb77b7a9797ca21c2b3972d2f571443002a2382a4f"
           }
         ]
       },

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:e2f65fab3e3545baa951c45e05474bca9a98fdc77aa773958ee3cb8e161d7176"
+          "sha256": "sha256:c6c894a2482bb4e57989be440b2779bb37c4e205d194577cae37cbcb7d2d988c"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",
@@ -542,7 +542,7 @@
         "evidenceRoots": [
           {
             "path": "framework/kfx/evidence/kfd-10/runtime-warrant-adopter.json",
-            "sha256": "sha256:5b73b540e87dd1d15033251b3f1dd942a762b19471cdaafccebd550d5b06f3c6"
+          "sha256": "sha256:a8737dcc0bab9543d1e22e0f32a58a16f95976606db8d9e456170ad781ba46b7"
           }
         ]
       },

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -542,7 +542,7 @@
         "evidenceRoots": [
           {
             "path": "framework/kfx/evidence/kfd-10/runtime-warrant-adopter.json",
-            "sha256": "sha256:633260fba51ddf10b83050cb77b7a9797ca21c2b3972d2f571443002a2382a4f"
+            "sha256": "sha256:5b73b540e87dd1d15033251b3f1dd942a762b19471cdaafccebd550d5b06f3c6"
           }
         ]
       },
@@ -563,7 +563,7 @@
       "claimClass": "draft-adopter-evidence",
       "knownLimitations": [
         "This is first-party specialized adopter evidence for design feedback, not KFD-10 conformance, activation, independent certification or shipped support.",
-        "The Core API is source-qualified; product host adapters do not yet consume leased Runtime Warrants by default."
+        "Product host adoption is limited to the first-party specialized witness and does not establish independent KFD-10 conformance."
       ],
       "owner": "kungfu-kfx-control",
       "nextGate": "Keep evidence non-conforming until KFD-10 activation and an adopter qualification contract exist."

--- a/developer/sdk/kfd/kfd-2/claims/cross-language-authority-membrane.json
+++ b/developer/sdk/kfd/kfd-2/claims/cross-language-authority-membrane.json
@@ -61,7 +61,7 @@
       "pointer": {
         "kind": "file",
         "path": "docs/adr/KF-ADR-019f8c53-6105-71e5-8f34-53f2a81ee61c.md",
-        "sha256": "413f530bb52a299c481150b18cdaf5b6536934014176c1af8c9aadf60f0d7a9b"
+        "sha256": "1d89fcf741abd3b597ea531719881121eadfc0bdb33ff3c13bfcfc1ab7d74297"
       },
       "description": "Accepted one-native-owner and four-language projection decision with explicit non-claims."
     }
@@ -92,7 +92,7 @@
       },
       {
         "path": "docs/adr/KF-ADR-019f8c53-6105-71e5-8f34-53f2a81ee61c.md",
-        "sha256": "413f530bb52a299c481150b18cdaf5b6536934014176c1af8c9aadf60f0d7a9b"
+        "sha256": "1d89fcf741abd3b597ea531719881121eadfc0bdb33ff3c13bfcfc1ab7d74297"
       }
     ],
     "artifactSha256": [

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.3",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.3",
-    "sourceSha": "5abb2905f695f3c6f666b3d0a13ae85eb26dd067"
+    "sourceSha": "7da2b72c20d680349e031ce2ff15796b46c762df"
   },
   "claims": [
     {
@@ -360,7 +360,7 @@
           "pointer": {
             "kind": "file",
             "path": "docs/adr/KF-ADR-019f8c53-6105-71e5-8f34-53f2a81ee61c.md",
-            "sha256": "413f530bb52a299c481150b18cdaf5b6536934014176c1af8c9aadf60f0d7a9b"
+            "sha256": "1d89fcf741abd3b597ea531719881121eadfc0bdb33ff3c13bfcfc1ab7d74297"
           },
           "description": "Accepted one-native-owner and four-language projection decision with explicit non-claims."
         }

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -542,7 +542,7 @@
         "evidenceRoots": [
           {
             "path": "framework/kfx/evidence/kfd-10/runtime-warrant-adopter.json",
-            "sha256": "sha256:621faa1c11c0670d95db01c17ad00fca44d22c89f0b65299664c9a20da981d06"
+            "sha256": "sha256:633260fba51ddf10b83050cb77b7a9797ca21c2b3972d2f571443002a2382a4f"
           }
         ]
       },

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:e2f65fab3e3545baa951c45e05474bca9a98fdc77aa773958ee3cb8e161d7176"
+            "sha256": "sha256:c6c894a2482bb4e57989be440b2779bb37c4e205d194577cae37cbcb7d2d988c"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",
@@ -542,7 +542,7 @@
         "evidenceRoots": [
           {
             "path": "framework/kfx/evidence/kfd-10/runtime-warrant-adopter.json",
-            "sha256": "sha256:5b73b540e87dd1d15033251b3f1dd942a762b19471cdaafccebd550d5b06f3c6"
+            "sha256": "sha256:a8737dcc0bab9543d1e22e0f32a58a16f95976606db8d9e456170ad781ba46b7"
           }
         ]
       },

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -542,7 +542,7 @@
         "evidenceRoots": [
           {
             "path": "framework/kfx/evidence/kfd-10/runtime-warrant-adopter.json",
-            "sha256": "sha256:633260fba51ddf10b83050cb77b7a9797ca21c2b3972d2f571443002a2382a4f"
+            "sha256": "sha256:5b73b540e87dd1d15033251b3f1dd942a762b19471cdaafccebd550d5b06f3c6"
           }
         ]
       },
@@ -563,7 +563,7 @@
       "claimClass": "draft-adopter-evidence",
       "knownLimitations": [
         "This is first-party specialized adopter evidence for design feedback, not KFD-10 conformance, activation, independent certification or shipped support.",
-        "The Core API is source-qualified; product host adapters do not yet consume leased Runtime Warrants by default."
+        "Product host adoption is limited to the first-party specialized witness and does not establish independent KFD-10 conformance."
       ],
       "owner": "kungfu-kfx-control",
       "nextGate": "Keep evidence non-conforming until KFD-10 activation and an adopter qualification contract exist."

--- a/docs/adr/KF-ADR-019f86da-4f90-72df-add3-948f3ae38c3a.md
+++ b/docs/adr/KF-ADR-019f86da-4f90-72df-add3-948f3ae38c3a.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: KF-ADR-019f86da-4f90-72df-add3-948f3ae38c3a
 decision_status: accepted
 implementation_status: implemented
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/734, https://github.com/kungfu-systems/kungfu/pull/842, https://github.com/kungfu-systems/kungfu/pull/873, https://github.com/kungfu-systems/kungfu/pull/906, https://github.com/kungfu-systems/kungfu/pull/922, https://github.com/kungfu-systems/kungfu/pull/1137, https://github.com/kungfu-systems/kungfu/pull/1151, https://github.com/kungfu-systems/kungfu/pull/1202, https://github.com/kungfu-systems/kungfu/pull/1704, https://github.com/kungfu-systems/kungfu/pull/1718, https://github.com/kungfu-systems/kungfu/pull/1728, https://github.com/kungfu-systems/kungfu/pull/1744, https://github.com/kungfu-systems/kungfu/pull/1771, https://github.com/kungfu-systems/kungfu/pull/1784, https://github.com/kungfu-systems/kungfu/pull/3140]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/734, https://github.com/kungfu-systems/kungfu/pull/842, https://github.com/kungfu-systems/kungfu/pull/873, https://github.com/kungfu-systems/kungfu/pull/906, https://github.com/kungfu-systems/kungfu/pull/922, https://github.com/kungfu-systems/kungfu/pull/1137, https://github.com/kungfu-systems/kungfu/pull/1151, https://github.com/kungfu-systems/kungfu/pull/1202, https://github.com/kungfu-systems/kungfu/pull/1704, https://github.com/kungfu-systems/kungfu/pull/1718, https://github.com/kungfu-systems/kungfu/pull/1728, https://github.com/kungfu-systems/kungfu/pull/1744, https://github.com/kungfu-systems/kungfu/pull/1771, https://github.com/kungfu-systems/kungfu/pull/1784, https://github.com/kungfu-systems/kungfu/pull/3140, https://github.com/kungfu-systems/kungfu/pull/3395]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/1784
 qualification_refs: [framework/kfx/tooling/run-identity-neutral-terminal-qualification.mjs, docs/qualification/kfx-identity-neutral-terminal.md, framework/api/tests/kfx-host.test.ts, framework/gui/src/agent-work-lab.test.ts, framework/tui/src/agent-work-lab-view.test.ts, framework/core/src/libkungfu/tests/native_kfx_service_host_tests.cpp, framework/kfx/evidence/kfd-10/runtime-warrant-adopter.json]
 review_state: self-reviewed
@@ -14,7 +14,7 @@ period: 2026-07-15
 theme: surface-neutral-kfx-contributions-thin-bindings
 confidence: high
 evidence_grade: B
-last_reviewed: 2026-08-15
+last_reviewed: 2026-08-24
 ---
 
 # KF-ADR-019f86da-4f90-72df-add3-948f3ae38c3a: KFX contributes semantics once; GUI, TUI, CLI, and agents project them
@@ -130,6 +130,12 @@ Native Core owns issue, heartbeat, revoke, recovery, and settlement, while the
 Python service and host dispatcher only carry exact requests and receipts.
 Neither a surface nor the KFD-10 witness can infer a lease, widen capabilities,
 replace a root, activate an adopter, or publish a release.
+
+PR #3395 extends the thin projection to the public API edge, TUI Node/Python/C++
+service host, native WASM host, and Rewind Node/Python adapters. Those hosts
+adopt, heartbeat, fence, and settle only the exact Core receipt; they do not
+rescan authority, recover a live holder, or collapse capability, Warrant,
+Episode, and Settlement roots into a surface-private decision.
 
 ## Decision
 

--- a/docs/adr/KF-ADR-019f86da-4f90-73f3-b027-c343b2bc8bcc.md
+++ b/docs/adr/KF-ADR-019f86da-4f90-73f3-b027-c343b2bc8bcc.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: KF-ADR-019f86da-4f90-73f3-b027-c343b2bc8bcc
 decision_status: accepted
 implementation_status: implemented
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/568, https://github.com/kungfu-systems/kungfu/pull/734, https://github.com/kungfu-systems/kungfu/pull/815, https://github.com/kungfu-systems/kungfu/pull/906, https://github.com/kungfu-systems/kungfu/pull/922, https://github.com/kungfu-systems/kungfu/pull/1704, https://github.com/kungfu-systems/kungfu/pull/1718, https://github.com/kungfu-systems/kungfu/pull/1728, https://github.com/kungfu-systems/kungfu/pull/1744, https://github.com/kungfu-systems/kungfu/pull/1771, https://github.com/kungfu-systems/kungfu/pull/1784, https://github.com/kungfu-systems/kungfu/pull/3140]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/568, https://github.com/kungfu-systems/kungfu/pull/734, https://github.com/kungfu-systems/kungfu/pull/815, https://github.com/kungfu-systems/kungfu/pull/906, https://github.com/kungfu-systems/kungfu/pull/922, https://github.com/kungfu-systems/kungfu/pull/1704, https://github.com/kungfu-systems/kungfu/pull/1718, https://github.com/kungfu-systems/kungfu/pull/1728, https://github.com/kungfu-systems/kungfu/pull/1744, https://github.com/kungfu-systems/kungfu/pull/1771, https://github.com/kungfu-systems/kungfu/pull/1784, https://github.com/kungfu-systems/kungfu/pull/3140, https://github.com/kungfu-systems/kungfu/pull/3395]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/1784
 qualification_refs: [framework/kfx/tooling/run-identity-neutral-terminal-qualification.mjs, docs/qualification/kfx-identity-neutral-terminal.md, framework/core/src/libkungfu/tests/native_kfx_contract_tests.cpp, framework/core/src/libkungfu/tests/native_kfx_service_host_tests.cpp, framework/kfx/evidence/kfd-10/runtime-warrant-adopter.json]
 review_state: self-reviewed
@@ -14,7 +14,7 @@ period: 2026-07-15
 theme: transactional-kfx-package-lifecycle-authority
 confidence: high
 evidence_grade: B
-last_reviewed: 2026-08-15
+last_reviewed: 2026-08-24
 ---
 
 # KF-ADR-019f86da-4f90-73f3-b027-c343b2bc8bcc: KFX packages are immutable content; Core owns transactional lifecycle state
@@ -114,6 +114,12 @@ purpose, capability, generation, fencing token, heartbeat, expiry, revocation,
 recovery, and residual settlement to exact Fact/Cut roots. Stale, duplicated,
 expired, revoked, amplified, or root-substituted operations fail closed, while
 the KFD-10 row remains draft adopter evidence rather than activation.
+
+PR #3395 makes product hosts consume that Core-owned lease by default without
+moving lease state into the package store or a host-private registry. Crash
+recovery advances the Core generation and fence, live leases cannot be stolen,
+and heartbeat loss or terminal-settlement failure closes execution. The host
+retains no authority to mint, recover, revoke, or substitute a Runtime Warrant.
 
 ## Decision
 

--- a/docs/adr/KF-ADR-019f86da-4f90-7d6c-926a-ddd27dbde8ab.md
+++ b/docs/adr/KF-ADR-019f86da-4f90-7d6c-926a-ddd27dbde8ab.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: KF-ADR-019f86da-4f90-7d6c-926a-ddd27dbde8ab
 decision_status: accepted
 implementation_status: implemented
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/571, https://github.com/kungfu-systems/kungfu/pull/568, https://github.com/kungfu-systems/kungfu/pull/731, https://github.com/kungfu-systems/kungfu/pull/734, https://github.com/kungfu-systems/kungfu/pull/906, https://github.com/kungfu-systems/kungfu/pull/922, https://github.com/kungfu-systems/kungfu/pull/942, https://github.com/kungfu-systems/kungfu/pull/975, https://github.com/kungfu-systems/kungfu/pull/1704, https://github.com/kungfu-systems/kungfu/pull/1718, https://github.com/kungfu-systems/kungfu/pull/1728, https://github.com/kungfu-systems/kungfu/pull/1744, https://github.com/kungfu-systems/kungfu/pull/1771, https://github.com/kungfu-systems/kungfu/pull/1784, https://github.com/kungfu-systems/kungfu/pull/3140]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/571, https://github.com/kungfu-systems/kungfu/pull/568, https://github.com/kungfu-systems/kungfu/pull/731, https://github.com/kungfu-systems/kungfu/pull/734, https://github.com/kungfu-systems/kungfu/pull/906, https://github.com/kungfu-systems/kungfu/pull/922, https://github.com/kungfu-systems/kungfu/pull/942, https://github.com/kungfu-systems/kungfu/pull/975, https://github.com/kungfu-systems/kungfu/pull/1704, https://github.com/kungfu-systems/kungfu/pull/1718, https://github.com/kungfu-systems/kungfu/pull/1728, https://github.com/kungfu-systems/kungfu/pull/1744, https://github.com/kungfu-systems/kungfu/pull/1771, https://github.com/kungfu-systems/kungfu/pull/1784, https://github.com/kungfu-systems/kungfu/pull/3140, https://github.com/kungfu-systems/kungfu/pull/3395]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/1784
 qualification_refs: [framework/core/src/libkungfu/tests/fixtures/native_kfx_contract/buildchain-2.13.0-alpha.0-envelope.json, framework/core/src/libkungfu/tests/native_kfx_contract_tests.cpp, framework/core/tests/python/test_native_kfx_contract.py, framework/core/tests/storage-node-binding.test.js, framework/api/tests/storage.test.ts, framework/kfx/tooling/run-identity-neutral-terminal-qualification.mjs, docs/qualification/kfx-identity-neutral-terminal.md, framework/core/src/libkungfu/tests/native_kfx_service_host_tests.cpp, framework/kfx/evidence/kfd-10/runtime-warrant-adopter.json]
 review_state: self-reviewed
@@ -14,7 +14,7 @@ period: 2026-07-15
 theme: kfd-aware-kfx-trust-buildchain-admission
 confidence: high
 evidence_grade: B
-last_reviewed: 2026-08-15
+last_reviewed: 2026-08-24
 ---
 
 # KF-ADR-019f86da-4f90-7d6c-926a-ddd27dbde8ab: KFX admission consumes KFD facts and exact Buildchain attestations
@@ -153,6 +153,12 @@ or settle a Runtime Warrant; Core verifies the lease generation, fencing,
 holder, purpose, attenuated capabilities, heartbeat, expiry, revocation, and
 roots. The manifest evidence remains draft and cannot activate an adopter or
 broaden its privileges.
+
+PR #3395 projects the draft witness onto real product-host adoption evidence.
+The evidence covers generation, fencing, heartbeat, expiry, revocation,
+crash/recovery, terminal settlement, replay, and root substitution, but it does
+not upgrade KFD-10 to conforming or shipped. KFD facts still neither mint the
+lease nor widen the separately admitted capability grant.
 
 ## Decision
 

--- a/docs/adr/KF-ADR-019f86da-4f90-7ef4-b28b-ee1fbaf9e62e.md
+++ b/docs/adr/KF-ADR-019f86da-4f90-7ef4-b28b-ee1fbaf9e62e.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: KF-ADR-019f86da-4f90-7ef4-b28b-ee1fbaf9e62e
 decision_status: accepted
 implementation_status: implemented
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/842, https://github.com/kungfu-systems/kungfu/pull/873, https://github.com/kungfu-systems/kungfu/pull/885, https://github.com/kungfu-systems/kungfu/pull/906, https://github.com/kungfu-systems/kungfu/pull/922, https://github.com/kungfu-systems/kungfu/pull/1704, https://github.com/kungfu-systems/kungfu/pull/1718, https://github.com/kungfu-systems/kungfu/pull/1728, https://github.com/kungfu-systems/kungfu/pull/1744, https://github.com/kungfu-systems/kungfu/pull/1771, https://github.com/kungfu-systems/kungfu/pull/1784, https://github.com/kungfu-systems/kungfu/pull/3140]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/842, https://github.com/kungfu-systems/kungfu/pull/873, https://github.com/kungfu-systems/kungfu/pull/885, https://github.com/kungfu-systems/kungfu/pull/906, https://github.com/kungfu-systems/kungfu/pull/922, https://github.com/kungfu-systems/kungfu/pull/1704, https://github.com/kungfu-systems/kungfu/pull/1718, https://github.com/kungfu-systems/kungfu/pull/1728, https://github.com/kungfu-systems/kungfu/pull/1744, https://github.com/kungfu-systems/kungfu/pull/1771, https://github.com/kungfu-systems/kungfu/pull/1784, https://github.com/kungfu-systems/kungfu/pull/3140, https://github.com/kungfu-systems/kungfu/pull/3395]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/1784
 qualification_refs: [framework/kfx/tooling/run-identity-neutral-terminal-qualification.mjs, docs/qualification/kfx-identity-neutral-terminal.md, framework/core/src/libkungfu/tests/native_kfx_contract_tests.cpp, framework/core/src/libkungfu/tests/native_kfx_service_host_tests.cpp, framework/kfx/evidence/kfd-10/runtime-warrant-adopter.json]
 review_state: self-reviewed
@@ -14,7 +14,7 @@ period: 2026-07-15
 theme: core-native-multisurface-kfx-runtime
 confidence: high
 evidence_grade: B
-last_reviewed: 2026-08-15
+last_reviewed: 2026-08-24
 ---
 
 # KF-ADR-019f86da-4f90-7ef4-b28b-ee1fbaf9e62e: one Core-native KFX runtime serves GUI, TUI, CLI, and agents
@@ -136,6 +136,13 @@ heartbeats, revokes, recovers, and settles generation- and fencing-bound
 leases; host and Python surfaces remain thin projections. The witness keeps
 one-shot Mutation Warrants distinct and does not let KFD status activate a
 package, grant runtime privilege, or publish a release.
+
+PR #3395 carries that lease into the real API, TUI service, native WASM, and
+Rewind adapter hosts. Each host adopts before execution, heartbeats the exact
+generation and fence, and settles the terminal outcome; stale, duplicate,
+expired, revoked, or root-substituted use fails closed. Capability grants,
+Mutation Warrants, Runtime Warrants, Episodes, and Settlements remain distinct
+authorities, while KFD-10 remains draft, non-conforming adopter evidence.
 
 ## Decision
 

--- a/docs/adr/KF-ADR-019f8c53-6105-71e5-8f34-53f2a81ee61c.md
+++ b/docs/adr/KF-ADR-019f8c53-6105-71e5-8f34-53f2a81ee61c.md
@@ -4,7 +4,7 @@ doc_type: architecture-decision
 adr_id: KF-ADR-019f8c53-6105-71e5-8f34-53f2a81ee61c
 decision_status: accepted
 implementation_status: implemented
-implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1388, https://github.com/kungfu-systems/kungfu/pull/1404, https://github.com/kungfu-systems/kungfu/pull/1458, https://github.com/kungfu-systems/kungfu/pull/1473, https://github.com/kungfu-systems/kungfu/pull/1487, https://github.com/kungfu-systems/kungfu/pull/1718, https://github.com/kungfu-systems/kungfu/pull/1728, https://github.com/kungfu-systems/kungfu/pull/1744, https://github.com/kungfu-systems/kungfu/pull/3140]
+implementation_prs: [https://github.com/kungfu-systems/kungfu/pull/1388, https://github.com/kungfu-systems/kungfu/pull/1404, https://github.com/kungfu-systems/kungfu/pull/1458, https://github.com/kungfu-systems/kungfu/pull/1473, https://github.com/kungfu-systems/kungfu/pull/1487, https://github.com/kungfu-systems/kungfu/pull/1718, https://github.com/kungfu-systems/kungfu/pull/1728, https://github.com/kungfu-systems/kungfu/pull/1744, https://github.com/kungfu-systems/kungfu/pull/3140, https://github.com/kungfu-systems/kungfu/pull/3395]
 closure_pr: https://github.com/kungfu-systems/kungfu/pull/1473
 qualification_refs: [framework/cut/cut.contract.json, framework/cut/schema/cut-v1.schema.json, framework/episode/native-operation-catalog.contract.json, framework/work-lifecycle/kungfu-work-lifecycle-operation-matrix.contract.json, framework/work-lifecycle/work-lifecycle-native.contract.json, framework/registry/contract.registry-envelope.json, framework/registry/invariant.registry-envelope.json, scripts/generate-work-lifecycle-sdk.mjs, scripts/lib/sdk-generator.mjs, scripts/materialize-work-lifecycle-operation-matrix.mjs, scripts/check-core-cut.test.mjs, scripts/check-work-authority-surface.test.mjs, scripts/check-work-lifecycle-operation-matrix.test.mjs, scripts/check-work-lifecycle-native.test.mjs, scripts/check-native-authority-membrane.test.mjs, tests/qualification/work-lifecycle/four-language-v1.json, tests/qualification/layers/sdk/run.mjs, docs/qualification/evidence/authority-membrane/2026-07-25-macos-arm64/sdk-report.json, scripts/registry-envelope.test.mjs, framework/core/src/libkungfu/tests/api_contract_tests.cpp, scripts/run-native-kfx-admission-tests.mjs, framework/core/src/libkungfu/tests/native_kfx_service_host_tests.cpp, framework/kfx/evidence/kfd-10/runtime-warrant-adopter.json]
 review_state: self-reviewed
@@ -14,7 +14,7 @@ period: 2026-07-22
 theme: core-cut-and-work-lifecycle-waist
 confidence: high
 evidence_grade: B
-last_reviewed: 2026-08-15
+last_reviewed: 2026-08-24
 ai_provenance: GPT-5 via Codex on 2026-07-22 and 2026-07-25; based on repository contracts, implementations, fixtures, installed qualification outputs, and user-authorized design constraints; no claim about unobserved external adopters or unreleased platform artifacts
 ---
 
@@ -136,6 +136,12 @@ Warrant: Core owns generation, fencing, holder-bound heartbeat, expiry,
 revocation, recovery, and residual settlement. KFX and KFD-10 only project the
 exact receipts, so neither can substitute a root, amplify authority, activate
 an adopter, or publish a release.
+
+PR #3395 proves that real product hosts consume the leased Runtime Warrant
+without merging it into capability-grant, Mutation Warrant, Episode, or
+Settlement authority. Host crash and recovery advance the Core-owned
+generation and fence, and terminal execution remains incomplete until Core
+retains settlement; KFD-10 remains draft evidence over that native waist.
 
 ## Consequences
 

--- a/framework/api/src/capability/kfx-host.ts
+++ b/framework/api/src/capability/kfx-host.ts
@@ -277,6 +277,167 @@ export function authorizeKfxHostLaunch(
   return authorization;
 }
 
+export type KfxRuntimeWarrantAuthorization =
+  KfxExperienceFlowDescriptor['runtimeAuthorizations'][number];
+
+export type KfxRuntimeWarrantAdoption = {
+  schema: 'kungfu.kfx.runtime-warrant-adoption/v1';
+  executionAllowed: true;
+  runtimeWarrant: {
+    schema: 'kungfu.kfx.runtime-warrant/v1';
+    warrantRoot: string;
+    packageKey: string;
+    host: KfxRuntimeHost;
+    holder: string;
+    capabilityGrantRoot: string;
+    hostAuthorizationRoot: string;
+    mutationWarrantRoot: string;
+    expiresAt: number;
+    heartbeatTtl: number;
+  };
+  leaseState: {
+    schema: 'kungfu.kfx.runtime-lease-state-fact/v1';
+    warrantRoot: string;
+    packageKey: string;
+    host: KfxRuntimeHost;
+    holder: string;
+    generation: number;
+    fencingToken: string;
+    state: 'active';
+    heartbeatAt: number;
+    heartbeatDeadline: number;
+    expiresAt: number;
+  };
+  recovery: null | {
+    schema: 'kungfu.kfx.runtime-warrant-transition/v1';
+    event: 'lease-expired' | 'heartbeat-expired';
+    leaseState: { state: 'recovered' } & Record<string, unknown>;
+    receipt: Record<string, unknown>;
+  };
+  receipt: Record<string, unknown>;
+};
+
+export type KfxRuntimeWarrantTransition = {
+  schema: 'kungfu.kfx.runtime-warrant-transition/v1';
+  event: string;
+  leaseState: Record<string, unknown> & { state: string };
+  receipt: Record<string, unknown>;
+};
+
+export type KfxRuntimeWarrant = {
+  adopt: (
+    authorization: KfxRuntimeWarrantAuthorization,
+    request: {
+      holder: string;
+      purpose: string;
+      leaseNonce: string;
+      issuedAt: number;
+      expiresAt: number;
+      heartbeatTtl: number;
+      residualResponsibility: string;
+      requestedCapabilities: string[];
+    },
+  ) => KfxRuntimeWarrantAdoption;
+  heartbeat: (
+    adoption: KfxRuntimeWarrantAdoption,
+    recordedAt: number,
+  ) => KfxRuntimeWarrantTransition;
+  settle: (
+    adoption: KfxRuntimeWarrantAdoption,
+    request: {
+      recordedAt: number;
+      outcome: string;
+      residualResponsibilityDisposition: string;
+    },
+  ) => KfxRuntimeWarrantTransition;
+};
+
+export type OpenKfxRuntimeWarrantOptions = {
+  binding: KfNativeBinding;
+  locator: KfLocator;
+};
+
+function runtimeWarrantFence(adoption: KfxRuntimeWarrantAdoption) {
+  const warrant = adoption.runtimeWarrant;
+  const lease = adoption.leaseState;
+  if (
+    adoption.schema !== 'kungfu.kfx.runtime-warrant-adoption/v1' ||
+    adoption.executionAllowed !== true ||
+    warrant.schema !== 'kungfu.kfx.runtime-warrant/v1' ||
+    lease.schema !== 'kungfu.kfx.runtime-lease-state-fact/v1' ||
+    lease.state !== 'active' ||
+    lease.warrantRoot !== warrant.warrantRoot ||
+    lease.packageKey !== warrant.packageKey ||
+    lease.host !== warrant.host ||
+    lease.holder !== warrant.holder ||
+    !Number.isSafeInteger(lease.generation) ||
+    lease.generation < 1 ||
+    !lease.fencingToken.startsWith('sha256:') ||
+    warrant.warrantRoot === warrant.capabilityGrantRoot ||
+    warrant.warrantRoot === warrant.mutationWarrantRoot
+  ) {
+    throw new Error('KFX Runtime Warrant adoption identity does not match');
+  }
+  return {
+    packageKey: warrant.packageKey,
+    host: warrant.host,
+    holder: warrant.holder,
+    expectedWarrantRoot: warrant.warrantRoot,
+    expectedGeneration: lease.generation,
+    expectedFencingToken: lease.fencingToken,
+  };
+}
+
+export function openKfxRuntimeWarrant(
+  options: OpenKfxRuntimeWarrantOptions,
+): KfxRuntimeWarrant {
+  const operation = options.binding.runStorageServiceOperation;
+  if (!operation) {
+    throw new Error(
+      'native binding does not expose KFX Runtime Warrant operations',
+    );
+  }
+  const runtimeDir = resolveRuntimeDir(options.locator);
+  const run = <T>(action: string, request: object): T =>
+    operation('kfx_runtime', runtimeDir, { action, request }) as T;
+  return {
+    adopt: (authorization, request) => {
+      if (
+        authorization.cutRoot === null ||
+        authorization.capabilityGrantRoot === null ||
+        authorization.authorizationRoot.length === 0 ||
+        request.requestedCapabilities.length === 0
+      ) {
+        throw new Error('KFX Runtime Warrant requires exact host authority');
+      }
+      const adoption = run<KfxRuntimeWarrantAdoption>('runtime-warrant-adopt', {
+        packageKey: authorization.packageKey,
+        host: authorization.host,
+        expectedCutRoot: authorization.cutRoot,
+        expectedRevision: authorization.revision,
+        expectedGenerationRoot: authorization.generationRoot,
+        expectedPackageRoot: authorization.packageRoot,
+        expectedCapabilityGrantRoot: authorization.capabilityGrantRoot,
+        expectedAuthorizationRoot: authorization.authorizationRoot,
+        expectedGrantedCapabilities: authorization.grantedCapabilities,
+        ...request,
+      });
+      runtimeWarrantFence(adoption);
+      return adoption;
+    },
+    heartbeat: (adoption, recordedAt) =>
+      run<KfxRuntimeWarrantTransition>('runtime-warrant-heartbeat', {
+        ...runtimeWarrantFence(adoption),
+        recordedAt,
+      }),
+    settle: (adoption, request) =>
+      run<KfxRuntimeWarrantTransition>('runtime-warrant-settle', {
+        ...runtimeWarrantFence(adoption),
+        ...request,
+      }),
+  };
+}
+
 // Public narrow capability for the KFX Control Suite. Product roles identify
 // assembly/distribution metadata only. Core owns Passport verification,
 // capability grants, Work/Warrant settlement, CAS, and recovery state.

--- a/framework/api/tests/kfx-host.test.ts
+++ b/framework/api/tests/kfx-host.test.ts
@@ -13,9 +13,13 @@ import {
   type KfxControlStatus,
   type KfxExperienceFlowDescriptor,
   authorizeKfxHostLaunch,
+  openKfxRuntimeWarrant,
   projectKfxControlSuiteHost,
   projectKfxExperienceFlowHost,
 } from '../src/capability/kfx-host.ts';
+import type { KfNativeBinding } from '../src/capability/types.ts';
+
+const root = (char: string) => `sha256:${char.repeat(64)}`;
 
 const descriptor: KfxExperienceFlowDescriptor = {
   schema: 'kungfu.kfx.experience-flow-host/v3',
@@ -175,6 +179,117 @@ test('runtime launch requires the exact grant, generation, and authorization roo
       ),
     /(admission identity|authorization) does not match/,
   );
+});
+
+test('product hosts adopt, heartbeat, and settle only the exact Core Runtime Warrant fence', () => {
+  const calls: Array<Record<string, unknown>> = [];
+  const runtimeAuthorization = descriptor.runtimeAuthorizations[0];
+  assert.ok(runtimeAuthorization);
+  const authorization = {
+    ...runtimeAuthorization,
+    host: 'service-node' as const,
+  };
+  const adoption = {
+    schema: 'kungfu.kfx.runtime-warrant-adoption/v1' as const,
+    executionAllowed: true as const,
+    runtimeWarrant: {
+      schema: 'kungfu.kfx.runtime-warrant/v1' as const,
+      warrantRoot: root('e'),
+      packageKey: authorization.packageKey,
+      host: authorization.host,
+      holder: 'service-host:42',
+      capabilityGrantRoot: authorization.capabilityGrantRoot,
+      hostAuthorizationRoot: authorization.authorizationRoot,
+      mutationWarrantRoot: root('f'),
+      expiresAt: 10_000,
+      heartbeatTtl: 1_000,
+    },
+    leaseState: {
+      schema: 'kungfu.kfx.runtime-lease-state-fact/v1' as const,
+      warrantRoot: root('e'),
+      packageKey: authorization.packageKey,
+      host: authorization.host,
+      holder: 'service-host:42',
+      generation: 3,
+      fencingToken: root('a'),
+      state: 'active' as const,
+      heartbeatAt: 1_000,
+      heartbeatDeadline: 2_000,
+      expiresAt: 10_000,
+    },
+    recovery: null,
+    receipt: {},
+  };
+  const binding = {
+    runStorageServiceOperation: (
+      _operation: string,
+      _runtimeDir: string,
+      options: Record<string, unknown>,
+    ) => {
+      calls.push(options);
+      return calls.length === 1
+        ? adoption
+        : {
+            schema: 'kungfu.kfx.runtime-warrant-transition/v1',
+            event: calls.length === 2 ? 'heartbeat' : 'settled',
+            leaseState: { state: calls.length === 2 ? 'active' : 'settled' },
+            receipt: {},
+          };
+    },
+  } as unknown as KfNativeBinding;
+  const warrant = openKfxRuntimeWarrant({
+    binding,
+    locator: { runtimeDir: '/runtime' },
+  });
+  const adopted = warrant.adopt(authorization, {
+    holder: 'service-host:42',
+    purpose: 'run the authorized service adapter',
+    leaseNonce: 'launch-42',
+    issuedAt: 1_000,
+    expiresAt: 10_000,
+    heartbeatTtl: 1_000,
+    residualResponsibility: 'retained-by-kungfu-core',
+    requestedCapabilities: authorization.grantedCapabilities,
+  });
+  warrant.heartbeat(adopted, 1_500);
+  warrant.settle(adopted, {
+    recordedAt: 1_600,
+    outcome: 'completed',
+    residualResponsibilityDisposition: 'retained-by-kungfu-core',
+  });
+
+  assert.deepEqual(
+    calls.map((call) => call.action),
+    [
+      'runtime-warrant-adopt',
+      'runtime-warrant-heartbeat',
+      'runtime-warrant-settle',
+    ],
+  );
+  const issueRequest = calls[0]?.request as Record<string, unknown>;
+  assert.equal(issueRequest.expectedCapabilityGrantRoot, root('8'));
+  assert.equal(issueRequest.expectedAuthorizationRoot, root('d'));
+  assert.equal(issueRequest.expectedGenerationRoot, root('6'));
+  const heartbeatRequest = calls[1]?.request as Record<string, unknown>;
+  assert.equal(heartbeatRequest.expectedWarrantRoot, root('e'));
+  assert.equal(heartbeatRequest.expectedGeneration, 3);
+  assert.equal(heartbeatRequest.expectedFencingToken, root('a'));
+  assert.notEqual(
+    adoption.runtimeWarrant.warrantRoot,
+    adoption.runtimeWarrant.capabilityGrantRoot,
+  );
+  assert.notEqual(
+    adoption.runtimeWarrant.warrantRoot,
+    adoption.runtimeWarrant.mutationWarrantRoot,
+  );
+
+  const substituted = structuredClone(adoption);
+  substituted.leaseState.warrantRoot = root('0');
+  assert.throws(
+    () => warrant.heartbeat(substituted, 1_700),
+    /adoption identity does not match/,
+  );
+  assert.equal(calls.length, 3);
 });
 
 test('preview and mismatched admissions fail closed before host execution', () => {

--- a/framework/core/src/libkungfu/src/runtime/kfx/native_authority.cpp
+++ b/framework/core/src/libkungfu/src/runtime/kfx/native_authority.cpp
@@ -1000,6 +1000,42 @@ json issue_runtime_warrant(const json &descriptor, const json &launch, const jso
           {"receipt", receipt}};
 }
 
+json adopt_runtime_warrant(const json &descriptor, const json &launch, const json &request,
+                           const std::string &runtime_dir) {
+  const auto &authorization = launch.at("authorization");
+  const auto package_key = authorization.at("packageKey").get<std::string>();
+  const auto host = authorization.at("host").get<std::string>();
+  const auto issued_at = runtime_time(request, "issuedAt");
+  for (const auto *field : {"expectedWarrantRoot", "expectedGeneration", "expectedFencingToken"}) {
+    if (request.contains(field))
+      refuse("KF_KFX_RUNTIME_FENCE_STALE",
+             std::string("Runtime Warrant adoption derives recovery fencing in Core; caller supplied ") + field);
+  }
+
+  json recovery = nullptr;
+  const auto current = load_runtime_warrant(runtime_dir, package_key, host);
+  if (current.present && current.state.value("state", "") == "active") {
+    const bool lease_expired = issued_at >= current.state.at("expiresAt").get<int64_t>();
+    const bool heartbeat_expired = issued_at > current.state.at("heartbeatDeadline").get<int64_t>();
+    if (!lease_expired && !heartbeat_expired)
+      refuse("KF_KFX_RUNTIME_WARRANT_ACTIVE",
+             "the package and host already have a live Runtime Warrant; adoption cannot steal its lease");
+    recovery = transition_runtime_warrant("runtime-warrant-recover",
+                                          {{"packageKey", package_key},
+                                           {"host", host},
+                                           {"expectedWarrantRoot", current.warrant.at("warrantRoot")},
+                                           {"expectedGeneration", current.state.at("generation")},
+                                           {"expectedFencingToken", current.state.at("fencingToken")},
+                                           {"recordedAt", issued_at}},
+                                          runtime_dir);
+  }
+
+  auto result = issue_runtime_warrant(descriptor, launch, request, runtime_dir);
+  result["schema"] = "kungfu.kfx.runtime-warrant-adoption/v1";
+  result["recovery"] = recovery;
+  return result;
+}
+
 void require_runtime_fence(const runtime_warrant_view &current, const json &request, bool require_holder) {
   if (!current.present)
     refuse("KF_KFX_RUNTIME_WARRANT_MISSING", "no Runtime Warrant exists for the requested package and host");

--- a/framework/core/src/libkungfu/src/runtime/kfx/native_authority.h
+++ b/framework/core/src/libkungfu/src/runtime/kfx/native_authority.h
@@ -25,6 +25,9 @@ using assessment_fn =
 [[nodiscard]] nlohmann::json issue_runtime_warrant(const nlohmann::json &descriptor, const nlohmann::json &host_launch,
                                                    const nlohmann::json &request, const std::string &runtime_dir);
 
+[[nodiscard]] nlohmann::json adopt_runtime_warrant(const nlohmann::json &descriptor, const nlohmann::json &host_launch,
+                                                   const nlohmann::json &request, const std::string &runtime_dir);
+
 [[nodiscard]] nlohmann::json transition_runtime_warrant(const std::string &action, const nlohmann::json &request,
                                                         const std::string &runtime_dir);
 

--- a/framework/core/src/libkungfu/src/runtime/kfx/native_registry.cpp
+++ b/framework/core/src/libkungfu/src/runtime/kfx/native_registry.cpp
@@ -46,6 +46,7 @@ static json query_native_kfx_registry_unchecked(const std::string &action, const
                                                 "authorize-host",
                                                 "history",
                                                 "runtime-warrant-issue",
+                                                "runtime-warrant-adopt",
                                                 "runtime-warrant-heartbeat",
                                                 "runtime-warrant-revoke",
                                                 "runtime-warrant-settle",
@@ -66,7 +67,8 @@ static json query_native_kfx_registry_unchecked(const std::string &action, const
     return lifecycle_history(runtime_dir, request);
   const bool runtime_transition = action == "runtime-warrant-heartbeat" || action == "runtime-warrant-revoke" ||
                                   action == "runtime-warrant-settle" || action == "runtime-warrant-recover";
-  const bool runtime_mutation = action == "runtime-warrant-issue" || runtime_transition;
+  const bool runtime_mutation =
+      action == "runtime-warrant-issue" || action == "runtime-warrant-adopt" || runtime_transition;
   if ((action == "apply" || runtime_mutation || action == "kfd-10-witness") && runtime_dir.empty())
     refuse("KF_KFX_AUTHORITY_CLAIM_FORBIDDEN", "native KFX authority operation requires an explicit runtime directory");
   std::optional<lifecycle_writer_lock> writer_lock;
@@ -98,10 +100,12 @@ static json query_native_kfx_registry_unchecked(const std::string &action, const
     refuse("KF_KFX_CUT_MISSING", "no named KFX Fact Cut exists; provide a bounded discovery observation to plan");
   }
   const auto load_plan = lifecycle_plan(selected, lifecycle, request);
-  if (action == "runtime-warrant-issue") {
+  if (action == "runtime-warrant-issue" || action == "runtime-warrant-adopt") {
     const auto &descriptor = load_plan.at("hostContract");
-    return authority::issue_runtime_warrant(descriptor, authorize_host_launch(descriptor, lifecycle, request), request,
-                                            runtime_dir);
+    const auto launch = authorize_host_launch(descriptor, lifecycle, request);
+    return action == "runtime-warrant-adopt"
+               ? authority::adopt_runtime_warrant(descriptor, launch, request, runtime_dir)
+               : authority::issue_runtime_warrant(descriptor, launch, request, runtime_dir);
   }
   if (action == "authorize-host")
     return authorize_host_launch(load_plan.at("hostContract"), lifecycle, request);

--- a/framework/core/src/libkungfu/src/runtime/storage/domain_dispatch.cpp
+++ b/framework/core/src/libkungfu/src/runtime/storage/domain_dispatch.cpp
@@ -29,7 +29,8 @@ namespace yy_enums = kungfu::yijinjing::enums;
 bool is_kfx_registry_action(const std::string &action) {
   static const std::string actions =
       "|list|inspect|resolve|plan|status|assess|apply|authorize-host|history|runtime-warrant-issue|"
-      "runtime-warrant-heartbeat|runtime-warrant-revoke|runtime-warrant-settle|runtime-warrant-recover|kfd-10-witness|";
+      "runtime-warrant-adopt|runtime-warrant-heartbeat|runtime-warrant-revoke|runtime-warrant-settle|"
+      "runtime-warrant-recover|kfd-10-witness|";
   return actions.contains("|" + action + "|");
 }
 

--- a/framework/core/src/libkungfu/tests/native_kfx_service_host_tests.cpp
+++ b/framework/core/src/libkungfu/tests/native_kfx_service_host_tests.cpp
@@ -312,6 +312,56 @@ void test_runtime_warrant_contract() {
   require(expired.at("event") == "lease-expired" && expired.at("leaseState").at("state") == "recovered",
           "Core did not fail closed and settle the exact lease-expiry boundary");
 
+  auto issue_five = issue_request;
+  issue_five["leaseNonce"] = "generation-5";
+  issue_five["issuedAt"] = 60;
+  issue_five["expiresAt"] = 100;
+  const auto issued_five = kfx::query_native_kfx_registry("runtime-warrant-issue", issue_five, runtime_dir.string());
+  auto adopt = issue_request;
+  adopt["holder"] = "worker-b";
+  adopt["purpose"] = "restart optional KFX view after host crash";
+  adopt["leaseNonce"] = "generation-6";
+  adopt["issuedAt"] = 71;
+  adopt["expiresAt"] = 110;
+  auto early_adopt = adopt;
+  early_adopt["issuedAt"] = 70;
+  require_refusal("KF_KFX_RUNTIME_WARRANT_ACTIVE", [&] {
+    (void)kfx::query_native_kfx_registry("runtime-warrant-adopt", early_adopt, runtime_dir.string());
+  });
+  auto substituted_adopt = adopt;
+  substituted_adopt["expectedWarrantRoot"] = issued_five.at("runtimeWarrant").at("warrantRoot");
+  require_refusal("KF_KFX_RUNTIME_FENCE_STALE", [&] {
+    (void)kfx::query_native_kfx_registry("runtime-warrant-adopt", substituted_adopt, runtime_dir.string());
+  });
+  const auto adopted = kfx::query_native_kfx_registry("runtime-warrant-adopt", adopt, runtime_dir.string());
+  require(adopted.at("schema") == "kungfu.kfx.runtime-warrant-adoption/v1" &&
+              adopted.at("recovery").at("event") == "heartbeat-expired" &&
+              adopted.at("recovery").at("leaseState").at("state") == "recovered" &&
+              adopted.at("leaseState").at("generation") == 6 &&
+              adopted.at("leaseState").at("fencingToken") != issued_five.at("leaseState").at("fencingToken"),
+          "Core host adoption did not recover a crashed holder and issue a fenced successor generation");
+  auto stale_crashed_holder = transition;
+  stale_crashed_holder["expectedWarrantRoot"] = issued_five.at("runtimeWarrant").at("warrantRoot");
+  stale_crashed_holder["expectedGeneration"] = issued_five.at("leaseState").at("generation");
+  stale_crashed_holder["expectedFencingToken"] = issued_five.at("leaseState").at("fencingToken");
+  stale_crashed_holder["recordedAt"] = 72;
+  require_refusal("KF_KFX_RUNTIME_FENCE_STALE", [&] {
+    (void)kfx::query_native_kfx_registry("runtime-warrant-heartbeat", stale_crashed_holder, runtime_dir.string());
+  });
+  json settle_adopted = {{"packageKey", "optional-view"},
+                         {"host", authorization.at("host")},
+                         {"holder", "worker-b"},
+                         {"expectedWarrantRoot", adopted.at("runtimeWarrant").at("warrantRoot")},
+                         {"expectedGeneration", adopted.at("leaseState").at("generation")},
+                         {"expectedFencingToken", adopted.at("leaseState").at("fencingToken")},
+                         {"recordedAt", 75},
+                         {"outcome", "completed"},
+                         {"residualResponsibilityDisposition", "retained-by-kungfu-core"}};
+  const auto settled_adopted =
+      kfx::query_native_kfx_registry("runtime-warrant-settle", settle_adopted, runtime_dir.string());
+  require(settled_adopted.at("leaseState").at("state") == "settled",
+          "adopted Runtime Warrant did not retain terminal settlement");
+
   const json witness_request = {{"packageKey", "optional-view"}, {"host", authorization.at("host")}};
   const auto witness_a = kfx::query_native_kfx_registry("kfd-10-witness", witness_request, runtime_dir.string());
   const auto witness_b = kfx::query_native_kfx_registry("kfd-10-witness", witness_request, runtime_dir.string());

--- a/framework/core/src/libwasm/host.cpp
+++ b/framework/core/src/libwasm/host.cpp
@@ -12,6 +12,8 @@
 #include <nlohmann/json.hpp>
 
 #include <algorithm>
+#include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <cstdio>
 #include <filesystem>
@@ -19,9 +21,11 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <span>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <vector>
 
 #if defined(_WIN32)
@@ -322,6 +326,114 @@ nlohmann::json receipt_json(const options &opts, const std::string &engine,
           {"guest_result", receipt.guest_result}};
 }
 
+class runtime_warrant_lease {
+public:
+  runtime_warrant_lease(const options &opts, nlohmann::json adoption) : opts_(opts), adoption_(std::move(adoption)) {
+    const auto &warrant = adoption_.at("runtimeWarrant");
+    const auto &state = adoption_.at("leaseState");
+    if (adoption_.value("schema", "") != "kungfu.kfx.runtime-warrant-adoption/v1" ||
+        !adoption_.value("executionAllowed", false) || warrant.at("packageKey") != opts_.package_key ||
+        warrant.at("host") != "wasm" || warrant.at("capabilityGrantRoot") != opts_.capability_grant_root ||
+        warrant.at("hostAuthorizationRoot") != opts_.authorization_root ||
+        warrant.at("warrantRoot") == warrant.at("capabilityGrantRoot") ||
+        warrant.at("warrantRoot") == warrant.at("mutationWarrantRoot") ||
+        state.at("warrantRoot") != warrant.at("warrantRoot") || state.at("holder") != warrant.at("holder") ||
+        state.at("state") != "active") {
+      throw std::runtime_error("Core Runtime Warrant adoption identity does not match the WASM host launch");
+    }
+    heartbeat_thread_ = std::thread([this] { heartbeat_loop(); });
+  }
+
+  runtime_warrant_lease(const runtime_warrant_lease &) = delete;
+  runtime_warrant_lease &operator=(const runtime_warrant_lease &) = delete;
+
+  ~runtime_warrant_lease() {
+    stop_heartbeat();
+    if (!settled_ && heartbeat_error().empty()) {
+      try {
+        settle_transition("failed");
+      } catch (...) {
+      }
+    }
+  }
+
+  void settle(const std::string &outcome) {
+    stop_heartbeat();
+    const auto failure = heartbeat_error();
+    if (!failure.empty()) {
+      throw std::runtime_error("Runtime Warrant heartbeat failed closed: " + failure);
+    }
+    settle_transition(outcome);
+    settled_ = true;
+  }
+
+private:
+  nlohmann::json fence_request(int64_t recorded_at) const {
+    const auto &warrant = adoption_.at("runtimeWarrant");
+    const auto &state = adoption_.at("leaseState");
+    return {{"packageKey", warrant.at("packageKey")},
+            {"host", warrant.at("host")},
+            {"holder", warrant.at("holder")},
+            {"expectedWarrantRoot", warrant.at("warrantRoot")},
+            {"expectedGeneration", state.at("generation")},
+            {"expectedFencingToken", state.at("fencingToken")},
+            {"recordedAt", recorded_at}};
+  }
+
+  void heartbeat_loop() {
+    std::unique_lock<std::mutex> lock(wait_mutex_);
+    while (!wait_cv_.wait_for(lock, std::chrono::seconds(2), [this] { return stopping_; })) {
+      lock.unlock();
+      try {
+        const auto transition = kungfu::runtime::kfx::query_native_kfx_registry(
+            "runtime-warrant-heartbeat", fence_request(yy::time::now_in_nano()), opts_.runtime_dir);
+        if (transition.at("leaseState").at("state") != "active")
+          throw std::runtime_error("Core did not retain the active lease state");
+      } catch (const std::exception &error) {
+        std::lock_guard<std::mutex> failure_lock(failure_mutex_);
+        failure_ = error.what();
+        return;
+      }
+      lock.lock();
+    }
+  }
+
+  void stop_heartbeat() {
+    {
+      std::lock_guard<std::mutex> lock(wait_mutex_);
+      stopping_ = true;
+    }
+    wait_cv_.notify_all();
+    if (heartbeat_thread_.joinable())
+      heartbeat_thread_.join();
+  }
+
+  std::string heartbeat_error() const {
+    std::lock_guard<std::mutex> lock(failure_mutex_);
+    return failure_;
+  }
+
+  void settle_transition(const std::string &outcome) {
+    auto request = fence_request(yy::time::now_in_nano());
+    request["outcome"] = outcome;
+    request["residualResponsibilityDisposition"] = "retained-by-kungfu-core";
+    const auto transition =
+        kungfu::runtime::kfx::query_native_kfx_registry("runtime-warrant-settle", request, opts_.runtime_dir);
+    if (transition.at("leaseState").at("state") != "settled")
+      throw std::runtime_error("Core did not retain terminal Runtime Warrant settlement");
+  }
+
+  const options &opts_;
+  nlohmann::json adoption_;
+  std::thread heartbeat_thread_;
+  mutable std::mutex failure_mutex_;
+  std::mutex wait_mutex_;
+  std::condition_variable wait_cv_;
+  std::string failure_;
+  bool stopping_ = false;
+  bool settled_ = false;
+};
+
 int run_self_test(const char *argv0) {
   const auto adapters = executable_dir(argv0) / "libwasm";
   auto results = nlohmann::json::object();
@@ -360,8 +472,9 @@ int main(int argc, char **argv) {
     if (opts.world != WORLD_V1 || opts.capabilities != KF_LIBWASM_CAP_JOURNAL_READ_BATCH) {
       throw std::invalid_argument("unsupported world or capability grant");
     }
-    const auto host_authorization = kungfu::runtime::kfx::query_native_kfx_registry(
-        "authorize-host",
+    const auto issued_at = yy::time::now_in_nano();
+    const auto adoption = kungfu::runtime::kfx::query_native_kfx_registry(
+        "runtime-warrant-adopt",
         {{"packageKey", opts.package_key},
          {"host", "wasm"},
          {"expectedCutRoot", opts.cut_root},
@@ -370,10 +483,17 @@ int main(int argc, char **argv) {
          {"expectedPackageRoot", opts.package_root},
          {"expectedCapabilityGrantRoot", opts.capability_grant_root},
          {"expectedAuthorizationRoot", opts.authorization_root},
-         {"expectedGrantedCapabilities", nlohmann::json::array({"journal.read.batch"})}},
+         {"expectedGrantedCapabilities", nlohmann::json::array({"journal.read.batch"})},
+         {"holder", "kungfu-wasm-host:" + std::to_string(issued_at)},
+         {"purpose", "execute the authorized WASM product adapter"},
+         {"leaseNonce", root_hash(opts.package_key + ":" + std::to_string(issued_at))},
+         {"issuedAt", issued_at},
+         {"expiresAt", issued_at + 3600LL * 1000LL * 1000LL * 1000LL},
+         {"heartbeatTtl", 5LL * 1000LL * 1000LL * 1000LL},
+         {"residualResponsibility", "retained-by-kungfu-core"},
+         {"requestedCapabilities", nlohmann::json::array({"journal.read.batch"})}},
         opts.runtime_dir);
-    if (!host_authorization.value("executionAllowed", false))
-      throw std::invalid_argument("Core refused the exact KFX host authorization");
+    runtime_warrant_lease runtime_lease(opts, adoption);
     if (opts.qualification_seed) {
       seed_qualification_journal(opts);
     }
@@ -439,6 +559,7 @@ int main(int argc, char **argv) {
     execution_body["admission_event_id"] = admission.at("admission_event_id");
     const auto execution_fact = record_fact(opts.runtime_dir, "execution", actual_hash, execution_body);
     execution_body["execution_admission_event_id"] = execution_fact.at("admission_event_id");
+    runtime_lease.settle(status == KF_LIBWASM_OK ? "completed" : "failed");
     std::cout << execution_body.dump() << std::endl;
     return status == KF_LIBWASM_OK ? 0 : status;
   } catch (const std::exception &error) {

--- a/framework/core/src/python/kungfu/rewind/adapters.py
+++ b/framework/core/src/python/kungfu/rewind/adapters.py
@@ -35,28 +35,51 @@ ENV_PLUGIN_ADAPTERS = "KUNGFU_REWIND_ADAPTERS"
 ENV_NODE_ADAPTERS = "KUNGFU_REWIND_NODE_ADAPTERS"
 
 
+def _runtime_warrant_parts(
+    adoption: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    warrant = adoption.get("runtimeWarrant") or {}
+    state = adoption.get("leaseState") or {}
+    expected = {
+        "schema": "kungfu.kfx.runtime-warrant-adoption/v1",
+        "executionAllowed": True,
+        "state": "active",
+        "stateWarrantRoot": warrant.get("warrantRoot"),
+        "stateHolder": warrant.get("holder"),
+    }
+    actual = {
+        "schema": adoption.get("schema"),
+        "executionAllowed": adoption.get("executionAllowed"),
+        "state": state.get("state"),
+        "stateWarrantRoot": state.get("warrantRoot"),
+        "stateHolder": state.get("holder"),
+    }
+    if actual != expected:
+        raise ValueError("KF_KFX_RUNTIME_FENCE_STALE")
+    authority_roots = {
+        warrant.get("warrantRoot"),
+        warrant.get("capabilityGrantRoot"),
+        warrant.get("mutationWarrantRoot"),
+    }
+    if None in authority_roots or len(authority_roots) != 3:
+        raise ValueError("KF_KFX_RUNTIME_AUTHORITY_COLLAPSE")
+    return warrant, state
+
+
 class RuntimeWarrantLease:
     """Core-owned lease for one in-process adapter injection."""
 
-    def __init__(self, runtime_dir: str, adoption: dict[str, Any]) -> None:
-        warrant = adoption.get("runtimeWarrant") or {}
-        state = adoption.get("leaseState") or {}
-        if (
-            adoption.get("schema") != "kungfu.kfx.runtime-warrant-adoption/v1"
-            or adoption.get("executionAllowed") is not True
-            or state.get("state") != "active"
-            or state.get("warrantRoot") != warrant.get("warrantRoot")
-            or state.get("holder") != warrant.get("holder")
-            or warrant.get("warrantRoot") == warrant.get("capabilityGrantRoot")
-            or warrant.get("warrantRoot") == warrant.get("mutationWarrantRoot")
-        ):
-            raise ValueError("KF_KFX_RUNTIME_FENCE_STALE")
-        self.runtime_dir = runtime_dir
-        self.adoption = adoption
-        self._stop = threading.Event()
-        self._error: BaseException | None = None
-        self._thread = threading.Thread(target=self._heartbeat, daemon=True)
-        self._thread.start()
+    @classmethod
+    def start(cls, runtime_dir: str, adoption: dict[str, Any]) -> RuntimeWarrantLease:
+        _runtime_warrant_parts(adoption)
+        lease = cls()
+        lease.runtime_dir = runtime_dir
+        lease.adoption = adoption
+        lease._stop = threading.Event()
+        lease._error: BaseException | None = None
+        lease._thread = threading.Thread(target=lease._heartbeat, daemon=True)
+        lease._thread.start()
+        return lease
 
     def _fence(self) -> dict[str, Any]:
         warrant = self.adoption["runtimeWarrant"]
@@ -134,10 +157,59 @@ def _scan_packages(root: str) -> Iterator[str]:
                     yield nested
 
 
-def discover_adapters(
-    runtime_dir: str | None,
+def _adopt_adapter(
+    runtime_dir: str,
     runtime: str,
-    lease_sink: list[RuntimeWarrantLease],
+    key: str,
+    descriptor: dict[str, Any],
+    candidate: dict[str, Any],
+) -> tuple[dict[str, Any] | None, RuntimeWarrantLease | None]:
+    try:
+        now = time.time_ns()
+        adoption = storage_service.kfx_registry(
+            "runtime-warrant-adopt",
+            {
+                "packageKey": key,
+                "host": f"adapter-{runtime}",
+                "expectedCutRoot": descriptor.get("cutRoot"),
+                "expectedRevision": descriptor.get("revision"),
+                "expectedGenerationRoot": descriptor.get("generationRoot"),
+                "expectedPackageRoot": candidate.get("packageRoot"),
+                "expectedCapabilityGrantRoot": candidate.get("capabilityGrantRoot"),
+                "expectedAuthorizationRoot": candidate.get("authorizationRoot"),
+                "expectedGrantedCapabilities": candidate.get("grantedCapabilities", []),
+                "holder": f"kungfu-trace:{os.getpid()}:{key}",
+                "purpose": f"inject authorized adapter-{runtime} product host",
+                "leaseNonce": uuid.uuid4().hex,
+                "issuedAt": now,
+                "expiresAt": now + 3_600_000_000_000,
+                "heartbeatTtl": 5_000_000_000,
+                "residualResponsibility": "retained-by-kungfu-core",
+                "requestedCapabilities": candidate.get("grantedCapabilities", []),
+            },
+            runtime_dir,
+        )
+        launch = adoption.get("hostLaunch") or {}
+        authorization = launch.get("authorization")
+        if {
+            "executionAllowed": adoption.get("executionAllowed"),
+            "authorizationRoot": (
+                authorization.get("authorizationRoot")
+                if isinstance(authorization, dict)
+                else None
+            ),
+        } != {
+            "executionAllowed": True,
+            "authorizationRoot": candidate.get("authorizationRoot"),
+        }:
+            return None, None
+        return authorization, RuntimeWarrantLease.start(runtime_dir, adoption)
+    except (OSError, RuntimeError, ValueError):
+        return None, None
+
+
+def discover_adapters(
+    runtime_dir: str | None, runtime: str, lease_sink: list[RuntimeWarrantLease]
 ) -> tuple[list[str], list[str], list[dict[str, str | None]]]:
     """Return (entry_files, package_dirs, refused) for kfx packages declaring an
     adapter form for `runtime` ('python' or 'node'). First occurrence of a
@@ -202,55 +274,11 @@ def discover_adapters(
                         and observed.get("manifestRoot")
                         == candidate.get("manifestRoot")
                     ):
-                        try:
-                            now = time.time_ns()
-                            adoption = storage_service.kfx_registry(
-                                "runtime-warrant-adopt",
-                                {
-                                    "packageKey": key,
-                                    "host": f"adapter-{runtime}",
-                                    "expectedCutRoot": descriptor.get("cutRoot"),
-                                    "expectedRevision": descriptor.get("revision"),
-                                    "expectedGenerationRoot": descriptor.get(
-                                        "generationRoot"
-                                    ),
-                                    "expectedPackageRoot": candidate.get("packageRoot"),
-                                    "expectedCapabilityGrantRoot": candidate.get(
-                                        "capabilityGrantRoot"
-                                    ),
-                                    "expectedAuthorizationRoot": candidate.get(
-                                        "authorizationRoot"
-                                    ),
-                                    "expectedGrantedCapabilities": candidate.get(
-                                        "grantedCapabilities", []
-                                    ),
-                                    "holder": f"kungfu-trace:{os.getpid()}:{key}",
-                                    "purpose": f"inject authorized adapter-{runtime} product host",
-                                    "leaseNonce": uuid.uuid4().hex,
-                                    "issuedAt": now,
-                                    "expiresAt": now + 3_600_000_000_000,
-                                    "heartbeatTtl": 5_000_000_000,
-                                    "residualResponsibility": "retained-by-kungfu-core",
-                                    "requestedCapabilities": candidate.get(
-                                        "grantedCapabilities", []
-                                    ),
-                                },
-                                runtime_dir or "",
-                            )
-                            launch = adoption.get("hostLaunch") or {}
-                            authorization = launch.get("authorization")
-                            if (
-                                adoption.get("executionAllowed") is not True
-                                or not isinstance(authorization, dict)
-                                or authorization.get("authorizationRoot")
-                                != candidate.get("authorizationRoot")
-                            ):
-                                authorization = None
-                            else:
-                                lease = RuntimeWarrantLease(runtime_dir or "", adoption)
-                                lease_sink.append(lease)
-                        except (OSError, RuntimeError, ValueError):
-                            authorization = None
+                        authorization, lease = _adopt_adapter(
+                            runtime_dir or "", runtime, key, descriptor, candidate
+                        )
+                        if lease is not None:
+                            lease_sink.append(lease)
                         break
             if authorization is None:
                 refused.append({"key": kfx.get("key"), "package": os.path.abspath(pkg)})

--- a/framework/core/src/python/kungfu/rewind/adapters.py
+++ b/framework/core/src/python/kungfu/rewind/adapters.py
@@ -69,6 +69,12 @@ def _runtime_warrant_parts(
 class RuntimeWarrantLease:
     """Core-owned lease for one in-process adapter injection."""
 
+    runtime_dir: str
+    adoption: dict[str, Any]
+    _stop: threading.Event
+    _error: BaseException | None
+    _thread: threading.Thread
+
     @classmethod
     def start(cls, runtime_dir: str, adoption: dict[str, Any]) -> RuntimeWarrantLease:
         _runtime_warrant_parts(adoption)
@@ -76,7 +82,7 @@ class RuntimeWarrantLease:
         lease.runtime_dir = runtime_dir
         lease.adoption = adoption
         lease._stop = threading.Event()
-        lease._error: BaseException | None = None
+        lease._error = None
         lease._thread = threading.Thread(target=lease._heartbeat, daemon=True)
         lease._thread.start()
         return lease

--- a/framework/core/src/python/kungfu/rewind/adapters.py
+++ b/framework/core/src/python/kungfu/rewind/adapters.py
@@ -19,7 +19,11 @@
 from __future__ import annotations
 
 import os
+import threading
+import time
+import uuid
 from collections.abc import Iterator
+from typing import Any
 
 from kungfu import kfx_contract
 from kungfu.storage import service as storage_service
@@ -29,6 +33,76 @@ ENV_EXTENSION_PATH = "KF_EXTENSION_PATH"
 # reads ENV_PLUGIN_ADAPTERS, the node hook reads ENV_NODE_ADAPTERS.
 ENV_PLUGIN_ADAPTERS = "KUNGFU_REWIND_ADAPTERS"
 ENV_NODE_ADAPTERS = "KUNGFU_REWIND_NODE_ADAPTERS"
+
+
+class RuntimeWarrantLease:
+    """Core-owned lease for one in-process adapter injection."""
+
+    def __init__(self, runtime_dir: str, adoption: dict[str, Any]) -> None:
+        warrant = adoption.get("runtimeWarrant") or {}
+        state = adoption.get("leaseState") or {}
+        if (
+            adoption.get("schema") != "kungfu.kfx.runtime-warrant-adoption/v1"
+            or adoption.get("executionAllowed") is not True
+            or state.get("state") != "active"
+            or state.get("warrantRoot") != warrant.get("warrantRoot")
+            or state.get("holder") != warrant.get("holder")
+            or warrant.get("warrantRoot") == warrant.get("capabilityGrantRoot")
+            or warrant.get("warrantRoot") == warrant.get("mutationWarrantRoot")
+        ):
+            raise ValueError("KF_KFX_RUNTIME_FENCE_STALE")
+        self.runtime_dir = runtime_dir
+        self.adoption = adoption
+        self._stop = threading.Event()
+        self._error: BaseException | None = None
+        self._thread = threading.Thread(target=self._heartbeat, daemon=True)
+        self._thread.start()
+
+    def _fence(self) -> dict[str, Any]:
+        warrant = self.adoption["runtimeWarrant"]
+        state = self.adoption["leaseState"]
+        return {
+            "packageKey": warrant["packageKey"],
+            "host": warrant["host"],
+            "holder": warrant["holder"],
+            "expectedWarrantRoot": warrant["warrantRoot"],
+            "expectedGeneration": state["generation"],
+            "expectedFencingToken": state["fencingToken"],
+        }
+
+    def _heartbeat(self) -> None:
+        while not self._stop.wait(2.0):
+            try:
+                transition = storage_service.kfx_registry(
+                    "runtime-warrant-heartbeat",
+                    {**self._fence(), "recordedAt": time.time_ns()},
+                    self.runtime_dir,
+                )
+                if (transition.get("leaseState") or {}).get("state") != "active":
+                    raise RuntimeError("Runtime Warrant heartbeat was not retained")
+            except BaseException as error:  # fail closed across the child lifetime
+                self._error = error
+                return
+
+    def settle(self, outcome: str) -> None:
+        self._stop.set()
+        self._thread.join()
+        if self._error is not None:
+            raise RuntimeError(
+                "Runtime Warrant heartbeat failed closed"
+            ) from self._error
+        transition = storage_service.kfx_registry(
+            "runtime-warrant-settle",
+            {
+                **self._fence(),
+                "recordedAt": time.time_ns(),
+                "outcome": outcome,
+                "residualResponsibilityDisposition": "retained-by-kungfu-core",
+            },
+            self.runtime_dir,
+        )
+        if (transition.get("leaseState") or {}).get("state") != "settled":
+            raise RuntimeError("Runtime Warrant terminal settlement was not retained")
 
 
 def _extension_roots(runtime_dir: str | None) -> list[str]:
@@ -61,7 +135,9 @@ def _scan_packages(root: str) -> Iterator[str]:
 
 
 def discover_adapters(
-    runtime_dir: str | None, runtime: str
+    runtime_dir: str | None,
+    runtime: str,
+    lease_sink: list[RuntimeWarrantLease],
 ) -> tuple[list[str], list[str], list[dict[str, str | None]]]:
     """Return (entry_files, package_dirs, refused) for kfx packages declaring an
     adapter form for `runtime` ('python' or 'node'). First occurrence of a
@@ -127,8 +203,9 @@ def discover_adapters(
                         == candidate.get("manifestRoot")
                     ):
                         try:
-                            launch = storage_service.kfx_registry(
-                                "authorize-host",
+                            now = time.time_ns()
+                            adoption = storage_service.kfx_registry(
+                                "runtime-warrant-adopt",
                                 {
                                     "packageKey": key,
                                     "host": f"adapter-{runtime}",
@@ -147,17 +224,31 @@ def discover_adapters(
                                     "expectedGrantedCapabilities": candidate.get(
                                         "grantedCapabilities", []
                                     ),
+                                    "holder": f"kungfu-trace:{os.getpid()}:{key}",
+                                    "purpose": f"inject authorized adapter-{runtime} product host",
+                                    "leaseNonce": uuid.uuid4().hex,
+                                    "issuedAt": now,
+                                    "expiresAt": now + 3_600_000_000_000,
+                                    "heartbeatTtl": 5_000_000_000,
+                                    "residualResponsibility": "retained-by-kungfu-core",
+                                    "requestedCapabilities": candidate.get(
+                                        "grantedCapabilities", []
+                                    ),
                                 },
                                 runtime_dir or "",
                             )
+                            launch = adoption.get("hostLaunch") or {}
                             authorization = launch.get("authorization")
                             if (
-                                launch.get("executionAllowed") is not True
+                                adoption.get("executionAllowed") is not True
                                 or not isinstance(authorization, dict)
                                 or authorization.get("authorizationRoot")
                                 != candidate.get("authorizationRoot")
                             ):
                                 authorization = None
+                            else:
+                                lease = RuntimeWarrantLease(runtime_dir or "", adoption)
+                                lease_sink.append(lease)
                         except (OSError, RuntimeError, ValueError):
                             authorization = None
                         break

--- a/framework/core/src/python/kungfu/rewind/supervisor.py
+++ b/framework/core/src/python/kungfu/rewind/supervisor.py
@@ -61,6 +61,12 @@ _ANTHROPIC_ENV = ("ANTHROPIC_BASE_URL",)
 _STOP = object()
 
 
+def _status_from_exit_code(exit_code: int) -> RunStatus:
+    if exit_code < 0:
+        return RunStatus.Interrupted
+    return RunStatus.Succeeded if exit_code == 0 else RunStatus.Failed
+
+
 class Supervisor:
     def __init__(
         self, runtime_dir: str, command: Iterable[str], run_id: str | None = None
@@ -164,6 +170,32 @@ class Supervisor:
     def bundle_dir(self) -> str:
         return os.path.join(self.runtime_dir, "rewind", self.run_id, "bundle")
 
+    def _run_child(self) -> tuple[RunStatus, int]:
+        child: subprocess.Popen[Any] | None = None
+        try:
+            child = subprocess.Popen(self.command, env=self.child_env())
+            exit_code = child.wait()
+            return _status_from_exit_code(exit_code), exit_code
+        except KeyboardInterrupt:
+            assert child is not None
+            child.send_signal(signal.SIGINT)
+            return RunStatus.Interrupted, child.wait()
+
+    def _settle_adapter_leases(
+        self, status: RunStatus, exit_code: int
+    ) -> tuple[RunStatus, int]:
+        warrant_outcome = "completed" if status == RunStatus.Succeeded else "failed"
+        for lease in self.adapter_leases:
+            try:
+                lease.settle(warrant_outcome)
+            except (OSError, RuntimeError, ValueError) as error:
+                status, exit_code = RunStatus.Failed, 1
+                sys.stderr.write(
+                    f"[kungfu trace] adapter Runtime Warrant failed closed: {error}\n"
+                )
+        self.adapter_leases.clear()
+        return status, exit_code
+
     def run(self) -> tuple[int, Any, str]:
         writer_thread = threading.Thread(target=self._drain_events)
         writer_thread.start()
@@ -181,29 +213,10 @@ class Supervisor:
         )
 
         status, exit_code = RunStatus.Failed, 1
-        child: subprocess.Popen[Any] | None = None
         try:
-            child = subprocess.Popen(self.command, env=self.child_env())
-            exit_code = child.wait()
-            status = RunStatus.Succeeded if exit_code == 0 else RunStatus.Failed
-            if exit_code < 0:
-                status = RunStatus.Interrupted
-        except KeyboardInterrupt:
-            assert child is not None
-            child.send_signal(signal.SIGINT)
-            exit_code = child.wait()
-            status = RunStatus.Interrupted
+            status, exit_code = self._run_child()
         finally:
-            warrant_outcome = "completed" if status == RunStatus.Succeeded else "failed"
-            for lease in self.adapter_leases:
-                try:
-                    lease.settle(warrant_outcome)
-                except (OSError, RuntimeError, ValueError) as error:
-                    status, exit_code = RunStatus.Failed, 1
-                    sys.stderr.write(
-                        f"[kungfu trace] adapter Runtime Warrant failed closed: {error}\n"
-                    )
-            self.adapter_leases.clear()
+            status, exit_code = self._settle_adapter_leases(status, exit_code)
             # child gone -> no new wire or hook events; stop the capture
             # layers before the RunEnd bracket so every event lands inside
             # the run

--- a/framework/core/src/python/kungfu/rewind/supervisor.py
+++ b/framework/core/src/python/kungfu/rewind/supervisor.py
@@ -63,8 +63,8 @@ _STOP = object()
 
 def _status_from_exit_code(exit_code: int) -> RunStatus:
     if exit_code < 0:
-        return RunStatus.Interrupted
-    return RunStatus.Succeeded if exit_code == 0 else RunStatus.Failed
+        return RunStatus.Interrupted  # type: ignore[return-value]
+    return RunStatus.Succeeded if exit_code == 0 else RunStatus.Failed  # type: ignore[return-value]
 
 
 class Supervisor:
@@ -179,7 +179,7 @@ class Supervisor:
         except KeyboardInterrupt:
             assert child is not None
             child.send_signal(signal.SIGINT)
-            return RunStatus.Interrupted, child.wait()
+            return RunStatus.Interrupted, child.wait()  # type: ignore[return-value]
 
     def _settle_adapter_leases(
         self, status: RunStatus, exit_code: int
@@ -189,7 +189,7 @@ class Supervisor:
             try:
                 lease.settle(warrant_outcome)
             except (OSError, RuntimeError, ValueError) as error:
-                status, exit_code = RunStatus.Failed, 1
+                status, exit_code = RunStatus.Failed, 1  # type: ignore[assignment]
                 sys.stderr.write(
                     f"[kungfu trace] adapter Runtime Warrant failed closed: {error}\n"
                 )
@@ -214,9 +214,12 @@ class Supervisor:
 
         status, exit_code = RunStatus.Failed, 1
         try:
-            status, exit_code = self._run_child()
+            status, exit_code = self._run_child()  # type: ignore[assignment]
         finally:
-            status, exit_code = self._settle_adapter_leases(status, exit_code)
+            status, exit_code = self._settle_adapter_leases(  # type: ignore[assignment, arg-type]
+                status,  # type: ignore[arg-type]
+                exit_code,
+            )
             # child gone -> no new wire or hook events; stop the capture
             # layers before the RunEnd bracket so every event lands inside
             # the run

--- a/framework/core/src/python/kungfu/rewind/supervisor.py
+++ b/framework/core/src/python/kungfu/rewind/supervisor.py
@@ -77,6 +77,7 @@ class Supervisor:
             source=f"rewind:{self.run_id}",
         )
         self.events: queue.SimpleQueue[Any] = queue.SimpleQueue()
+        self.adapter_leases: list[adapters.RuntimeWarrantLease] = []
         self.proxy = ModelWireProxy(
             self.run_id, self.enqueue, upstreams=self._upstreams()
         )
@@ -132,10 +133,10 @@ class Supervisor:
         # adapters also put their package dirs on PYTHONPATH so an adapter can
         # import its own siblings; node adapters are required by absolute path.
         py_entries, py_dirs, py_refused = adapters.discover_adapters(
-            self.runtime_dir, "python"
+            self.runtime_dir, "python", self.adapter_leases
         )
         node_entries, _, node_refused = adapters.discover_adapters(
-            self.runtime_dir, "node"
+            self.runtime_dir, "node", self.adapter_leases
         )
         for refused in py_refused + node_refused:
             # In-process adapter injection requires an exact Core host
@@ -180,17 +181,29 @@ class Supervisor:
         )
 
         status, exit_code = RunStatus.Failed, 1
-        child = subprocess.Popen(self.command, env=self.child_env())
+        child: subprocess.Popen[Any] | None = None
         try:
+            child = subprocess.Popen(self.command, env=self.child_env())
             exit_code = child.wait()
             status = RunStatus.Succeeded if exit_code == 0 else RunStatus.Failed
             if exit_code < 0:
                 status = RunStatus.Interrupted
         except KeyboardInterrupt:
+            assert child is not None
             child.send_signal(signal.SIGINT)
             exit_code = child.wait()
             status = RunStatus.Interrupted
         finally:
+            warrant_outcome = "completed" if status == RunStatus.Succeeded else "failed"
+            for lease in self.adapter_leases:
+                try:
+                    lease.settle(warrant_outcome)
+                except (OSError, RuntimeError, ValueError) as error:
+                    status, exit_code = RunStatus.Failed, 1
+                    sys.stderr.write(
+                        f"[kungfu trace] adapter Runtime Warrant failed closed: {error}\n"
+                    )
+            self.adapter_leases.clear()
             # child gone -> no new wire or hook events; stop the capture
             # layers before the RunEnd bracket so every event lands inside
             # the run

--- a/framework/core/src/python/kungfu/storage/kfx_service.py
+++ b/framework/core/src/python/kungfu/storage/kfx_service.py
@@ -54,6 +54,7 @@ def kfx_registry(
         "history",
         "authorize-host",
         "runtime-warrant-issue",
+        "runtime-warrant-adopt",
         "runtime-warrant-heartbeat",
         "runtime-warrant-revoke",
         "runtime-warrant-settle",

--- a/framework/core/tests/python/test_adapter_trust.py
+++ b/framework/core/tests/python/test_adapter_trust.py
@@ -74,8 +74,8 @@ def _host_descriptor(package_key, authorization_root):
         "runtimeTier": "integrated-explicit",
         "admissionGrade": "kfd-attested",
         "placement": "co-resident",
-        "requiredCapabilities": [],
-        "grantedCapabilities": [],
+        "requiredCapabilities": ["process"],
+        "grantedCapabilities": ["process"],
         "reportRoot": roots["report"],
         "admissionPlanRoot": roots["admissionPlan"],
         "corePolicyRoot": roots["corePolicy"],
@@ -163,7 +163,11 @@ def _mock_native_authority(
                     "manifestRoot": candidate["manifestRoot"],
                 }
             }
-        if action != "authorize-host":
+        if action == "runtime-warrant-heartbeat":
+            return {"leaseState": {"state": "active"}}
+        if action == "runtime-warrant-settle":
+            return {"leaseState": {"state": "settled"}}
+        if action != "runtime-warrant-adopt":
             raise AssertionError(f"unexpected native KFX action: {action}")
         candidate = next(
             (
@@ -181,8 +185,24 @@ def _mock_native_authority(
         ):
             raise ValueError("KF_KFX_AUTHORIZATION_STALE")
         return {
+            "schema": "kungfu.kfx.runtime-warrant-adoption/v1",
             "executionAllowed": True,
-            "authorization": candidate,
+            "hostLaunch": {"authorization": candidate},
+            "runtimeWarrant": {
+                "warrantRoot": f"sha256:{'6' * 64}",
+                "packageKey": candidate["packageKey"],
+                "host": candidate["host"],
+                "holder": request["holder"],
+                "capabilityGrantRoot": candidate["capabilityGrantRoot"],
+                "mutationWarrantRoot": candidate["warrantRoot"],
+            },
+            "leaseState": {
+                "warrantRoot": f"sha256:{'6' * 64}",
+                "holder": request["holder"],
+                "generation": 1,
+                "fencingToken": f"sha256:{'7' * 64}",
+                "state": "active",
+            },
         }
 
     monkeypatch.setattr(adapters.storage_service, "kfx_registry", kfx_registry)
@@ -200,7 +220,7 @@ def test_discovery_origin_and_package_name_confer_zero_authority(tmp_path, monke
     _setup(tmp_path, monkeypatch)
     _mock_native_authority(monkeypatch, None)
     entries, dirs, refused = adapters.discover_adapters(
-        str(tmp_path / "runtime"), "python"
+        str(tmp_path / "runtime"), "python", []
     )
     assert entries == [] and dirs == []
     assert {row["key"] for row in refused} == {"bundled-a", "external-b"}
@@ -214,16 +234,22 @@ def test_only_the_exact_core_authorization_allows_in_process_injection(
     descriptor = _host_descriptor("external-b", authorization_root)
     calls = _mock_native_authority(monkeypatch, descriptor, "external-b")
 
+    leases = []
     entries, dirs, refused = adapters.discover_adapters(
-        str(tmp_path / "runtime"), "python"
+        str(tmp_path / "runtime"), "python", leases
     )
     assert len(entries) == 1
     assert {os.path.basename(path) for path in dirs} == {"external-b"}
     assert {row["key"] for row in refused} == {"bundled-a"}
-    launch = next(request for action, request, _ in calls if action == "authorize-host")
+    launch = next(
+        request for action, request, _ in calls if action == "runtime-warrant-adopt"
+    )
     assert launch["expectedCutRoot"] == descriptor["cutRoot"]
     assert launch["expectedGenerationRoot"] == descriptor["generationRoot"]
     assert launch["expectedAuthorizationRoot"] == authorization_root
+    assert launch["requestedCapabilities"] == ["process"]
+    for lease in leases:
+        lease.settle("completed")
 
 
 def test_caller_supplied_descriptor_conveys_zero_authority(tmp_path, monkeypatch):
@@ -235,7 +261,7 @@ def test_caller_supplied_descriptor_conveys_zero_authority(tmp_path, monkeypatch
     _mock_native_authority(monkeypatch, None)
 
     entries, dirs, refused = adapters.discover_adapters(
-        str(tmp_path / "runtime"), "python"
+        str(tmp_path / "runtime"), "python", []
     )
     assert entries == [] and dirs == []
     assert {row["key"] for row in refused} == {"bundled-a", "external-b"}
@@ -249,8 +275,8 @@ def test_same_key_shadow_with_different_closure_is_refused(tmp_path, monkeypatch
     )
 
     entries, dirs, refused = adapters.discover_adapters(
-        str(tmp_path / "runtime"), "python"
+        str(tmp_path / "runtime"), "python", []
     )
     assert entries == [] and dirs == []
     assert {row["key"] for row in refused} == {"bundled-a", "external-b"}
-    assert not any(action == "authorize-host" for action, _, _ in calls)
+    assert not any(action == "runtime-warrant-adopt" for action, _, _ in calls)

--- a/framework/core/tests/python/test_native_kfx_contract.py
+++ b/framework/core/tests/python/test_native_kfx_contract.py
@@ -111,6 +111,7 @@ def test_native_kfx_python_binding_is_a_thin_core_edge(tmp_path):
     [
         "authorize-host",
         "runtime-warrant-issue",
+        "runtime-warrant-adopt",
         "runtime-warrant-heartbeat",
         "runtime-warrant-revoke",
         "runtime-warrant-settle",

--- a/framework/kfx/evidence/kfd-10/runtime-warrant-adopter.json
+++ b/framework/kfx/evidence/kfd-10/runtime-warrant-adopter.json
@@ -58,7 +58,7 @@
     },
     {
       "path": "framework/core/src/python/kungfu/rewind/adapters.py",
-      "sha256": "sha256:6a8924bb14d3ac8961fb65c672051fdad02f3e1ee1f8a1d160d20f069bc31370"
+      "sha256": "sha256:aabbab12a635967e52cd1a250311a48a584bede45c1334afd94fffd91c460567"
     }
   ],
   "qualification": {

--- a/framework/kfx/evidence/kfd-10/runtime-warrant-adopter.json
+++ b/framework/kfx/evidence/kfd-10/runtime-warrant-adopter.json
@@ -58,7 +58,7 @@
     },
     {
       "path": "framework/core/src/python/kungfu/rewind/adapters.py",
-      "sha256": "sha256:aabbab12a635967e52cd1a250311a48a584bede45c1334afd94fffd91c460567"
+      "sha256": "sha256:6627e1e2dc143e8d9e59c9054de0d2fba58955543fed9d3a88cd42bbb318ad6a"
     }
   ],
   "qualification": {

--- a/framework/kfx/evidence/kfd-10/runtime-warrant-adopter.json
+++ b/framework/kfx/evidence/kfd-10/runtime-warrant-adopter.json
@@ -11,17 +11,18 @@
   "implementation": {
     "mutationWarrant": "one-shot Core-issued authority consumed by Fact/Work settlement",
     "runtimeWarrant": "Core-issued lease with an independent root, holder, purpose, generation, fencing token, heartbeat deadline, expiry, revocation channel, recovery owner and residual responsibility",
+    "hostAdoption": "WASM, service-node, service-python, service-cpp, adapter-node and adapter-python hosts adopt before execution, heartbeat the exact Core fence and terminally settle; they cannot supply recovery fencing",
     "authorityStore": "yijinjing Fact kernel with exact named-Cut CAS",
     "witness": "kungfu.kfx.kfd-10-adopter-witness/v1"
   },
   "sourceRoots": [
     {
       "path": "framework/core/src/libkungfu/src/runtime/kfx/native_authority.cpp",
-      "sha256": "sha256:63537015a9a7e1082e44bfd76d1a1d7b0acd60992bc9e85f215ac202e852136f"
+      "sha256": "sha256:63796bedad0c75cfe029aab7b6255cd89912faa6c7e246a1e18d036b505e471d"
     },
     {
       "path": "framework/core/src/libkungfu/src/runtime/kfx/native_registry.cpp",
-      "sha256": "sha256:e5e2488640ee58bdf4b1cee2ee430559dfe18262dcfc307e458dd5f65f7773b2"
+      "sha256": "sha256:770736ddabb3ecce4c9ecf6220d6f0b307a009ba8aeeaad881fd392e7e68307d"
     },
     {
       "path": "framework/core/src/libkungfu/tests/native_kfx_contract_tests.cpp",
@@ -29,19 +30,35 @@
     },
     {
       "path": "framework/core/src/libkungfu/tests/native_kfx_service_host_tests.cpp",
-      "sha256": "sha256:2ea2e2577823c7629e473360be36f9feca70b8ad16d7e04018c2e97ee872c314"
+      "sha256": "sha256:c9f603cc606f522953697731a61b0a44d39e9c3abb896cc09e7b69bb6a7f071d"
     },
     {
       "path": "framework/core/src/libkungfu/src/runtime/storage/domain_dispatch.cpp",
-      "sha256": "sha256:535b3dcd6058d70f7ecc8e16029e133e95fca942c4f7bc77235cc29ec6f10417"
+      "sha256": "sha256:aec37bd56ce055212b9a47c631a0076def7e88e5ca3d12427ae1b4297607f626"
     },
     {
       "path": "framework/core/src/python/kungfu/storage/kfx_service.py",
-      "sha256": "sha256:22784a1f779898c9a36c2c55e47f49484b1a7821ab8386b87311f4847d225724"
+      "sha256": "sha256:62a9695c5a43b6149304b33bee65aa1fab791dbf4f58a9fdc4e74906203b357b"
     },
     {
       "path": "framework/kfx/kungfu-kfx-domain-profile.contract.json",
-      "sha256": "sha256:09b57a3c98285c8836b399e7350b8d97db7af7125b62b4f6112905f2ca62f7b1"
+      "sha256": "sha256:b1a471d4dec92bf3734d52069ca6d0eb7c9701774af529e1ff407f6a2d428a42"
+    },
+    {
+      "path": "framework/api/src/capability/kfx-host.ts",
+      "sha256": "sha256:cf6376d015d660d9cbc8025b69dc7f41721eb6bcec376201493d8dce3ff32263"
+    },
+    {
+      "path": "framework/tui/src/service-host.ts",
+      "sha256": "sha256:25baf3e87a87f466c3bd65e902a8df1064e1e53716b664dc9f67d6053a803c75"
+    },
+    {
+      "path": "framework/core/src/libwasm/host.cpp",
+      "sha256": "sha256:987ca72a80279fdf73340b01c701d74d2664e09067d2d55b7fa93834c3332de0"
+    },
+    {
+      "path": "framework/core/src/python/kungfu/rewind/adapters.py",
+      "sha256": "sha256:6a8924bb14d3ac8961fb65c672051fdad02f3e1ee1f8a1d160d20f069bc31370"
     }
   ],
   "qualification": {
@@ -55,11 +72,15 @@
       "independent revocation",
       "terminal settlement",
       "successor generation and fencing",
+      "Core-owned crashed-holder adoption",
+      "product host heartbeat and terminal settlement",
       "deterministic witness replay"
     ],
     "failClosedCases": [
       "authority amplification",
       "active lease duplication",
+      "early adoption lease theft",
+      "caller-supplied recovery fence",
       "warrant root substitution",
       "stale holder",
       "stale fencing token",

--- a/framework/kfx/kungfu-kfx-domain-profile.contract.json
+++ b/framework/kfx/kungfu-kfx-domain-profile.contract.json
@@ -44,6 +44,7 @@
     "activate",
     "qualify",
     "runtime-warrant-issue",
+    "runtime-warrant-adopt",
     "runtime-warrant-heartbeat",
     "runtime-warrant-revoke",
     "runtime-warrant-settle",

--- a/framework/site/src/kfx-site-bundle.source.json
+++ b/framework/site/src/kfx-site-bundle.source.json
@@ -121,6 +121,14 @@
       "nonClaim": "Retained terminal qualification does not promote KFX to stable or authorize a new package."
     },
     {
+      "id": "runtime-warrant-adopter-evidence",
+      "path": "framework/kfx/evidence/kfd-10/runtime-warrant-adopter.json",
+      "role": "draft-runtime-authority-evidence",
+      "maturity": "pre-release",
+      "status": "staged",
+      "nonClaim": "Draft KFD-10 adopter evidence does not activate KFD-10, grant a capability, issue a Runtime Warrant, or authorize host execution."
+    },
+    {
       "id": "github-webhook-suite-readme",
       "path": "extensions/github-webhook-reference-suite/README.md",
       "role": "reference-suite-guide",
@@ -166,20 +174,20 @@
     {
       "id": "architecture",
       "title": "Architecture and hosts",
-      "summary": "The 4.0.0-alpha.3 development line keeps views, adapters, and services in distinct physical hosts while preserving one Core descriptor.",
+      "summary": "The 4.0.0-alpha.3 development line keeps views, adapters, and services in distinct physical hosts; each executable product host adopts and heartbeats an exact Core-owned leased Runtime Warrant before execution.",
       "maturity": "pre-release",
       "status": "implemented",
-      "sourceIds": ["kfx-topology", "surface-neutral-contributions"],
-      "nonClaim": "Presentation parity does not merge renderer, injected adapter, and service isolation."
+      "sourceIds": ["kfx-topology", "surface-neutral-contributions", "runtime-warrant-adopter-evidence"],
+      "nonClaim": "Presentation parity, host placement, or adapter discovery does not merge isolation boundaries or issue runtime authority."
     },
     {
       "id": "package-facets",
       "title": "Packages and facets",
-      "summary": "The 4.0.0-alpha.3 KFX manifest declares package identity, facets, requested capabilities, and host inputs; retained qualification covers package, install, activation, upgrade, rollback, and removal for the maintained webhook suite.",
+      "summary": "The 4.0.0-alpha.3 KFX manifest declares package identity, facets, requested capabilities, and host inputs; after separate native admission, executable product hosts consume a distinct Core-issued Runtime Warrant lease.",
       "maturity": "pre-release",
       "status": "implemented",
-      "sourceIds": ["kfx-contract", "extensions-guide", "installed-authoring-contract", "github-webhook-qualification"],
-      "nonClaim": "A conforming manifest remains inert until native admission."
+      "sourceIds": ["kfx-contract", "extensions-guide", "installed-authoring-contract", "github-webhook-qualification", "runtime-warrant-adopter-evidence"],
+      "nonClaim": "A conforming manifest remains inert and is neither a capability grant nor a Runtime Warrant."
     },
     {
       "id": "registry-admission-lifecycle",
@@ -193,11 +201,11 @@
     {
       "id": "capabilities",
       "title": "Capabilities and confinement",
-      "summary": "On the 4.0.0-alpha.3 development line, packages request capabilities while Core policy and an explicit exact grant select the allowed subset for one host and preserve that separation across rollback.",
+      "summary": "On the 4.0.0-alpha.3 development line, Core keeps the exact capability grant separate from the leased Runtime Warrant that binds one holder, generation, fencing token, heartbeat, expiry, revocation, recovery, and terminal settlement.",
       "maturity": "pre-release",
       "status": "implemented",
-      "sourceIds": ["kfx-contract", "capability-ownership", "kfx-topology", "installed-authoring-contract", "github-webhook-qualification"],
-      "nonClaim": "Declaration, KFD success, or package origin does not grant a capability."
+      "sourceIds": ["kfx-contract", "capability-ownership", "kfx-topology", "installed-authoring-contract", "github-webhook-qualification", "runtime-warrant-adopter-evidence"],
+      "nonClaim": "Declaration, KFD evidence, package origin, an Episode, or Settlement does not become a capability grant or Runtime Warrant."
     },
     {
       "id": "trust",
@@ -211,20 +219,20 @@
     {
       "id": "agent-first-authoring",
       "title": "Installed Agent-first authoring",
-      "summary": "The installed 4.0.0-alpha.3-matched kit supports scaffold, inspect, validate, build, offline qualify, package, install, activate, upgrade, rollback, and remove steps.",
+      "summary": "The installed 4.0.0-alpha.3-matched kit supports inert authoring and lifecycle steps; separately admitted product hosts then adopt Core-owned Runtime Warrant leases without deriving authority from authoring output.",
       "maturity": "pre-release",
       "status": "experimental",
-      "sourceIds": ["installed-agent-index", "installed-authoring-brief", "installed-authoring-contract", "github-webhook-suite-readme"],
-      "nonClaim": "Authoring output remains inert; lifecycle commands require their declared native admission and do not expose a public listener by themselves."
+      "sourceIds": ["installed-agent-index", "installed-authoring-brief", "installed-authoring-contract", "github-webhook-suite-readme", "runtime-warrant-adopter-evidence"],
+      "nonClaim": "Authoring output and draft adopter evidence remain inert; neither can issue a Runtime Warrant or expose a public listener."
     },
     {
       "id": "sdk-cli",
       "title": "SDK and CLI surfaces",
-      "summary": "The 4.0.0-alpha.3 runtime SDK projection and public CLI catalog expose version-matched authoring, lifecycle, and native inspection routes.",
+      "summary": "The 4.0.0-alpha.3 runtime SDK projection exposes typed Runtime Warrant adoption, heartbeat, revocation, and settlement edges while Core alone owns issuance, recovery fencing, and authoritative lease state.",
       "maturity": "pre-release",
       "status": "implemented",
-      "sourceIds": ["installed-authoring-brief", "installed-authoring-contract", "cli-surface-catalog", "kfx-contract", "github-webhook-suite-readme"],
-      "nonClaim": "A visible CLI route does not change its declared mutation or approval policy."
+      "sourceIds": ["installed-authoring-brief", "installed-authoring-contract", "cli-surface-catalog", "kfx-contract", "github-webhook-suite-readme", "runtime-warrant-adopter-evidence"],
+      "nonClaim": "A visible SDK type or CLI route does not mint, recover, or widen Runtime Warrant authority."
     },
     {
       "id": "profiles-suites",
@@ -247,17 +255,18 @@
     {
       "id": "qualification-status",
       "title": "Current qualification status",
-      "summary": "For the 4.0.0-alpha.3 development line, identity-neutral terminal evidence and the maintained webhook Profile cover installed-product package, lifecycle, rollback, removal, and local reference-suite qualification.",
+      "summary": "For the 4.0.0-alpha.3 development line, retained qualification covers existing installed-product and reference-suite boundaries; the product-host Runtime Warrant witness is additional draft KFD-10 adopter evidence only.",
       "maturity": "pre-release",
       "status": "qualified",
-      "sourceIds": ["kfx-terminal-qualification", "installed-authoring-contract", "github-webhook-qualification", "github-webhook-suite-readme"],
-      "nonClaim": "Current retained evidence does not establish stable compatibility, downstream Site adoption, or completion of the optional real GitHub/AWS China canary."
+      "sourceIds": ["kfx-terminal-qualification", "installed-authoring-contract", "github-webhook-qualification", "github-webhook-suite-readme", "runtime-warrant-adopter-evidence"],
+      "nonClaim": "The draft Runtime Warrant witness does not establish KFD-10 conformance, activation, shipped support, stable compatibility, or downstream Site adoption."
     }
   ],
   "humanReadingOrder": ["value", "architecture", "package-facets", "registry-admission-lifecycle", "capabilities", "trust", "agent-first-authoring", "sdk-cli", "profiles-suites", "github-webhook-reference", "qualification-status"],
   "agentReadingOrder": ["value", "architecture", "package-facets", "registry-admission-lifecycle", "capabilities", "trust", "agent-first-authoring", "sdk-cli", "profiles-suites", "github-webhook-reference", "qualification-status"],
   "nonClaims": [
     "The dedicated KFX Site Bundle is a deterministic documentation projection, not a registry, permission system, lifecycle authority, or maturity oracle.",
+    "The retained KFD-10 Runtime Warrant adopter witness is draft, non-conforming, non-shipped evidence and does not grant product authority.",
     "This source change does not publish @kungfu-tech/site or any other npm package.",
     "The production KFX Site does not consume this bundle until a separately reviewed downstream adoption.",
     "No source-built or retained qualification evidence opens a stable KFX compatibility line."

--- a/framework/tui/src/service-host-python.test.ts
+++ b/framework/tui/src/service-host-python.test.ts
@@ -5,7 +5,11 @@ import { delimiter, dirname, join, resolve } from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
-import type { ServiceAuthorization } from '@kungfu-tech/api/capability';
+import type {
+  KfxRuntimeWarrant,
+  KfxRuntimeWarrantAdoption,
+  KfxRuntimeWarrantAuthorization,
+} from '@kungfu-tech/api/capability';
 import type { KfxServicePlanEntry } from '@kungfu-tech/kfx';
 
 import {
@@ -27,8 +31,8 @@ function deadline(message: string): Promise<never> {
 }
 
 function authorization(
-  runtimeTier: ServiceAuthorization['runtimeTier'],
-): ServiceAuthorization {
+  runtimeTier: KfxRuntimeWarrantAuthorization['runtimeTier'],
+): KfxRuntimeWarrantAuthorization {
   const capabilities = ['ledger', 'network', 'process'];
   return {
     schema: 'kungfu.kfx.host-authorization/v2',
@@ -56,6 +60,64 @@ function authorization(
     generationRoot: root('f'),
     executionAllowed: true,
     authorizationRoot: root('0'),
+    host: 'service-python',
+  };
+}
+
+function runtimeWarrant(events: string[] = []): KfxRuntimeWarrant {
+  return {
+    adopt: (exact, request) => {
+      events.push('adopt');
+      return {
+        schema: 'kungfu.kfx.runtime-warrant-adoption/v1',
+        executionAllowed: true,
+        runtimeWarrant: {
+          schema: 'kungfu.kfx.runtime-warrant/v1',
+          warrantRoot: root('1'),
+          packageKey: exact.packageKey,
+          host: exact.host,
+          holder: request.holder,
+          capabilityGrantRoot: exact.capabilityGrantRoot ?? root('2'),
+          hostAuthorizationRoot: exact.authorizationRoot,
+          mutationWarrantRoot: exact.warrantRoot ?? root('3'),
+          expiresAt: request.expiresAt,
+          heartbeatTtl: request.heartbeatTtl,
+        },
+        leaseState: {
+          schema: 'kungfu.kfx.runtime-lease-state-fact/v1',
+          warrantRoot: root('1'),
+          packageKey: exact.packageKey,
+          host: exact.host,
+          holder: request.holder,
+          generation: 1,
+          fencingToken: root('4'),
+          state: 'active',
+          heartbeatAt: request.issuedAt,
+          heartbeatDeadline: request.issuedAt + request.heartbeatTtl,
+          expiresAt: request.expiresAt,
+        },
+        recovery: null,
+        receipt: {},
+      } satisfies KfxRuntimeWarrantAdoption;
+    },
+    heartbeat: () => {
+      events.push('heartbeat');
+      return {
+        schema: 'kungfu.kfx.runtime-warrant-transition/v1',
+        event: 'heartbeat',
+        leaseState: { state: 'active' },
+        receipt: {},
+      };
+    },
+    settle: () => {
+      events.push('settle');
+      return {
+        schema: 'kungfu.kfx.runtime-warrant-transition/v1',
+        event: 'settled',
+        leaseState: { state: 'settled' },
+        receipt: {},
+      };
+    },
   };
 }
 
@@ -110,12 +172,14 @@ test('Python launch refuses capabilities outside the exact Core grant', async ()
     launchDiscoveredService(entry, {
       caps: { ledger: {} },
       authorization: narrowed,
+      runtimeWarrant: runtimeWarrant(),
     }),
     /KF_KFX_HOST_NOT_AUTHORIZED/,
   );
 });
 
 test('integrated-explicit Python service uses standard asyncio in a separate process', async () => {
+  const warrantEvents: string[] = [];
   const reports: Array<Record<string, unknown>> = [];
   let resolveRunning: (() => void) | undefined;
   let resolveStopped: (() => void) | undefined;
@@ -152,6 +216,8 @@ test('integrated-explicit Python service uses standard asyncio in a separate pro
   const service = await launchDiscoveredService(entry, {
     caps,
     authorization: authorization('integrated-explicit'),
+    runtimeWarrant: runtimeWarrant(warrantEvents),
+    runtimeWarrantHeartbeatTtlMs: 20,
     pythonCommand:
       process.env.KUNGFU_PYTHON_BIN ??
       (process.platform === 'win32' ? 'python' : 'python3'),
@@ -169,6 +235,7 @@ test('integrated-explicit Python service uses standard asyncio in a separate pro
       process: 'subprocess-ok',
       concurrentRelayCounts: [1, 2],
     });
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 25));
 
     service.dispose();
     releaseRunningResult?.();
@@ -178,6 +245,9 @@ test('integrated-explicit Python service uses standard asyncio in a separate pro
     ]);
     assert.equal(await service.done, 0);
     assert.deepEqual(reports.at(-1), { phase: 'stopped' });
+    assert.equal(warrantEvents[0], 'adopt');
+    assert.ok(warrantEvents.includes('heartbeat'));
+    assert.equal(warrantEvents.at(-1), 'settle');
   } finally {
     // A failed readiness assertion must not strand the Python child and keep
     // the Node test process alive. This is especially important on Windows,

--- a/framework/tui/src/service-host.ts
+++ b/framework/tui/src/service-host.ts
@@ -12,13 +12,16 @@
 // binary directly and it speaks the relay through its linked guest proxy
 // (framework/core/src/capability/guest.hpp). Unsupported runtime/platform
 // combinations are refused rather than mis-launched.
+import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import {
   type GuestProcess,
+  type KfxRuntimeWarrant,
+  type KfxRuntimeWarrantAdoption,
+  type KfxRuntimeWarrantAuthorization,
   type SandboxedGuest,
-  type ServiceAuthorization,
   type SpawnFn,
   type WindowsSandboxSpawn,
   createInProcessAsyncCaps,
@@ -36,7 +39,16 @@ export type LaunchServiceOptions = {
   // the real capabilities the host resolves the service's relay calls against;
   // only the entry's declared capabilities are reachable.
   caps: Record<string, Record<string, unknown>>;
-  authorization: ServiceAuthorization;
+  authorization: KfxRuntimeWarrantAuthorization;
+  // Product hosts may launch only while holding the Core-issued lease. The
+  // transport is injected so tests and alternate native embeddings retain the
+  // same authority path rather than reimplementing warrant state locally.
+  runtimeWarrant: KfxRuntimeWarrant;
+  runtimeWarrantHolder?: string;
+  runtimeWarrantLeaseMs?: number;
+  runtimeWarrantHeartbeatTtlMs?: number;
+  runtimeWarrantNow?: () => number;
+  runtimeWarrantNonce?: () => string;
   // override the node bootstrap path (defaults to the sibling service-bootstrap).
   bootstrap?: string;
   // injectable for tests; forwarded to launchSandboxedGuest.
@@ -83,7 +95,7 @@ export function resolveServiceRuntime(
     command?: string;
     path?: string;
     shutdownTimeoutMs?: number;
-    authorization?: ServiceAuthorization;
+    authorization?: KfxRuntimeWarrantAuthorization;
   } = {},
 ): {
   kind: 'node' | 'cpp' | 'python';
@@ -168,49 +180,6 @@ export async function launchDiscoveredService(
       'KF_KFX_HOST_NOT_AUTHORIZED: service discovery and authorization do not match',
     );
   }
-  const landing = resolveServiceLanding(opts.authorization);
-
-  if (landing.tier === 'co-resident') {
-    // Integrated execution is an explicit placement in the rooted grant.
-    if (entry.runtimes.includes('node') && entry.entry.node) {
-      const caps = createInProcessAsyncCaps(opts.caps, declared);
-      const bodyPath = join(entry.dir, entry.entry.node);
-      const done = import(pathToFileURL(bodyPath).href)
-        .then((mod: { run: (c: Record<string, unknown>) => Promise<void> }) =>
-          mod.run(caps),
-        )
-        .then(() => null);
-      return { tier: 'co-resident', done, dispose: () => {} };
-    }
-    if (!entry.runtimes.includes('python') || !entry.entry.python) {
-      throw new Error(
-        `integrated service '${entry.id}' has no node or python body`,
-      );
-    }
-    const runtime = resolveServiceRuntime(entry, DEFAULT_BOOTSTRAP, declared, {
-      command: opts.pythonCommand,
-      path: opts.pythonPath,
-      shutdownTimeoutMs: opts.pythonShutdownTimeoutMs,
-      authorization: opts.authorization,
-    });
-    const guest: GuestProcess = await launchIntegratedGuest({
-      runtime,
-      caps: opts.caps,
-      declared,
-      spawn: opts.spawn,
-      inheritEnv: false,
-      gracefulShutdown: {
-        timeoutMs: (opts.pythonShutdownTimeoutMs ?? 5_000) + 1_000,
-      },
-    });
-    return {
-      tier: 'co-resident',
-      done: guest.exited,
-      dispose: guest.dispose,
-    };
-  }
-
-  // Isolated execution is physically confined by the Core-derived profile.
   const runtime = resolveServiceRuntime(
     entry,
     opts.bootstrap ?? DEFAULT_BOOTSTRAP,
@@ -222,23 +191,157 @@ export async function launchDiscoveredService(
       authorization: opts.authorization,
     },
   );
-  const guest: SandboxedGuest = await launchSandboxedGuest({
-    runtime,
-    caps: opts.caps,
-    declared,
-    profile: landing.profile,
-    spawn: opts.spawn,
-    windowsSpawn: opts.windowsSpawn,
-    inheritEnv: runtime.kind !== 'python',
-    gracefulShutdown:
-      runtime.kind === 'python'
-        ? { timeoutMs: (opts.pythonShutdownTimeoutMs ?? 5_000) + 1_000 }
-        : undefined,
+  const expectedHost = `service-${runtime.kind}`;
+  if (opts.authorization.host !== expectedHost) {
+    throw new Error(
+      'KF_KFX_HOST_NOT_AUTHORIZED: service runtime and authorization host do not match',
+    );
+  }
+  const landing = resolveServiceLanding(opts.authorization);
+  const now = opts.runtimeWarrantNow ?? Date.now;
+  const issuedAt = now();
+  const leaseMs = opts.runtimeWarrantLeaseMs ?? 60_000;
+  const heartbeatTtl = opts.runtimeWarrantHeartbeatTtlMs ?? 15_000;
+  const holder =
+    opts.runtimeWarrantHolder ??
+    `kungfu-service-host:${process.pid}:${entry.id}`;
+  const adoption = opts.runtimeWarrant.adopt(opts.authorization, {
+    holder,
+    purpose: `run authorized ${expectedHost} product adapter`,
+    leaseNonce: opts.runtimeWarrantNonce?.() ?? randomUUID(),
+    issuedAt,
+    expiresAt: issuedAt + leaseMs,
+    heartbeatTtl,
+    residualResponsibility: 'retained-by-kungfu-core',
+    requestedCapabilities: [...declared],
   });
+
+  let guestDone: Promise<number | null>;
+  let guestDispose: () => void;
+  let tier: LaunchedService['tier'];
+  let networkConsent: boolean | undefined;
+
+  try {
+    if (landing.tier === 'co-resident') {
+      tier = 'co-resident';
+      // Integrated execution is an explicit placement in the rooted grant.
+      if (runtime.kind === 'node' && entry.entry.node) {
+        const caps = createInProcessAsyncCaps(opts.caps, declared);
+        const bodyPath = join(entry.dir, entry.entry.node);
+        guestDone = import(pathToFileURL(bodyPath).href)
+          .then((mod: { run: (c: Record<string, unknown>) => Promise<void> }) =>
+            mod.run(caps),
+          )
+          .then(() => null);
+        guestDispose = () => {};
+      } else {
+        if (runtime.kind !== 'python') {
+          throw new Error(
+            `integrated service '${entry.id}' has no node or python body`,
+          );
+        }
+        const guest: GuestProcess = await launchIntegratedGuest({
+          runtime,
+          caps: opts.caps,
+          declared,
+          spawn: opts.spawn,
+          inheritEnv: false,
+          gracefulShutdown: {
+            timeoutMs: (opts.pythonShutdownTimeoutMs ?? 5_000) + 1_000,
+          },
+        });
+        guestDone = guest.exited;
+        guestDispose = guest.dispose;
+      }
+    } else {
+      // Isolated execution is physically confined by the Core-derived profile.
+      const guest: SandboxedGuest = await launchSandboxedGuest({
+        runtime,
+        caps: opts.caps,
+        declared,
+        profile: landing.profile,
+        spawn: opts.spawn,
+        windowsSpawn: opts.windowsSpawn,
+        inheritEnv: runtime.kind !== 'python',
+        gracefulShutdown:
+          runtime.kind === 'python'
+            ? { timeoutMs: (opts.pythonShutdownTimeoutMs ?? 5_000) + 1_000 }
+            : undefined,
+      });
+      tier = 'sandbox';
+      guestDone = guest.exited;
+      guestDispose = guest.dispose;
+      networkConsent = landing.networkConsent;
+    }
+  } catch (error) {
+    settleRuntimeWarrant(opts.runtimeWarrant, adoption, now(), 'failed');
+    throw error;
+  }
+
+  let disposed = false;
+  let rejectLease: (reason: unknown) => void = () => {};
+  const leaseFailure = new Promise<never>((_resolve, reject) => {
+    rejectLease = reject;
+  });
+  const interval = setInterval(
+    () => {
+      try {
+        const transition = opts.runtimeWarrant.heartbeat(adoption, now());
+        if (transition.leaseState.state !== 'active') {
+          throw new Error('KFX Runtime Warrant heartbeat was not retained');
+        }
+      } catch (error) {
+        guestDispose();
+        rejectLease(error);
+      }
+    },
+    Math.max(1, Math.floor(heartbeatTtl / 2)),
+  );
+  interval.unref();
+  const done = Promise.race([guestDone, leaseFailure])
+    .then(
+      (exitCode) => {
+        settleRuntimeWarrant(
+          opts.runtimeWarrant,
+          adoption,
+          now(),
+          disposed
+            ? 'cancelled'
+            : exitCode === null || exitCode === 0
+              ? 'completed'
+              : 'failed',
+        );
+        return exitCode;
+      },
+      (error) => {
+        settleRuntimeWarrant(opts.runtimeWarrant, adoption, now(), 'failed');
+        throw error;
+      },
+    )
+    .finally(() => clearInterval(interval));
   return {
-    tier: 'sandbox',
-    done: guest.exited,
-    dispose: guest.dispose,
-    networkConsent: landing.networkConsent,
+    tier,
+    done,
+    dispose: () => {
+      disposed = true;
+      guestDispose();
+    },
+    ...(networkConsent === undefined ? {} : { networkConsent }),
   };
+}
+
+function settleRuntimeWarrant(
+  warrant: KfxRuntimeWarrant,
+  adoption: KfxRuntimeWarrantAdoption,
+  recordedAt: number,
+  outcome: 'completed' | 'failed' | 'cancelled',
+): void {
+  const transition = warrant.settle(adoption, {
+    recordedAt,
+    outcome,
+    residualResponsibilityDisposition: 'retained-by-kungfu-core',
+  });
+  if (transition.leaseState.state !== 'settled') {
+    throw new Error('KFX Runtime Warrant terminal settlement was not retained');
+  }
 }

--- a/scripts/kfd-support-matrix.mjs
+++ b/scripts/kfd-support-matrix.mjs
@@ -381,7 +381,7 @@ function validateMatrix(matrix, { verifyInstalledKfd = true } = {}) {
     kfd10Witness.authoritySeparation?.settlementIsNotWarrant !== true,
     kfd10Witness.authoritySeparation?.recoveryOwnedByCore !== true,
     !Array.isArray(kfd10Witness.sourceRoots),
-    kfd10Witness.sourceRoots?.length !== 7,
+    kfd10Witness.sourceRoots?.length !== 11,
   ].some(Boolean);
   if (malformedKfd10Witness) {
     fail('KFD-10 specialized witness is malformed or claim-widened');


### PR DESCRIPTION
## Summary

- Add the Core-owned `runtime-warrant-adopt` transition so product hosts recover only expired or missed-heartbeat leases, receive a successor generation/fence, and cannot steal a live lease or supply recovery fencing.
- Make the public API edge, TUI Node/Python/C++ service host, native WASM host, and Rewind Node/Python adapters adopt before execution, heartbeat the exact leased Runtime Warrant, fail closed on lease loss, and retain terminal settlement.
- Cover crash/recovery, generation, fencing, heartbeat, expiry, revocation, stale/duplicate use, authority amplification, and Warrant-root substitution while keeping capability grant, Warrant, Episode, and Settlement authorities distinct.
- Extend the retained KFD-10 source witness to the real host adapters without activating KFD-10: it remains draft adopter evidence, non-conforming, non-shipped, and forbidden as release or runtime-permission authority.

This is the second focused slice of Assignment `2026-08-10-kungfu-kfx-kfd10-runtime-warrant-adopter`, based directly on the protected merge of first-slice PR #3390. It does not rewrite or combine with #3390.

## Verification

- slice ancestry base: `9b35e6596522eece343f62fdc3fe3a2b9765048a`
- exact source head: `f35de6f87f4e801b1b734704e02ebbfb2185b4e0`
- repository staged gate passed on the exact repaired source head
- Python type baseline: 257 source files passed under the project uv toolchain
- exact PR-event ADR delivery gate passed with zero findings
- changed-code function-risk ratchet passed against the exact protected base
- exact-head Core build passed
- native API and KFX contracts: 2/2 passed
- API Runtime Warrant host tests: 6/6 passed
- real Python service-host tests: 3/3 passed, including adopt/heartbeat/settle
- Rewind adapter trust tests: 4/4 passed
- KFD support-matrix source check and negative fixtures passed; rowCount=13 and shippedSupportCount=4; KFD-10 remains draft adopter evidence only
- semantic Site Bundle impact check passed with `unresolvedFacets=[]`
- Site Bundle and impact tests: 26/26 passed
- the broader TUI package build still exposes the protected-base `main.tsx` ready/close type mismatch; the affected service-host tests and API build pass

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"dev-delivery","intent":"stage-ready","adrs":["KF-ADR-019f86da-4f90-7ef4-b28b-ee1fbaf9e62e","KF-ADR-019f86da-4f90-73f3-b027-c343b2bc8bcc","KF-ADR-019f86da-4f90-7d6c-926a-ddd27dbde8ab","KF-ADR-019f86da-4f90-72df-add3-948f3ae38c3a","KF-ADR-019f8c53-6105-71e5-8f34-53f2a81ee61c"],"summary":"Make real KFX product host adapters consume exact Core-owned leased Runtime Warrants while retaining draft KFD-10 evidence and authority separation.","verification":["repository staged gate","changed-code function-risk ratchet","exact-head Core build","native KFX contract tests","product host adapter tests","KFD support matrix source check"]}
-->

## Evolution Map impact

Evolution impact: extends

This extends the current Core-native KFX Runtime Warrant stage into real product host adapters. It does not allocate a new Era, replace current authority, or activate KFD-10.

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The only release-surface change is the retained KFD support projection. It explicitly keeps KFD-10 draft, non-shipped, and release-forbidden. This PR performs no package publication, tag, release, deployment, privilege widening, or runtime activation.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation and retained evidence updated where behavior changed

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6IjIwMjYtMDgtMTAta2ZkLWZ1bGwtY3V0LWFkb3B0ZXItY29uZm9ybWFuY2UtYW5kLXRoaXJkLXBhcnR5LXRvb2xjaGFpbiIsImFzc2lnbm1lbnRJZCI6IjIwMjYtMDgtMTAta3VuZ2Z1LWtmeC1rZmQxMC1ydW50aW1lLXdhcnJhbnQtYWRvcHRlciIsImRlbGl2ZXJ5Q2xhc3MiOiJuYXRpdmUtcHJvb2YtcmVxdWlyZWQiLCJkZXZIZWFkIjoiNzAzODVhMDVhMjg2ZmRiM2ZmNGFhNmNmYzhjMmUyYjE5MTRiMWI0ZSIsInB1bGxSZXF1ZXN0SGVhZCI6ImYzNWRlNmY4N2Y0ZTgwMWIxYjczNDcwNGUwMmViYmZiMjE4NWI0ZTAiLCJyZXBsYXllZENhbmRpZGF0ZSI6ImQ0YTNkMzBhODc5YjgwZmZkZDA5OGVlZDNkMWE2ZjJhNTYyZjgyODQiLCJyZXBsYXllZFRyZWUiOiI3MmRhZjAzNzZkZWIzMTg1NzRlYjFjY2UxMjM4OTU2ZmIwY2NhN2U1IiwicXVldWVBdHRlbXB0IjoiZjM1ZGU2Zjg3ZjRlODAxYjFiNzM0NzA0ZTAyZWJiZmIyMTg1YjRlMEA3MDM4NWEwNWEyODZmZGIzZmY0YWE2Y2ZjOGMyZTJiMTkxNGIxYjRlIiwiYWRtaXNzaW9uUHJvb2ZSb290Ijoic2hhMjU2OjZhMmRhMTQ4ZGUyY2VlZGJhZDkxYmZkNmM0YmZkNzBkY2ZmNDE2MjlkNGQ3YThjZTVkYmQxNmJkZDRhNWNhYjMiLCJhZG1pc3Npb25Qcm9vZlJvb3RzIjpbInNoYTI1Njo2YTJkYTE0OGRlMmNlZWRiYWQ5MWJmZDZjNGJmZDcwZGNmZjQxNjI5ZDRkN2E4Y2U1ZGJkMTZiZGQ0YTVjYWIzIiwic2hhMjU2OmIwMGZlYTE1ZDdiNWNhNjhjZmFjNjA4MjY1ZjU5NjliZjg2ODYyYWI3MDZhZDg1MDgwOWU0ZmM5NjZhOTNlZjEiXSwic3RhdHVzQ29udGV4dCI6IlF1ZXVlIGZhbWlseSBsZWFzZS9lMWM3YzUwZWY4MmNhODEyIiwibGVhc2VSb290Ijoic2hhMjU2OjIxM2U1OTdlMTE1MmQwOTlhNDFjODQ4MTdiNjZjZmZhNTVmMDM0M2Y2ZTMzMTMzYjc2MDE3MjU2MjRiYzAxYTIifQ -->