### PR TITLE
fix(runtime): reject deterministic interrupted commands

### DIFF
--- a/framework/core/src/python/kungfu/assignment_runtime/authority.py
+++ b/framework/core/src/python/kungfu/assignment_runtime/authority.py
@@ -267,8 +267,8 @@ def _interrupted_command_rejection(
     diagnostic = {
         "code": "interrupted-command-rejected",
         "message": (
-            "An interrupted command failed deterministic validation before "
-            "authority execution"
+            "An interrupted command failed deterministic validation without "
+            "an admitted authority mutation"
         ),
         "severity": "warning",
         "recovery": [],
@@ -323,6 +323,17 @@ class WorkControlAuthority:
             )
         except profile_sdk.ProfileSdkError as error:
             code = str(error.diagnosis.get("code") or "")
+            cause = error.__cause__
+            if (
+                write
+                and code == "member-adapter-invoke-failed"
+                and isinstance(cause, ValueError)
+            ):
+                raise LocalRuntimeError(
+                    "invalid-command",
+                    str(cause),
+                    details={"operation": operation},
+                ) from error
             if code in {
                 "member-resolution-failed",
                 "profile-member-ambiguous",

--- a/framework/core/src/python/kungfu/assignment_runtime/local.py
+++ b/framework/core/src/python/kungfu/assignment_runtime/local.py
@@ -341,7 +341,13 @@ class EmbeddedLocalAssignmentRuntime(AssignmentRuntimeRecoveryMixin):
             return
         before = dict(pending.get("beforeRevision") or {})
         if revision.get("root") == before.get("root"):
-            authority_result = self.authority.apply(dict(pending["command"]))
+            try:
+                authority_result = self.authority.apply(dict(pending["command"]))
+            except LocalRuntimeError as error:
+                if error.code != "invalid-command":
+                    raise
+                self._reject_pending_before_authority(pending, error)
+                return
             pending = {**dict(pending), "authorityResult": authority_result}
             self._state["pending"] = pending
             self._save_state()

--- a/framework/core/tests/python/test_assignment_runtime.py
+++ b/framework/core/tests/python/test_assignment_runtime.py
@@ -792,6 +792,39 @@ def test_work_control_authority_rejects_conflicting_completion_context_roots(
     assert invoked is False
 
 
+def test_work_control_authority_projects_adapter_value_errors_as_invalid_commands(
+    tmp_path, monkeypatch
+):
+    authority = WorkControlAuthority(tmp_path, source=PROFILE_SOURCE)
+
+    def invoke(*_args, **_kwargs):
+        cause = ValueError("independent review changed before continuation decision")
+        raise profile_sdk.ProfileSdkError(
+            "member-adapter-invoke-failed", str(cause)
+        ) from cause
+
+    monkeypatch.setattr(authority, "_profile_source", lambda: str(PROFILE_SOURCE))
+    monkeypatch.setattr(profile_sdk, "invoke_member_adapter", invoke)
+
+    with pytest.raises(
+        LocalRuntimeError,
+        match="independent review changed before continuation decision",
+    ) as raised:
+        authority.apply(
+            {
+                "type": "assignment.continuation.decide",
+                "target": {
+                    "initiativeId": "initiative-a",
+                    "assignmentId": "assignment-a",
+                },
+                "arguments": {},
+            }
+        )
+
+    assert raised.value.code == "invalid-command"
+    assert raised.value.details == {"operation": "decide-continuation"}
+
+
 def test_work_control_authority_snapshot_avoids_atlas_parity(tmp_path, monkeypatch):
     authority = WorkControlAuthority(tmp_path, source=PROFILE_SOURCE)
     operations = []
@@ -1695,6 +1728,67 @@ def test_restart_rejects_invalid_completion_pending_before_authority(tmp_path):
         assert diagnostic["code"] == "interrupted-command-rejected"
         assert diagnostic["details"]["field"] == "evidenceAvailability"
         assert diagnostic["details"]["index"] == 0
+    finally:
+        recovered.close()
+
+
+def test_restart_rejects_deterministic_authority_error_without_sticky_pending(
+    tmp_path, monkeypatch
+):
+    runtime_dir = tmp_path / "invalid-authority-pending" / ".kungfu" / "runtime"
+    authority = FakeAuthority(runtime_dir)
+    runtime = EmbeddedLocalAssignmentRuntime(
+        runtime_dir,
+        realm_id=REALM["realmId"],
+        generation=REALM["generation"],
+        authority=authority,
+        contract=ASSIGNMENT_RUNTIME_CONTRACT,
+        request_schema=ENVELOPE_SCHEMA,
+    ).start()
+    snapshot = _handle(
+        runtime, _request("assignment.snapshot", "assignment.snapshot.read")
+    )
+    command = _command(
+        snapshot["revision"],
+        command_type="assignment.continuation.decide",
+    )
+    pending = {
+        "commandRoot": _root(command),
+        "command": command,
+        "beforeRevision": snapshot["revision"],
+        "requestId": "invalid.authority.pending",
+    }
+    runtime._state["pending"] = copy.deepcopy(pending)
+    runtime._save_state()
+    runtime.close()
+
+    def reject(_command):
+        raise LocalRuntimeError(
+            "invalid-command",
+            "independent review changed before continuation decision",
+            details={"operation": "decide-continuation"},
+        )
+
+    monkeypatch.setattr(authority, "apply", reject)
+    recovered = EmbeddedLocalAssignmentRuntime(
+        runtime_dir,
+        realm_id=REALM["realmId"],
+        generation=REALM["generation"],
+        authority=authority,
+        contract=ASSIGNMENT_RUNTIME_CONTRACT,
+        request_schema=ENVELOPE_SCHEMA,
+    ).start()
+    try:
+        assert recovered._state["pending"] is None
+        assert recovered._state["events"][-1]["kind"] == "command-rejected"
+        diagnostic = recovered._state["diagnostics"][-1]
+        assert diagnostic["code"] == "interrupted-command-rejected"
+        assert diagnostic["details"] == {
+            "commandId": command["commandId"],
+            "commandRoot": _root(command),
+            "errorCode": "invalid-command",
+            "operation": "decide-continuation",
+        }
     finally:
         recovered.close()
 


### PR DESCRIPTION
<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"Fail-closed Assignment Runtime repair preserves existing CLI, receipt, and authority contracts."}
-->

## Summary
- classify deterministic interrupted or failed command attempts as terminal rejections instead of leaving sticky pending state
- preserve retryability for genuinely transient transport failures
- add focused authority and local runtime regression coverage

## Validation
- 40 focused TypeScript tests passed
- 45 focused Python tests passed with 1 expected skip
- 2 runtime qualification tests passed
- 1183 Shifu/source acceptance tests passed

## Scope
This is an ADR-neutral fail-closed runtime repair under Assignment `2026-08-24-kungfu-terminal-review-admission-convergence`. It preserves public CLI parameters, receipt formats, authority boundaries, and retry semantics.

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA4LTI0LWt1bmdmdS10ZXJtaW5hbC1yZXZpZXctYWRtaXNzaW9uLWNvbnZlcmdlbmNlIiwiZGVsaXZlcnlDbGFzcyI6Im5hdGl2ZS1wcm9vZi1yZXF1aXJlZCIsImRldkhlYWQiOiJiZjg1YzU2YTQwZjA1YzRjMDYyOTUxYTRjMzBjNTNjYTZkMjM4YWNkIiwicHVsbFJlcXVlc3RIZWFkIjoiZDE0Yjc0ZWRlNjkzOWQ1MDViOWY3MTdkYjdjMmQ0ZjFlMmQzZjFmZCIsInJlcGxheWVkQ2FuZGlkYXRlIjoiMWI4NWU5MzY0MTIzYjZjOTVhMWJhYmYzZjFiZTQ1YTAwMmM2NmUwMCIsInJlcGxheWVkVHJlZSI6IjlhNWNiMjhmM2JiZmQ2YzBkNWMwMzgwMTM3NzcyMzI2NTk0ODA4ODEiLCJxdWV1ZUF0dGVtcHQiOiJkMTRiNzRlZGU2OTM5ZDUwNWI5ZjcxN2RiN2MyZDRmMWUyZDNmMWZkQGJmODVjNTZhNDBmMDVjNGMwNjI5NTFhNGMzMGM1M2NhNmQyMzhhY2QiLCJhZG1pc3Npb25Qcm9vZlJvb3QiOiJzaGEyNTY6YWMyY2Q4YjdjYWFlYjhmZTY4ZmMwZTY2MGE2ZWVhMjJjNGJjODk3ZWY1MzViOGI2MGU0NWE4OTY5M2M2Y2I1NSIsImFkbWlzc2lvblByb29mUm9vdHMiOlsic2hhMjU2OmFjMmNkOGI3Y2FhZWI4ZmU2OGZjMGU2NjBhNmVlYTIyYzRiYzg5N2VmNTM1YjhiNjBlNDVhODk2OTNjNmNiNTUiLCJzaGEyNTY6ZjYyODMxMTAwNTNmNDgyM2FlYjA3ZmViZWZmNDY2Mjg5NTRhYmQ1MDhiZWQ2YWI1OGFiZDVkMTg4Nzg2OGFhNSJdLCJzdGF0dXNDb250ZXh0IjoiUXVldWUgZmFtaWx5IGxlYXNlL2Q5OWYzYTkxNjY3MzllMGQiLCJsZWFzZVJvb3QiOiJzaGEyNTY6M2UxZWRlNTRjZDhlYTE4YjY5YzE1NmY2YmMwYWNjNGNjY2FjOWVhNzA0MWM4OTNiYWYxMjQ4NzI5YTZiM2Q5NSJ9 -->