### PR TITLE
fix(runtime): reject invalid completion evidence before replay

### DIFF
--- a/framework/core/src/python/kungfu/assignment_runtime/authority.py
+++ b/framework/core/src/python/kungfu/assignment_runtime/authority.py
@@ -146,6 +146,45 @@ class LocalRuntimeError(RuntimeError):
         self.diagnostics = list(diagnostics or [])
 
 
+def _validate_completion_evidence_row(index: int, row: Any) -> None:
+    if not isinstance(row, Mapping):
+        raise LocalRuntimeError(
+            "invalid-command",
+            "evidenceAvailability rows must be objects",
+            details={"field": "evidenceAvailability", "index": index},
+        )
+    acceptance = str(row.get("acceptance") or "").strip()
+    level = str(row.get("level") or "").strip()
+    state = str(row.get("state") or "").strip()
+    if (
+        not acceptance
+        or level not in {"thin", "full"}
+        or state not in {"available", "unavailable", "missing"}
+    ):
+        raise LocalRuntimeError(
+            "invalid-command",
+            "evidenceAvailability requires acceptance, thin/full level, "
+            "and available/unavailable/missing state",
+            details={"field": "evidenceAvailability", "index": index},
+        )
+
+
+def _validate_completion_evidence_availability(
+    command: Mapping[str, Any], arguments: Mapping[str, Any]
+) -> None:
+    if command.get("type") != "assignment.completion.claim":
+        return
+    evidence_availability = arguments.get("evidenceAvailability", [])
+    if not isinstance(evidence_availability, list):
+        raise LocalRuntimeError(
+            "invalid-command",
+            "evidenceAvailability must be an array",
+            details={"field": "evidenceAvailability"},
+        )
+    for index, row in enumerate(evidence_availability):
+        _validate_completion_evidence_row(index, row)
+
+
 def _validate_command_arguments(command: Mapping[str, Any]) -> None:
     arguments = command.get("arguments")
     if not isinstance(arguments, Mapping):
@@ -157,36 +196,7 @@ def _validate_command_arguments(command: Mapping[str, Any]) -> None:
             "Assessment executor profile must be inline, thread, or process",
             details={"field": "executorProfile"},
         )
-    if command.get("type") != "assignment.completion.claim":
-        return
-    evidence_availability = arguments.get("evidenceAvailability", [])
-    if not isinstance(evidence_availability, list):
-        raise LocalRuntimeError(
-            "invalid-command",
-            "evidenceAvailability must be an array",
-            details={"field": "evidenceAvailability"},
-        )
-    for index, row in enumerate(evidence_availability):
-        if not isinstance(row, Mapping):
-            raise LocalRuntimeError(
-                "invalid-command",
-                "evidenceAvailability rows must be objects",
-                details={"field": "evidenceAvailability", "index": index},
-            )
-        acceptance = str(row.get("acceptance") or "").strip()
-        level = str(row.get("level") or "").strip()
-        state = str(row.get("state") or "").strip()
-        if (
-            not acceptance
-            or level not in {"thin", "full"}
-            or state not in {"available", "unavailable", "missing"}
-        ):
-            raise LocalRuntimeError(
-                "invalid-command",
-                "evidenceAvailability requires acceptance, thin/full level, "
-                "and available/unavailable/missing state",
-                details={"field": "evidenceAvailability", "index": index},
-            )
+    _validate_completion_evidence_availability(command, arguments)
 
 
 def _normalize_completion_context_roots(

--- a/framework/core/src/python/kungfu/assignment_runtime/authority.py
+++ b/framework/core/src/python/kungfu/assignment_runtime/authority.py
@@ -157,6 +157,36 @@ def _validate_command_arguments(command: Mapping[str, Any]) -> None:
             "Assessment executor profile must be inline, thread, or process",
             details={"field": "executorProfile"},
         )
+    if command.get("type") != "assignment.completion.claim":
+        return
+    evidence_availability = arguments.get("evidenceAvailability", [])
+    if not isinstance(evidence_availability, list):
+        raise LocalRuntimeError(
+            "invalid-command",
+            "evidenceAvailability must be an array",
+            details={"field": "evidenceAvailability"},
+        )
+    for index, row in enumerate(evidence_availability):
+        if not isinstance(row, Mapping):
+            raise LocalRuntimeError(
+                "invalid-command",
+                "evidenceAvailability rows must be objects",
+                details={"field": "evidenceAvailability", "index": index},
+            )
+        acceptance = str(row.get("acceptance") or "").strip()
+        level = str(row.get("level") or "").strip()
+        state = str(row.get("state") or "").strip()
+        if (
+            not acceptance
+            or level not in {"thin", "full"}
+            or state not in {"available", "unavailable", "missing"}
+        ):
+            raise LocalRuntimeError(
+                "invalid-command",
+                "evidenceAvailability requires acceptance, thin/full level, "
+                "and available/unavailable/missing state",
+                details={"field": "evidenceAvailability", "index": index},
+            )
 
 
 def _normalize_completion_context_roots(

--- a/framework/core/tests/python/test_assignment_runtime.py
+++ b/framework/core/tests/python/test_assignment_runtime.py
@@ -1294,6 +1294,51 @@ def test_invalid_assessment_executor_is_rejected_before_pending_write(tmp_path):
         assert authority._read()["effects"] == []
 
 
+@pytest.mark.parametrize(
+    "evidence_availability",
+    [
+        {"acceptance": "acceptance-a", "level": "full", "state": "available"},
+        ["acceptance-a"],
+        [{"acceptance": "", "level": "full", "state": "available"}],
+        [{"acceptance": "acceptance-a", "level": "partial", "state": "available"}],
+        [{"acceptance": "acceptance-a", "level": "full", "state": "unknown"}],
+    ],
+)
+def test_invalid_completion_evidence_is_rejected_before_pending_write(
+    tmp_path, evidence_availability
+):
+    runtime_dir = tmp_path / "invalid-completion-evidence" / ".kungfu" / "runtime"
+    authority = FakeAuthority(runtime_dir)
+    with EmbeddedLocalAssignmentRuntime(
+        runtime_dir,
+        realm_id=REALM["realmId"],
+        generation=REALM["generation"],
+        authority=authority,
+        contract=ASSIGNMENT_RUNTIME_CONTRACT,
+        request_schema=ENVELOPE_SCHEMA,
+    ) as runtime:
+        snapshot = _handle(
+            runtime, _request("assignment.snapshot", "assignment.snapshot.read")
+        )
+        command = _command(
+            snapshot["revision"],
+            command_type="assignment.completion.claim",
+        )
+        command["arguments"] = {"evidenceAvailability": evidence_availability}
+        rejected = _handle(
+            runtime,
+            _request(
+                "command.submit",
+                "assignment.command.submit",
+                payload=command,
+            ),
+        )
+
+        assert rejected["error"]["code"] == "invalid-command"
+        assert runtime._state["pending"] is None
+        assert authority._read()["effects"] == []
+
+
 def test_restart_rejects_legacy_invalid_executor_pending_before_authority(tmp_path):
     runtime_dir = tmp_path / "legacy-invalid-executor" / ".kungfu" / "runtime"
     authority = FakeAuthority(runtime_dir)
@@ -1337,6 +1382,62 @@ def test_restart_rejects_legacy_invalid_executor_pending_before_authority(tmp_pa
         assert recovered._state["diagnostics"][-1]["code"] == (
             "interrupted-command-rejected"
         )
+    finally:
+        recovered.close()
+
+
+def test_restart_rejects_invalid_completion_pending_before_authority(tmp_path):
+    runtime_dir = tmp_path / "invalid-completion-pending" / ".kungfu" / "runtime"
+    authority = FakeAuthority(runtime_dir)
+    runtime = EmbeddedLocalAssignmentRuntime(
+        runtime_dir,
+        realm_id=REALM["realmId"],
+        generation=REALM["generation"],
+        authority=authority,
+        contract=ASSIGNMENT_RUNTIME_CONTRACT,
+        request_schema=ENVELOPE_SCHEMA,
+    ).start()
+    snapshot = _handle(
+        runtime, _request("assignment.snapshot", "assignment.snapshot.read")
+    )
+    command = _command(
+        snapshot["revision"],
+        command_type="assignment.completion.claim",
+    )
+    command["arguments"] = {
+        "evidenceAvailability": [
+            {
+                "acceptance": "acceptance-a",
+                "level": "partial",
+                "state": "available",
+            }
+        ]
+    }
+    runtime._state["pending"] = {
+        "commandRoot": _root(command),
+        "command": command,
+        "beforeRevision": snapshot["revision"],
+        "requestId": "invalid.completion.pending",
+    }
+    runtime._save_state()
+    runtime.close()
+
+    recovered = EmbeddedLocalAssignmentRuntime(
+        runtime_dir,
+        realm_id=REALM["realmId"],
+        generation=REALM["generation"],
+        authority=authority,
+        contract=ASSIGNMENT_RUNTIME_CONTRACT,
+        request_schema=ENVELOPE_SCHEMA,
+    ).start()
+    try:
+        assert recovered._state["pending"] is None
+        assert authority._read()["effects"] == []
+        assert recovered._state["events"][-1]["kind"] == "command-rejected"
+        diagnostic = recovered._state["diagnostics"][-1]
+        assert diagnostic["code"] == "interrupted-command-rejected"
+        assert diagnostic["details"]["field"] == "evidenceAvailability"
+        assert diagnostic["details"]["index"] == 0
     finally:
         recovered.close()
 


### PR DESCRIPTION
## Summary

- validate `assignment.completion.claim` evidence availability before durable pending write and before startup replay authority mutation
- reject non-array collections, non-object rows, empty acceptance, unsupported levels such as `partial`, and unknown states with the existing `invalid-command` path
- preserve the retained command root while recording the existing `command-rejected` event and `interrupted-command-rejected` diagnostic
- never rewrite invalid `partial` evidence into `thin` or `full`

This compatibility repair makes a retained invalid completion command recoverable through the public startup surface. It does not edit or bypass native Assignment state.

## Verification

- `./shifu test:assignment-runtime` — Node 40/40; Python 38 passed and 1 platform skip; selected runtime tests 2/2
- exact-head changed-code risk ratchet — 2 changed paths, 4 fast extractions, 2,632 full-path extractions, 0 blocking findings
- full function-risk analysis — 11,982 functions, 0 blocking findings
- exact-head Python structure — `sha256:716108bbc97740988a7c8ec11839ff60ec2112d53cfaf8a5f9f20b12ef042e49`, 0 blocking issues
- exact-head semantic amplification — 7 families, 103 surfaces, 0 issues
- exact-head full `./shifu check:source` — passed; Node 1,180 total / 1,169 passed / 11 skipped / 0 failed, Python state 40, runtime upgrade 135, desktop 73, Ruff and mypy 256 sources green, zero-write roots unchanged
- independent exact review — 0 blocking findings
- official queue replay against current protected `9b35e6596522eece343f62fdc3fe3a2b9765048a` — qualified; candidate `4530849ad239d0cb38193750a1827562a8f7ef58`, tree `1f6ff909ef3aec4e9d0e22c98a85d970e7e59a4c`, replayed 2, `compositionChanged=false`, diagnostics empty
- fresh Atlas/Kungfu work admission — verified at `4d3d497d76de1f021690c58a73bf2ae3046c59af`, binding `sha256:b60defbc53d34ce9cf8ac47135c2adabfc37e9e9c40f4cc5c6855ed2c7825648`

## Compatibility and scope

- only Assignment runtime validation and its Python tests change
- no watcher, GUI/TUI, C++ runtime, Node binding, Work Control adapter, dependency, or lockfile change
- no public import, CLI parameter, persistence-format, schema, or cross-language contract change
- the current protected drift has zero overlap with the two changed paths

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This private pending-replay validation repair preserves public APIs, CLI behavior, persistence formats, Work Control semantics, and cross-language contracts."
}
-->
