### PR TITLE
fix(install): parse Windows ownership conflict message

### DIFF
--- a/product/scripts/bootstrap-installer.mjs
+++ b/product/scripts/bootstrap-installer.mjs
@@ -442,7 +442,7 @@ if ($DryRun) { exit 0 }
 New-Item -ItemType Directory -Force -Path (Join-Path $InstallDir 'versions'), $BinDir | Out-Null
 $Existing = Get-Command kungfu -ErrorAction SilentlyContinue
 if ($Existing -and $Existing.Source -ne $Launcher) {
-  throw "error[ownership-conflict]: existing Kungfu is owned outside $Launcher: $($Existing.Source)"
+  throw "error[ownership-conflict]: existing Kungfu is owned outside \${Launcher}: $($Existing.Source)"
 }
 if (Test-Path $Launcher) {
   $firstLine = Get-Content -LiteralPath $Launcher -TotalCount 1

--- a/product/scripts/bootstrap-installer.test.mjs
+++ b/product/scripts/bootstrap-installer.test.mjs
@@ -273,6 +273,10 @@ test('bootstrap publication is deterministic and pins signed release identity', 
       /Get-AuthenticodeSignature/,
     );
     assert.match(powershell.bytes.toString(), /signed-channel-digest/);
+    assert.match(
+      powershell.bytes.toString(),
+      /existing Kungfu is owned outside \$\{Launcher\}:/,
+    );
     assert.match(powershell.bytes.toString(), /update bootstrap-verify/);
     assert.match(powershell.bytes.toString(), /\$ReleaseCutRoot = 'sha256:/);
     assert.match(powershell.bytes.toString(), /\$PlatformSliceRoot = 'sha256:/);


### PR DESCRIPTION
## Summary

Deliver fix(install): parse Windows ownership conflict message from fix/alpha3-windows-installer-parse into dev/v4/v4.0 through the kungfu-systems dual-account PR flow.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This maintenance delivery does not alter an architecture decision."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)