### PR TITLE
fix(release): admit sealed alpha3 candidate contract

### DIFF
--- a/docs/qualification/evidence/kungfu-fact-only-temporal-admission-cutover.json
+++ b/docs/qualification/evidence/kungfu-fact-only-temporal-admission-cutover.json
@@ -8,12 +8,12 @@
   "sourceAdmissionFactSetRoot": "sha256:504da3e9c9d220470791b0730b165c0c4db74b49ec9f0092a4e8cf7adafed130",
   "sourceAdmissionReceiptRoot": "sha256:3087ee3a4e476773bec759d58ac533a9452cb652006ebccdf11957f602b18d51",
   "sourceAdmissionPathReceiptRoot": "sha256:b82b7f44fe4493cbd1d2dbf000e86536858d405b134188da7eb33ebc567c8a0a",
-  "admissionFactSetRoot": "sha256:e23a07bee54985f1d0b8f7cba7908313dea86b6b18997099adcb0fa9e84b5871",
-  "admissionProofRoot": "sha256:12eed392ce3899eca7b995eaa3ef48a226040668b2da54212117f82372e22007",
+  "admissionFactSetRoot": "sha256:f7948f0f85b4cefa1ce72e9162397b852248a6d0f0ae05ac0ffd75e502a9580f",
+  "admissionProofRoot": "sha256:a77b0558711a7d66256c425a8b65797d0a34efbb6d1e2f8a7d9f9d9e0ee7a1ad",
   "factProjectionRoot": "sha256:b275910c8047541ff2e0292a4ba7611ca8cd7905934eb7e05d3aa44db1e0bba6",
   "factRegistryRoot": "sha256:232fd556a2372b29db586bbc2acbdfce6464a68c93902797ff527f75f7816c42",
   "factCutRoot": "sha256:f61b975d4a96c921cc4bd37fb3ed9a0596b47004fe34dc7219979d697e3707f9",
-  "contractFactSelectionReceiptRoot": "sha256:3ac3f51601c3ffae83085fc5db7a50b0571492116b523d728e17907731e3d113",
+  "contractFactSelectionReceiptRoot": "sha256:8727d797c0a578e34df876d88ee6510bfc4d4fa27795e12885df4dc2b800ad2c",
   "buildchainFactRoots": [
     "sha256:50e5b6e644493ac00d5b1d83a0ec6009f9faaae1bee15e88ee8386c9ec8a775d",
     "sha256:5664da2363bed0b45497215b60763c3be627e568eb3182af5891c23ae3875fbe",
@@ -25,8 +25,8 @@
     "sha256:a91ecf9e0168cb7ad185c7409b887c89580a4a362a071b466aa515ed8f201f85"
   ],
   "digestProjectionAuthority": "non-authoritative",
-  "rollbackSealRoot": "sha256:e8de0b7a102241aa47c9273b84b65b02dd889f92fdd7b8b1295e1454f7416112",
+  "rollbackSealRoot": "sha256:26448df8adbdf43977de448ac8c46dc8fa30eda91c114b02fd3d48a33ab68707",
   "rollbackNormalAdmissionEligible": false,
   "externalPublicationClaimed": false,
-  "qualificationRoot": "sha256:44ff0f87fe032b1e2680e547f17308b73733a39fa6813842cc5e8c4ba2a41cfc"
+  "qualificationRoot": "sha256:150a676eecf1aa4d3c85fc166e9970c6530242cfcea8388170c5626400377c25"
 }

--- a/docs/qualification/evidence/kungfu-temporal-release-admission-facts.json
+++ b/docs/qualification/evidence/kungfu-temporal-release-admission-facts.json
@@ -3,17 +3,18 @@
   "source": {
     "repository": "kungfu-systems/kungfu",
     "protectedBase": "dev/v4/v4.0",
-    "sourceCommit": "1e57f6a7637225082fe3f6eeef5b98b55c2a5f38",
-    "mergeCommit": "1e57f6a7637225082fe3f6eeef5b98b55c2a5f38"
+    "sourceCommit": "493687242d7c67e1e849a738a8c5eb6f6d6a3e5b",
+    "mergeCommit": "493687242d7c67e1e849a738a8c5eb6f6d6a3e5b"
   },
   "activeProofRoots": [
-    "sha256:12eed392ce3899eca7b995eaa3ef48a226040668b2da54212117f82372e22007",
-    "sha256:27073cb22644c89d8996ad578bca65d195d9b9969b9a32ca4e10f992220b7b21",
-    "sha256:b6a1a19c1d819171a90a7111ce69c371c72a94205db8b1bcfb925aac0c48c3af"
+    "sha256:03fbcd27a64fed137d8c2d18258bc2c5024a8f41bb6e774e984e57803bf9f91f",
+    "sha256:10a0979ddb8f4290364a233e03b4c981fddeae4ac53e5d049b466a5821163dfb",
+    "sha256:a77b0558711a7d66256c425a8b65797d0a34efbb6d1e2f8a7d9f9d9e0ee7a1ad",
+    "sha256:dfdad146972a56f41ff0adf4bb81e349a2e2ff13ac023854c12a199ca5e7796a"
   ],
   "proofs": [
     {
-      "proofRoot": "sha256:12eed392ce3899eca7b995eaa3ef48a226040668b2da54212117f82372e22007",
+      "proofRoot": "sha256:a77b0558711a7d66256c425a8b65797d0a34efbb6d1e2f8a7d9f9d9e0ee7a1ad",
       "record": {
         "schema": "kungfu.temporal-release-admission-proof/v1",
         "proofId": "alpha-sealed-candidate-historical-contract",
@@ -59,9 +60,9 @@
           "kind": "protected-git-cut",
           "repository": "kungfu-systems/kungfu",
           "protectedBase": "dev/v4/v4.0",
-          "commit": "1e57f6a7637225082fe3f6eeef5b98b55c2a5f38"
+          "commit": "493687242d7c67e1e849a738a8c5eb6f6d6a3e5b"
         },
-        "cutRoot": "sha256:cd8426c6843fd9870b2345ed78e2d1ae569218a5ba2d40738f407f04c993e41f",
+        "cutRoot": "sha256:2da5309cdc75575faadf9f418fdf1bc3a4477dd9dba4a9400059e01c46289931",
         "buildchainFactRoots": [
           "sha256:50e5b6e644493ac00d5b1d83a0ec6009f9faaae1bee15e88ee8386c9ec8a775d",
           "sha256:5664da2363bed0b45497215b60763c3be627e568eb3182af5891c23ae3875fbe",
@@ -70,7 +71,7 @@
       }
     },
     {
-      "proofRoot": "sha256:b6a1a19c1d819171a90a7111ce69c371c72a94205db8b1bcfb925aac0c48c3af",
+      "proofRoot": "sha256:dfdad146972a56f41ff0adf4bb81e349a2e2ff13ac023854c12a199ca5e7796a",
       "record": {
         "schema": "kungfu.temporal-release-admission-proof/v1",
         "proofId": "release-current-contract",
@@ -105,14 +106,73 @@
           "kind": "protected-git-cut",
           "repository": "kungfu-systems/kungfu",
           "protectedBase": "dev/v4/v4.0",
-          "commit": "1e57f6a7637225082fe3f6eeef5b98b55c2a5f38"
+          "commit": "493687242d7c67e1e849a738a8c5eb6f6d6a3e5b"
         },
-        "cutRoot": "sha256:cd8426c6843fd9870b2345ed78e2d1ae569218a5ba2d40738f407f04c993e41f",
+        "cutRoot": "sha256:2da5309cdc75575faadf9f418fdf1bc3a4477dd9dba4a9400059e01c46289931",
         "buildchainFactRoots": []
       }
     },
     {
-      "proofRoot": "sha256:27073cb22644c89d8996ad578bca65d195d9b9969b9a32ca4e10f992220b7b21",
+      "proofRoot": "sha256:10a0979ddb8f4290364a233e03b4c981fddeae4ac53e5d049b466a5821163dfb",
+      "record": {
+        "schema": "kungfu.temporal-release-admission-proof/v1",
+        "proofId": "alpha3-sealed-candidate-contract",
+        "status": "active",
+        "channel": "alpha",
+        "acceptedContractDigest": "sha256:cb12a8b2ac4a4752e1a5075d6e8a5b8ea48fb4ea7261f24a858363f9eecd1a25",
+        "currentContractDigest": "sha256:29f1218350d3cf49423ffc1b78e3328c3af554c21e8c3ffd31928ea9db51a404",
+        "pathKind": "composed",
+        "reason": "The sealed 4.0.0-alpha.3 candidate retains its candidate contract only because all three required publication surfaces equal the current Alpha targets through exact protected Buildchain compatibility Facts.",
+        "scope": {
+          "repository": "kungfu-systems/kungfu",
+          "channel": "alpha",
+          "operation": "release-admission",
+          "maximumPathDepth": 2
+        },
+        "scopeRoot": "sha256:07f1b06e782911d0f56a55c25fde16da8ada91b8fbd7a0fa99c97910e44e046c",
+        "evidence": {
+          "kind": "sealed-alpha-candidate-contract-recovery",
+          "version": "4.0.0-alpha.3",
+          "buildRunId": "32672193888",
+          "candidateSourceSha": "6d99af738b78eccb48885a5fd59b88a0e5e4900a",
+          "candidateTree": "b64e46b85655a28b1395aa8ebe5c4bf961d4c0cf",
+          "channelMergeSha": "067f36ce4ed2e54e7f1ee4490598d86f20bd90df",
+          "candidateRoot": "sha256:23887c05854b6e86eaa624321af7b1aa636bc83744462fc03d51e8cedcc452a6",
+          "buildSummaryRoot": "sha256:e0d70a0014ae96eb60c3d3702b7f7c15c458402a948295b9ce4d28ed9583c079",
+          "candidateRuntimeSha": "675b4f2a51af7e5f2aac58011c7ede0313b2b105",
+          "candidateContractDigest": "sha256:cb12a8b2ac4a4752e1a5075d6e8a5b8ea48fb4ea7261f24a858363f9eecd1a25",
+          "publicationRuntimeSha": "a5f43da50ea4ad5138ccf901135b89a711a1780c",
+          "currentContractDigest": "sha256:29f1218350d3cf49423ffc1b78e3328c3af554c21e8c3ffd31928ea9db51a404",
+          "requiredReleaseSurfaceDigests": {
+            "advanced-release-candidate-promote": "sha256:9db8dd07152855d03ff30f9c571438593c689d3e8139fa45431d000f548242f5",
+            "promote-buildchain-ref-action": "sha256:6147c0a8d5c36bfaa6021871574e1fc28192a3f1b8cfdae4d24ef3059ac1ebda",
+            "release-candidate-promote": "sha256:e60642aa298933d2c103284794921a6c340a50aa91ee528b06e58892a2a006bf"
+          },
+          "failClosedRunIds": ["32678949411", "32679370926", "32680010011"]
+        },
+        "evidenceRoot": "sha256:16d3e04262e205b82c22ffa08f44e65c1886aec77ce28acd54cb18ad806fbb94",
+        "authority": {
+          "kind": "protected-release-admission-authority",
+          "repository": "kungfu-systems/kungfu",
+          "protectedBase": "dev/v4/v4.0"
+        },
+        "authorityRoot": "sha256:ebdcc6088c05e0924fa3bfd5da047a6630ccdb9c13d842a4999416fa0321a69d",
+        "cut": {
+          "kind": "protected-git-cut",
+          "repository": "kungfu-systems/kungfu",
+          "protectedBase": "dev/v4/v4.0",
+          "commit": "493687242d7c67e1e849a738a8c5eb6f6d6a3e5b"
+        },
+        "cutRoot": "sha256:2da5309cdc75575faadf9f418fdf1bc3a4477dd9dba4a9400059e01c46289931",
+        "buildchainFactRoots": [
+          "sha256:50e5b6e644493ac00d5b1d83a0ec6009f9faaae1bee15e88ee8386c9ec8a775d",
+          "sha256:5664da2363bed0b45497215b60763c3be627e568eb3182af5891c23ae3875fbe",
+          "sha256:ec1c70ff70cca52ac276fab344b1c2d00c9581a8efec6d6fa37d56cb11632af1"
+        ]
+      }
+    },
+    {
+      "proofRoot": "sha256:03fbcd27a64fed137d8c2d18258bc2c5024a8f41bb6e774e984e57803bf9f91f",
       "record": {
         "schema": "kungfu.temporal-release-admission-proof/v1",
         "proofId": "alpha-current-contract",
@@ -147,12 +207,12 @@
           "kind": "protected-git-cut",
           "repository": "kungfu-systems/kungfu",
           "protectedBase": "dev/v4/v4.0",
-          "commit": "1e57f6a7637225082fe3f6eeef5b98b55c2a5f38"
+          "commit": "493687242d7c67e1e849a738a8c5eb6f6d6a3e5b"
         },
-        "cutRoot": "sha256:cd8426c6843fd9870b2345ed78e2d1ae569218a5ba2d40738f407f04c993e41f",
+        "cutRoot": "sha256:2da5309cdc75575faadf9f418fdf1bc3a4477dd9dba4a9400059e01c46289931",
         "buildchainFactRoots": []
       }
     }
   ],
-  "factSetRoot": "sha256:e23a07bee54985f1d0b8f7cba7908313dea86b6b18997099adcb0fa9e84b5871"
+  "factSetRoot": "sha256:f7948f0f85b4cefa1ce72e9162397b852248a6d0f0ae05ac0ffd75e502a9580f"
 }

--- a/docs/qualification/gates/release-admission-policy.json
+++ b/docs/qualification/gates/release-admission-policy.json
@@ -32,18 +32,22 @@
         "contractProjection": {
           "schema": "kungfu.temporal-release-admission-digest-projection/v1",
           "authority": "non-authoritative",
-          "sourceFactSetRoot": "sha256:e23a07bee54985f1d0b8f7cba7908313dea86b6b18997099adcb0fa9e84b5871",
+          "sourceFactSetRoot": "sha256:f7948f0f85b4cefa1ce72e9162397b852248a6d0f0ae05ac0ffd75e502a9580f",
           "entries": [
             {
               "contractDigest": "sha256:13c4679c4ac8764c85e29693bfb59099e21e9786cc6082552198d39393467490",
-              "sourceProofRoot": "sha256:12eed392ce3899eca7b995eaa3ef48a226040668b2da54212117f82372e22007"
+              "sourceProofRoot": "sha256:a77b0558711a7d66256c425a8b65797d0a34efbb6d1e2f8a7d9f9d9e0ee7a1ad"
             },
             {
               "contractDigest": "sha256:29f1218350d3cf49423ffc1b78e3328c3af554c21e8c3ffd31928ea9db51a404",
-              "sourceProofRoot": "sha256:27073cb22644c89d8996ad578bca65d195d9b9969b9a32ca4e10f992220b7b21"
+              "sourceProofRoot": "sha256:03fbcd27a64fed137d8c2d18258bc2c5024a8f41bb6e774e984e57803bf9f91f"
+            },
+            {
+              "contractDigest": "sha256:cb12a8b2ac4a4752e1a5075d6e8a5b8ea48fb4ea7261f24a858363f9eecd1a25",
+              "sourceProofRoot": "sha256:10a0979ddb8f4290364a233e03b4c981fddeae4ac53e5d049b466a5821163dfb"
             }
           ],
-          "projectionRoot": "sha256:598448c40cc084fe789e3a0cadd3fd9fc5f75a39a6208334c04530b384aa01ce"
+          "projectionRoot": "sha256:0d1caec6b3a9f943106b06ff54f6b616a4eeb640c0de5529e4a9a43de85f3cf9"
         },
         "contractLock": ".buildchain/alpha-contract-lock.json"
       },
@@ -59,14 +63,14 @@
         "contractProjection": {
           "schema": "kungfu.temporal-release-admission-digest-projection/v1",
           "authority": "non-authoritative",
-          "sourceFactSetRoot": "sha256:e23a07bee54985f1d0b8f7cba7908313dea86b6b18997099adcb0fa9e84b5871",
+          "sourceFactSetRoot": "sha256:f7948f0f85b4cefa1ce72e9162397b852248a6d0f0ae05ac0ffd75e502a9580f",
           "entries": [
             {
               "contractDigest": "sha256:8e9a161653c40611ffd76aa878ae348fc215506c1caa88347111fb122cfe7c12",
-              "sourceProofRoot": "sha256:b6a1a19c1d819171a90a7111ce69c371c72a94205db8b1bcfb925aac0c48c3af"
+              "sourceProofRoot": "sha256:dfdad146972a56f41ff0adf4bb81e349a2e2ff13ac023854c12a199ca5e7796a"
             }
           ],
-          "projectionRoot": "sha256:bf39df6594090878919e76ebff120f8a9a36af424f72e86dfa2a2f7ea93e1e03"
+          "projectionRoot": "sha256:e3685e4cfb3e4b7f95395ef7d438b7f9d5b82712c951aa6abf22bde669a6e597"
         },
         "contractLock": ".buildchain/contract-lock.json"
       }

--- a/framework/core/tests/python/test_temporal_release_admission.py
+++ b/framework/core/tests/python/test_temporal_release_admission.py
@@ -32,6 +32,9 @@ ROLLBACK_CONTRACT = (
 
 CURRENT = "sha256:29f1218350d3cf49423ffc1b78e3328c3af554c21e8c3ffd31928ea9db51a404"
 HISTORICAL = "sha256:13c4679c4ac8764c85e29693bfb59099e21e9786cc6082552198d39393467490"
+ALPHA3_CANDIDATE = (
+    "sha256:cb12a8b2ac4a4752e1a5075d6e8a5b8ea48fb4ea7261f24a858363f9eecd1a25"
+)
 
 
 def _json(path):
@@ -328,6 +331,20 @@ def test_contract_selection_uses_active_admission_fact_and_buildchain_fact_paths
     assert len(report["receipt"]["buildchainFactRoots"]) == 3
     assert len(report["receipt"]["compatibilityPathReceiptRoots"]) == 3
 
+    alpha3_report = verify_contract_selection(
+        contract=_json(CONTRACT),
+        admission_facts=_json(ADMISSION_FACTS),
+        compatibility_facts=_json(COMPATIBILITY_FACTS),
+        current_contract_lock=_json(ALPHA_LOCK),
+        channel="alpha",
+        accepted_contract_digest=ALPHA3_CANDIDATE,
+        current_contract_digest=CURRENT,
+    )
+    assert alpha3_report["ok"], alpha3_report["receipt"]["reasonCodes"]
+    assert alpha3_report["receipt"]["pathKind"] == "composed"
+    assert len(alpha3_report["receipt"]["buildchainFactRoots"]) == 3
+    assert len(alpha3_report["receipt"]["compatibilityPathReceiptRoots"]) == 3
+
     drift = _case(HISTORICAL)
     historical = next(
         row
@@ -413,5 +430,5 @@ def test_fact_contract_is_mirrored_and_bound_to_protected_buildchain_evidence():
     assert contract["factAuthority"]["buildchainFacts"] == str(
         COMPATIBILITY_FACTS.relative_to(ROOT)
     )
-    assert len(facts["activeProofRoots"]) == len(facts["proofs"]) == 3
+    assert len(facts["activeProofRoots"]) == len(facts["proofs"]) == 4
     assert len(projection["selectedFactRoots"]) == 3

--- a/framework/release/kungfu-temporal-release-rollback.contract.json
+++ b/framework/release/kungfu-temporal-release-rollback.contract.json
@@ -2,7 +2,7 @@
   "schema": "kungfu.temporal-release-admission-rollback/v1",
   "status": "sealed",
   "normalAdmissionEligible": false,
-  "sourceFactSetRoot": "sha256:e23a07bee54985f1d0b8f7cba7908313dea86b6b18997099adcb0fa9e84b5871",
+  "sourceFactSetRoot": "sha256:f7948f0f85b4cefa1ce72e9162397b852248a6d0f0ae05ac0ffd75e502a9580f",
   "invocation": {
     "command": "./shifu rollback:temporal-release-admission --request <request.json>",
     "mode": "offline-explicit",
@@ -21,31 +21,35 @@
     "alpha": {
       "schema": "kungfu.temporal-release-admission-digest-projection/v1",
       "authority": "non-authoritative",
-      "sourceFactSetRoot": "sha256:e23a07bee54985f1d0b8f7cba7908313dea86b6b18997099adcb0fa9e84b5871",
+      "sourceFactSetRoot": "sha256:f7948f0f85b4cefa1ce72e9162397b852248a6d0f0ae05ac0ffd75e502a9580f",
       "entries": [
         {
           "contractDigest": "sha256:13c4679c4ac8764c85e29693bfb59099e21e9786cc6082552198d39393467490",
-          "sourceProofRoot": "sha256:12eed392ce3899eca7b995eaa3ef48a226040668b2da54212117f82372e22007"
+          "sourceProofRoot": "sha256:a77b0558711a7d66256c425a8b65797d0a34efbb6d1e2f8a7d9f9d9e0ee7a1ad"
         },
         {
           "contractDigest": "sha256:29f1218350d3cf49423ffc1b78e3328c3af554c21e8c3ffd31928ea9db51a404",
-          "sourceProofRoot": "sha256:27073cb22644c89d8996ad578bca65d195d9b9969b9a32ca4e10f992220b7b21"
+          "sourceProofRoot": "sha256:03fbcd27a64fed137d8c2d18258bc2c5024a8f41bb6e774e984e57803bf9f91f"
+        },
+        {
+          "contractDigest": "sha256:cb12a8b2ac4a4752e1a5075d6e8a5b8ea48fb4ea7261f24a858363f9eecd1a25",
+          "sourceProofRoot": "sha256:10a0979ddb8f4290364a233e03b4c981fddeae4ac53e5d049b466a5821163dfb"
         }
       ],
-      "projectionRoot": "sha256:598448c40cc084fe789e3a0cadd3fd9fc5f75a39a6208334c04530b384aa01ce"
+      "projectionRoot": "sha256:0d1caec6b3a9f943106b06ff54f6b616a4eeb640c0de5529e4a9a43de85f3cf9"
     },
     "release": {
       "schema": "kungfu.temporal-release-admission-digest-projection/v1",
       "authority": "non-authoritative",
-      "sourceFactSetRoot": "sha256:e23a07bee54985f1d0b8f7cba7908313dea86b6b18997099adcb0fa9e84b5871",
+      "sourceFactSetRoot": "sha256:f7948f0f85b4cefa1ce72e9162397b852248a6d0f0ae05ac0ffd75e502a9580f",
       "entries": [
         {
           "contractDigest": "sha256:8e9a161653c40611ffd76aa878ae348fc215506c1caa88347111fb122cfe7c12",
-          "sourceProofRoot": "sha256:b6a1a19c1d819171a90a7111ce69c371c72a94205db8b1bcfb925aac0c48c3af"
+          "sourceProofRoot": "sha256:dfdad146972a56f41ff0adf4bb81e349a2e2ff13ac023854c12a199ca5e7796a"
         }
       ],
-      "projectionRoot": "sha256:bf39df6594090878919e76ebff120f8a9a36af424f72e86dfa2a2f7ea93e1e03"
+      "projectionRoot": "sha256:e3685e4cfb3e4b7f95395ef7d438b7f9d5b82712c951aa6abf22bde669a6e597"
     }
   },
-  "sealRoot": "sha256:e8de0b7a102241aa47c9273b84b65b02dd889f92fdd7b8b1295e1454f7416112"
+  "sealRoot": "sha256:26448df8adbdf43977de448ac8c46dc8fa30eda91c114b02fd3d48a33ab68707"
 }


### PR DESCRIPTION
## Summary

Admit the exact sealed `4.0.0-alpha.3` candidate contract to the current Alpha publication runtime through the existing Fact-only temporal admission path. The candidate and current runtimes expose identical breaking digests for all three required publication surfaces.

## Changes

- add one Alpha-only composed admission proof for candidate contract `cb12a8b2...`
- bind the proof to Build run `32672193888`, the sealed candidate tree, both runtime revisions, and the three exact compatibility Fact roots
- refresh the non-authoritative digest projections, rollback seal, and Fact-only cutover roots
- cover the Alpha.3 contract selection in the Python verifier suite

## Safety boundary

This change does not rebuild or mutate the candidate and grants no publication authority by itself. Contract selection remains fail-closed unless all three required publication surfaces resolve through the exact protected Buildchain Facts.

## Verification

- `./shifu check:temporal-release-admission`
- `./shifu test:release-admission`
- `./shifu check:source` (zero-write source gate; 1183 Node tests with 1172 passed and 11 environment skips, plus all subsequent suites passed)

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Admit one exact sealed Alpha candidate through existing Fact-only temporal release authority; no architecture contract or product behavior changes."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Boundary: the proof is Alpha-only, exact-candidate-bound, and requires the current three-surface compatibility path.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable; admission evidence only)
