### PR TITLE
fix(runtime): reject unresolved parent shorthand before replay

### DIFF
--- a/framework/core/src/python/kungfu/assignment_runtime/authority.py
+++ b/framework/core/src/python/kungfu/assignment_runtime/authority.py
@@ -199,6 +199,39 @@ def _validate_command_arguments(command: Mapping[str, Any]) -> None:
     _validate_completion_evidence_availability(command, arguments)
 
 
+def _validate_assignment_create_references(
+    command: Mapping[str, Any], snapshot: Mapping[str, Any]
+) -> None:
+    if command.get("type") != "assignment.create":
+        return
+    arguments = command.get("arguments")
+    if not isinstance(arguments, Mapping):
+        return
+    parent_assignment_id = str(arguments.get("parentAssignmentId") or "")
+    if not parent_assignment_id:
+        return
+    if arguments.get("parentAssignmentRef"):
+        raise LocalRuntimeError(
+            "invalid-command",
+            "Pass parentAssignmentId shorthand or parentAssignmentRef, not both",
+            details={"fields": ["parentAssignmentId", "parentAssignmentRef"]},
+        )
+    matches = [
+        row
+        for row in snapshot.get("assignments") or []
+        if row.get("assignmentId") == parent_assignment_id
+    ]
+    if len(matches) != 1:
+        raise LocalRuntimeError(
+            "invalid-command",
+            "Local parent Assignment shorthand must resolve exactly once",
+            details={
+                "field": "parentAssignmentId",
+                "matches": len(matches),
+            },
+        )
+
+
 def _normalize_completion_context_roots(
     operation: str, arguments: Mapping[str, Any]
 ) -> dict[str, Any]:

--- a/framework/core/src/python/kungfu/assignment_runtime/local.py
+++ b/framework/core/src/python/kungfu/assignment_runtime/local.py
@@ -39,6 +39,7 @@ from .authority import (
     _interrupted_command_rejection,
     _root,
     _stable,
+    _validate_assignment_create_references,
     _validate_command_arguments,
 )
 from .recovery import AssignmentRuntimeRecoveryMixin
@@ -322,6 +323,13 @@ class EmbeddedLocalAssignmentRuntime(AssignmentRuntimeRecoveryMixin):
             self._finalize_pending(dict(pending), snapshot, revision, recovered=True)
             return
         snapshot, revision = self._observe_snapshot(record_event=False)
+        try:
+            _validate_assignment_create_references(command, snapshot)
+        except LocalRuntimeError as error:
+            if error.code != "invalid-command":
+                raise
+            self._reject_pending_before_authority(pending, error)
+            return
         before = dict(pending.get("beforeRevision") or {})
         if revision.get("root") == before.get("root"):
             authority_result = self.authority.apply(dict(pending["command"]))
@@ -609,6 +617,7 @@ class EmbeddedLocalAssignmentRuntime(AssignmentRuntimeRecoveryMixin):
                 details={"field": forbidden},
             )
         _validate_command_arguments(command)
+        _validate_assignment_create_references(command, snapshot)
         attempt = command.get("attempt")
         lease = command.get("lease")
         warrant = command.get("warrant")

--- a/framework/core/src/python/kungfu/assignment_runtime/local.py
+++ b/framework/core/src/python/kungfu/assignment_runtime/local.py
@@ -323,6 +323,15 @@ class EmbeddedLocalAssignmentRuntime(AssignmentRuntimeRecoveryMixin):
             self._finalize_pending(dict(pending), snapshot, revision, recovered=True)
             return
         snapshot, revision = self._observe_snapshot(record_event=False)
+        self._resume_unapplied_pending(pending, command, snapshot, revision)
+
+    def _resume_unapplied_pending(
+        self,
+        pending: Mapping[str, Any],
+        command: Mapping[str, Any],
+        snapshot: Mapping[str, Any],
+        revision: Mapping[str, Any],
+    ) -> None:
         try:
             _validate_assignment_create_references(command, snapshot)
         except LocalRuntimeError as error:

--- a/framework/core/tests/python/test_assignment_runtime.py
+++ b/framework/core/tests/python/test_assignment_runtime.py
@@ -261,6 +261,41 @@ class FakeAuthority:
         self._write(state)
 
 
+class AssignmentCreateAuthority(FakeAuthority):
+    """Fake authority that exposes a configurable local Assignment snapshot."""
+
+    def __init__(self, root: Path, assignment_ids: list[str] | None = None):
+        super().__init__(root)
+        self.assignment_ids = list(assignment_ids or ["assignment-a"])
+        self.applied_commands: list[dict[str, Any]] = []
+
+    def inspect(self) -> dict[str, Any]:
+        snapshot = super().inspect()
+        template = snapshot["assignments"][0]
+        snapshot["assignments"] = [
+            {
+                **copy.deepcopy(template),
+                "assignmentId": assignment_id,
+                "subject": f"kungfu:{assignment_id}",
+            }
+            for assignment_id in self.assignment_ids
+        ]
+        return snapshot
+
+    def apply(self, command: dict[str, Any]) -> dict[str, Any]:
+        if command["type"] != "assignment.create":
+            return super().apply(command)
+        self.applied_commands.append(copy.deepcopy(command))
+        state = self._read()
+        state["version"] += 1
+        state["effects"].append(_root(command))
+        self._write(state)
+        return {
+            "authorityReceipt": {"result": {"coreReceipt": {"status": "admitted"}}},
+            "episodeRefs": [],
+        }
+
+
 def _request(
     operation: str,
     capability: str,
@@ -331,6 +366,45 @@ def _command(
             }
         ),
     }
+
+
+def _assignment_create_command(
+    revision: dict[str, Any],
+    *,
+    assignment_id: str = "assignment-child",
+    parent_assignment_id: str = "",
+    parent_assignment_ref: dict[str, Any] | None = None,
+    depends_on: list[str] | None = None,
+    dependency_refs: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    command = _command(
+        revision,
+        command_id=f"command.create.{assignment_id}",
+        idempotency_key=f"idem.create.{assignment_id}",
+        command_type="assignment.create",
+    )
+    command["target"] = {
+        "initiativeId": "initiative-a",
+        "assignmentId": assignment_id,
+    }
+    command["attempt"] = None
+    command["lease"] = None
+    command["warrant"] = None
+    command["arguments"] = {
+        "initiativeId": "initiative-a",
+        "assignmentId": assignment_id,
+        "title": "Child assignment",
+        "objective": "Exercise exact local parent validation",
+        "actor": "agent-a",
+        "actorType": "agent",
+        "source": "kungfu",
+        "status": "active",
+        "parentAssignmentId": parent_assignment_id,
+        "parentAssignmentRef": dict(parent_assignment_ref or {}),
+        "dependsOn": list(depends_on or []),
+        "dependencyRefs": copy.deepcopy(dependency_refs or []),
+    }
+    return command
 
 
 def _handle(runtime: EmbeddedLocalAssignmentRuntime, request: dict[str, Any]):
@@ -1292,6 +1366,189 @@ def test_invalid_assessment_executor_is_rejected_before_pending_write(tmp_path):
         assert rejected["error"]["code"] == "invalid-command"
         assert runtime._state["pending"] is None
         assert authority._read()["effects"] == []
+
+
+@pytest.mark.parametrize(
+    ("assignment_ids", "parent_assignment_id", "expected_matches"),
+    [
+        (["assignment-a"], "missing-parent", 0),
+        (["duplicate-parent", "duplicate-parent"], "duplicate-parent", 2),
+    ],
+)
+def test_assignment_create_rejects_unresolved_local_parent_before_pending_write(
+    tmp_path, assignment_ids, parent_assignment_id, expected_matches
+):
+    runtime_dir = tmp_path / "invalid-local-parent" / ".kungfu" / "runtime"
+    authority = AssignmentCreateAuthority(runtime_dir, assignment_ids)
+    with EmbeddedLocalAssignmentRuntime(
+        runtime_dir,
+        realm_id=REALM["realmId"],
+        generation=REALM["generation"],
+        authority=authority,
+        contract=ASSIGNMENT_RUNTIME_CONTRACT,
+        request_schema=ENVELOPE_SCHEMA,
+    ) as runtime:
+        snapshot = _handle(
+            runtime, _request("assignment.snapshot", "assignment.snapshot.read")
+        )
+        command = _assignment_create_command(
+            snapshot["revision"], parent_assignment_id=parent_assignment_id
+        )
+        rejected = _handle(
+            runtime,
+            _request(
+                "command.submit",
+                "assignment.command.submit",
+                payload=command,
+            ),
+        )
+
+        assert rejected["error"]["code"] == "invalid-command"
+        assert rejected["error"]["details"] == {
+            "field": "parentAssignmentId",
+            "matches": expected_matches,
+        }
+        assert runtime._state["pending"] is None
+        assert authority.applied_commands == []
+
+
+def test_assignment_create_accepts_local_parent_explicit_refs_and_dependencies(
+    tmp_path,
+):
+    work_ref = {
+        "workspace_identity_root": ROOT_A,
+        "object_kind": "assignment",
+        "subject": "kungfu:assignment-a",
+        "version_root": ROOT_B,
+        "cut_root": ROOT_A,
+    }
+    cases = [
+        {"assignment_id": "local-parent", "parent_assignment_id": "assignment-a"},
+        {
+            "assignment_id": "explicit-parent",
+            "parent_assignment_ref": work_ref,
+        },
+        {
+            "assignment_id": "dependency-shorthand",
+            "depends_on": ["not-yet-local"],
+        },
+        {
+            "assignment_id": "dependency-ref",
+            "dependency_refs": [work_ref],
+        },
+    ]
+    for case in cases:
+        runtime_dir = tmp_path / str(case["assignment_id"]) / ".kungfu" / "runtime"
+        authority = AssignmentCreateAuthority(runtime_dir)
+        with EmbeddedLocalAssignmentRuntime(
+            runtime_dir,
+            realm_id=REALM["realmId"],
+            generation=REALM["generation"],
+            authority=authority,
+            contract=ASSIGNMENT_RUNTIME_CONTRACT,
+            request_schema=ENVELOPE_SCHEMA,
+        ) as runtime:
+            snapshot = _handle(
+                runtime, _request("assignment.snapshot", "assignment.snapshot.read")
+            )
+            command = _assignment_create_command(snapshot["revision"], **case)
+            accepted = _handle(
+                runtime,
+                _request(
+                    "command.submit",
+                    "assignment.command.submit",
+                    payload=command,
+                ),
+            )
+
+            assert accepted["status"] == "ok"
+            assert runtime._state["pending"] is None
+            assert authority.applied_commands == [command]
+
+
+@pytest.mark.parametrize(
+    ("assignment_id", "request_id"),
+    [
+        (
+            "producer-budget-activation-linear-r7",
+            "legacy.r7.assignment.create",
+        ),
+        (
+            "producer-budget-activation-linear-r8",
+            "legacy.r8.assignment.create",
+        ),
+    ],
+)
+def test_restart_rejects_legacy_assignment_create_with_unresolved_parent(
+    tmp_path, assignment_id, request_id
+):
+    runtime_dir = tmp_path / assignment_id / ".kungfu" / "runtime"
+    authority = AssignmentCreateAuthority(runtime_dir)
+    runtime = EmbeddedLocalAssignmentRuntime(
+        runtime_dir,
+        realm_id=REALM["realmId"],
+        generation=REALM["generation"],
+        authority=authority,
+        contract=ASSIGNMENT_RUNTIME_CONTRACT,
+        request_schema=ENVELOPE_SCHEMA,
+    ).start()
+    snapshot = _handle(
+        runtime, _request("assignment.snapshot", "assignment.snapshot.read")
+    )
+    command = _assignment_create_command(
+        snapshot["revision"],
+        assignment_id=assignment_id,
+        parent_assignment_id="predecessor-not-in-current-snapshot",
+        depends_on=["historical-dependency"],
+    )
+    command_root = _root(command)
+    pending = {
+        "commandRoot": command_root,
+        "command": command,
+        "beforeRevision": snapshot["revision"],
+        "requestId": request_id,
+    }
+    runtime._state["pending"] = copy.deepcopy(pending)
+    runtime._save_state()
+    runtime.close()
+
+    persisted_before = json.loads(
+        (runtime_dir / "assignment-runtime" / "local-v1" / "state.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert persisted_before["pending"] == pending
+
+    recovered = EmbeddedLocalAssignmentRuntime(
+        runtime_dir,
+        realm_id=REALM["realmId"],
+        generation=REALM["generation"],
+        authority=authority,
+        contract=ASSIGNMENT_RUNTIME_CONTRACT,
+        request_schema=ENVELOPE_SCHEMA,
+    ).start()
+    try:
+        assert recovered._state["pending"] is None
+        assert authority.applied_commands == []
+        event = recovered._state["events"][-1]
+        assert event["kind"] == "command-rejected"
+        assert event["revision"] == pending["beforeRevision"]
+        assert event["payload"] == {
+            "commandId": command["commandId"],
+            "commandRoot": command_root,
+            "errorCode": "invalid-command",
+        }
+        diagnostic = recovered._state["diagnostics"][-1]
+        assert diagnostic["code"] == "interrupted-command-rejected"
+        assert diagnostic["details"] == {
+            "commandId": command["commandId"],
+            "commandRoot": command_root,
+            "errorCode": "invalid-command",
+            "field": "parentAssignmentId",
+            "matches": 0,
+        }
+    finally:
+        recovered.close()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- resolve local `parentAssignmentId` shorthand exactly once against the current Assignment snapshot before a new durable pending write
- apply the same pre-authority check to unapplied startup replay so retained R7/R8-shaped invalid commands use the existing deterministic rejection path
- preserve stored command id/root and before-revision evidence while emitting `command-rejected` plus `interrupted-command-rejected`, clearing pending, and never calling the adapter
- retain explicit parent WorkRefs, `dependsOn`, explicit dependency refs, and already-applied `authorityResult` recovery behavior

This compatibility repair makes an unresolved cross-workspace parent shorthand recoverable through the public startup surface. It does not edit or bypass native Assignment state.

## Verification

- `./shifu test:assignment-runtime` — Node 40/40; Python 43 passed and 1 platform skip; selected runtime tests 2/2
- function-risk — 12,000 functions, 146 advisory findings, 0 blocking; changed-code ratchet passed with 3 paths, 6 fast extractions, and 2,640 full-path extractions
- Python structure — `sha256:9c25eee9d05c6a31e0192fda819eb36ea52148fc48324dc12d00e08869df6ad5`, 0 blocking
- semantic amplification — 7 families, 103 surfaces, 0 issues
- full `./shifu check:source` — RC0; contract 1,181 total / 1,170 passed / 11 skipped / 0 failed, runtime upgrade 135, desktop 73, Ruff and mypy 257 sources green, zero-write roots unchanged
- independent exact review — 0 blocking findings
- official queue replay against protected `a15be50eb84ccdfd146f82538681a7f06ba4d61a` — qualified; candidate `60d55ac42352226fd14bf4b32dd399fdd5e4c2ea`, tree `56a446ea9c1cdef72395e8c1bdf11f5720cf9a45`, replayed 2, `compositionChanged=false`, diagnostics empty
- fresh Atlas/Kungfu work admission — verified at head `96cec3f9e617d675725a102bbad694702a476dcd`, binding `sha256:2ef45fee319c10a153065bc3d53753124351d0c9ae4058c74af9422d5c075cf2`

## Compatibility and scope

- only Assignment Runtime Python authority/local code and targeted Python tests change
- no watcher, GUI/TUI, C++ runtime, Node binding, dependency, package manifest, or lockfile change
- no public import, CLI parameter, persistence format, runtime protocol, schema, adapter key, or cross-language contract change
- latest protected drift only changes maintainability analyzer files and has no task-path overlap

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This private pre-authority parent-shorthand validation repair preserves public APIs, CLI behavior, persistence formats, runtime protocols, Work Control semantics, and cross-language contracts."
}
-->
