### PR TITLE
fix(release): align KFD-2 passport claims

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -377,8 +377,9 @@ jobs:
         .buildchain/kfd/kfd-1/documentation-pack.witness.json
       release-passport-kfd-2-claim-jsons: |
         .buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
-        .buildchain/kfd/kfd-2/claims/codex-report-receipts.json
         .buildchain/kfd/kfd-2/claims/remote-fact-boundary.json
+        .buildchain/kfd/kfd-2/claims/agent-work-state-contract.json
+        .buildchain/kfd/kfd-2/claims/cross-language-authority-membrane.json
       release-passport-kfd-3-prebuild-witness-jsons: |
         .buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
       release-passport-kfd-3-artifact-verify-command: node scripts/buildchain-kfd-evidence.mjs --artifact-witness --json
@@ -481,8 +482,9 @@ jobs:
         .buildchain/kfd/kfd-1/documentation-pack.witness.json
       release-passport-kfd-2-claim-jsons: |
         .buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
-        .buildchain/kfd/kfd-2/claims/codex-report-receipts.json
         .buildchain/kfd/kfd-2/claims/remote-fact-boundary.json
+        .buildchain/kfd/kfd-2/claims/agent-work-state-contract.json
+        .buildchain/kfd/kfd-2/claims/cross-language-authority-membrane.json
       release-passport-kfd-3-prebuild-witness-jsons: |
         .buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
       release-passport-kfd-3-artifact-verify-command: node "$GITHUB_WORKSPACE/.buildchain/publication-controller/scripts/buildchain-kfd-evidence.mjs" --write --json >/dev/null && node "$GITHUB_WORKSPACE/.buildchain/publication-controller/scripts/buildchain-kfd-evidence.mjs" --artifact-witness --json

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -1046,7 +1046,7 @@
           "authority": "release-control",
           "publication": "channel",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:375567b8b95d453168c684d792ec47fe0b0c0a0b7f6530657001327fea16758d",
+          "definitionDigest": "sha256:f068f296b10aac47494ef182faf5be45903cfde5ee8fa7ccac8edff30a55e8b7",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["BUILDCHAIN_ISSUE_APP_ID","BUILDCHAIN_ISSUE_APP_PRIVATE_KEY","KUNGFU_ALPHA_CHANNEL_SIGNING_PRIVATE_KEY","KUNGFU_GITHUB_TOKEN","KUNGFU_GOVERNANCE_AUDITOR_APP_PRIVATE_KEY"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@v3-alpha"],
           "steps": []
@@ -1066,7 +1066,7 @@
           "authority": "release-control",
           "publication": "channel",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:e3d57005c0faaf167fc60f29e778dbe36ebc08e7f7f732509fd3827b654a8ac6",
+          "definitionDigest": "sha256:d57038e49488c53971909d8cf3d8bcfb16a3c91cd23979aee222dd3daa6f2b29",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["BUILDCHAIN_ISSUE_APP_ID","BUILDCHAIN_ISSUE_APP_PRIVATE_KEY","KUNGFU_ALPHA_CHANNEL_SIGNING_PRIVATE_KEY","KUNGFU_GITHUB_TOKEN","KUNGFU_GOVERNANCE_AUDITOR_APP_PRIVATE_KEY"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/release-candidate-promote.yml@v3-alpha"],
           "steps": []

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -343,7 +343,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:efaf8463f1dae8adb237b95ce5330f87f1d0155e8809fcd08e6546a6001ce249"
+          "sourceRoot": "sha256:7afbda2fab5f780448ebb2b6c9891c69e53d17d091538b5158720f813fadcb45"
         },
         {
           "path": ".github/workflows/release-shifu.yml",
@@ -877,5 +877,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:99b71d04eae3f56691d86cdbc5bb1559055c165b433fe42f6f064b5950df2437"
+  "registryRoot": "sha256:5f8f310a40bb66d700b399f051ded521c8f7f0fd66df78518613e11481e90ae4"
 }

--- a/scripts/verify-kfd2-source-binding.test.mjs
+++ b/scripts/verify-kfd2-source-binding.test.mjs
@@ -25,3 +25,32 @@ test('release verification binds KFD-2 claims to the canonical prebuild witness'
   assert.match(verify, /KFD-2 release claims check requires source\.sourceSha/);
   assert.equal(releaseClaims.release.sourceSha, witness.source.sourceSha);
 });
+
+test('release workflows publish the complete canonical KFD-2 claim set', () => {
+  const workflow = fs.readFileSync(
+    path.join(ROOT, '.github/workflows/release-new-version.yml'),
+    'utf8',
+  );
+  const releaseClaims = readJson('.buildchain/kfd/kfd-2/release-claims.json');
+  const expectedPaths = releaseClaims.claims
+    .map(({ id }) => `.buildchain/kfd/kfd-2/claims/${id}.json`)
+    .sort();
+  const claimBlocks = [
+    ...workflow.matchAll(
+      /release-passport-kfd-2-claim-jsons: \|\n((?:\s+\.buildchain\/kfd\/kfd-2\/claims\/[^\n]+\.json\n?)+)/g,
+    ),
+  ];
+
+  assert.equal(claimBlocks.length, 2);
+  for (const [, block] of claimBlocks) {
+    const actualPaths = block
+      .trim()
+      .split('\n')
+      .map((entry) => entry.trim())
+      .sort();
+    assert.deepEqual(actualPaths, expectedPaths);
+    for (const relativePath of actualPaths) {
+      assert.equal(fs.existsSync(path.join(ROOT, relativePath)), true);
+    }
+  }
+});


### PR DESCRIPTION
## Summary

Align both Alpha release-passport callers with the canonical four-claim KFD-2 inventory after the Work Control zero-residue cutover retired `codex-report-receipts.json`.

## Changes

- remove the retired `codex-report-receipts` path from normal promotion and sealed-candidate recovery
- include the live `agent-work-state-contract` and `cross-language-authority-membrane` claims
- make the source-binding test require both workflow blocks to equal the canonical `release-claims.json` set and require every referenced file to exist
- refresh workflow authority and release publication roots through their canonical writers

## Safety boundary

This changes only the reviewed publication controller. It does not rebuild, recut, retag, or alter the frozen Alpha.3 candidate. The existing partial durable publication transaction remains bound to `v4.0.0-alpha.3` at `067f36ce4ed2e54e7f1ee4490598d86f20bd90df`.

## Verification

- `node --test scripts/verify-kfd2-source-binding.test.mjs` — 2 passed
- `node scripts/check-kungfu-gate-catalog.mjs` — 38 workflows aligned
- `node framework/release/publication-control-plane.mjs check` — qualifying
- commit hook staged gates passed
- full `./shifu check:source` was stopped during unrelated concurrent Python dependency setup and is not claimed as complete; protected CI remains authoritative

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Reconcile the release passport caller with the already canonical KFD-2 claim inventory; no architecture or product behavior changes."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Boundary: the fix updates the caller claim set only; exact candidate, version, tag, runtime, and durable transaction identities remain unchanged.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not applicable; controller reconciliation only)