### PR TITLE
fix(work): recover historical profile lifecycles

### DIFF
--- a/framework/core/src/python/kungfu/assignment_runtime/fresh_recovery.py
+++ b/framework/core/src/python/kungfu/assignment_runtime/fresh_recovery.py
@@ -15,6 +15,7 @@ import click
 from kungfu import initiative_family, profile_sdk
 from kungfu.agent import run_agent, session_contract, session_surface
 from kungfu.assignment_runtime import LocalAssignmentRuntimeApplication
+from kungfu.assignment_runtime import profile_lifecycle
 from kungfu.storage import service as storage_service
 
 JsonObject = dict[str, Any]
@@ -748,7 +749,7 @@ def register_commands(work_commands) -> None:
         write_immutable_json=work_commands._write_immutable_json,
         runtime=work_commands._runtime,
         status=work_commands._status,
-        prepare_resume_profile=work_commands._prepare_resume_profile,
+        prepare_resume_profile=profile_lifecycle.prepare_fresh_recovery_profile,
     )
     for command in commands:
         work_commands.assignment.add_command(command)

--- a/framework/core/src/python/kungfu/assignment_runtime/profile_lifecycle.py
+++ b/framework/core/src/python/kungfu/assignment_runtime/profile_lifecycle.py
@@ -33,6 +33,20 @@ def _required_actions(state: dict[str, Any] | None, desired_root: str) -> list[s
     return actions
 
 
+def _profile_state(runtime_dir: str | Path, profile_id: str) -> dict[str, Any] | None:
+    lifecycle = storage_service.profile_lifecycle(
+        runtime_dir, "list", include_removed=True
+    )
+    return next(
+        (
+            row
+            for row in lifecycle.get("profiles", [])
+            if row.get("profile_id") == profile_id and not row.get("removed")
+        ),
+        None,
+    )
+
+
 def ensure_work_profile(
     source: str | Path, runtime_dir: str | Path, authorized_by: str
 ) -> list[dict[str, Any]]:
@@ -72,3 +86,63 @@ def ensure_work_profile(
         )
     )
     return receipts
+
+
+def ensure_profile_lifecycle(
+    source: str | Path, runtime_dir: str | Path, authorized_by: str
+) -> list[dict[str, Any]]:
+    """Activate one exact Profile root without invoking Profile Work hooks."""
+
+    receipts = []
+    inspection = profile_sdk.validate_source(source, runtime_dir)["inspection"]
+    profile_id = inspection["profile"]["id"]
+    desired_root = inspection["profile_suite_root"]
+    state = _profile_state(runtime_dir, profile_id)
+    for action in _required_actions(state, desired_root):
+        values = {"granted_permissions": ["storage"]} if action == "activate" else {}
+        plan = profile_sdk.lifecycle_plan(runtime_dir, action, source, **values)
+        answer = profile_sdk.answer_decision(
+            plan["decisionCard"], "approve", authorized_by
+        )
+        receipts.append(
+            profile_sdk.authorized_lifecycle_apply(runtime_dir, plan, answer)
+        )
+    return receipts
+
+
+def prepare_fresh_recovery_profile(
+    runtime_dir: str | Path, actor: str, source: str | Path
+) -> dict[str, Any]:
+    """Activate exact retained Profile bytes without replaying Work setup."""
+
+    resolved_source = Path(source).resolve()
+    inspection = profile_sdk.validate_source(resolved_source, runtime_dir)["inspection"]
+    profile_id = inspection["profile"]["id"]
+    desired_root = inspection["profile_suite_root"]
+    previous = _profile_state(runtime_dir, profile_id)
+    receipts = ensure_profile_lifecycle(resolved_source, runtime_dir, actor)
+    current = storage_service.profile_lifecycle(
+        runtime_dir,
+        "get",
+        profile_id=profile_id,
+    )
+    if (
+        not current.get("activated")
+        or not current.get("qualified")
+        or current.get("profile_suite_root") != desired_root
+    ):
+        raise RuntimeError(
+            "Fresh recovery did not activate the exact Work Control Profile root"
+        )
+    return {
+        "schema": "kungfu.work.fresh-recovery-profile/v1",
+        "status": "reconciled" if receipts else "ready",
+        "profileId": profile_id,
+        "previousProfileSuiteRoot": (
+            previous.get("profile_suite_root") if previous is not None else None
+        ),
+        "profileSuiteRoot": desired_root,
+        "profileLifecycleReceiptCount": len(receipts),
+        "profileContractMutation": "not-permitted",
+        "writeOccurred": bool(receipts),
+    }

--- a/framework/core/tests/python/test_work_authority_surface.py
+++ b/framework/core/tests/python/test_work_authority_surface.py
@@ -917,6 +917,62 @@ def test_resume_prepare_reconciles_the_explicit_recovery_source(tmp_path, monkey
     assert receipt["profileSuiteRoot"] == desired_root
 
 
+def test_fresh_recovery_prepare_does_not_require_newer_profile_work_hooks(
+    tmp_path, monkeypatch
+):
+    source = tmp_path / "historical-work-control"
+    source.mkdir()
+    desired_root = f"sha256:{'d' * 64}"
+    reconciled = []
+
+    monkeypatch.setattr(
+        assignment_command.profile_sdk,
+        "validate_source",
+        lambda actual, _runtime: {
+            "inspection": {
+                "profile": {"id": "kungfu.work-control"},
+                "profile_suite_root": desired_root,
+            }
+        },
+    )
+
+    def lifecycle(_runtime, operation, **_values):
+        if operation == "list":
+            return {"profiles": []}
+        assert operation == "get"
+        return {
+            "profile_suite_root": desired_root,
+            "qualified": True,
+            "activated": True,
+        }
+
+    monkeypatch.setattr(
+        assignment_command.storage_service, "profile_lifecycle", lifecycle
+    )
+    monkeypatch.setattr(
+        assignment_command.profile_lifecycle,
+        "ensure_profile_lifecycle",
+        lambda actual, runtime, actor: (
+            reconciled.append((actual, runtime, actor)) or [{"status": "activated"}]
+        ),
+    )
+    monkeypatch.setattr(
+        assignment_command.profile_lifecycle,
+        "ensure_work_profile",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("fresh recovery must not invoke newer Profile Work hooks")
+        ),
+    )
+
+    receipt = assignment_command.profile_lifecycle.prepare_fresh_recovery_profile(
+        tmp_path / "runtime", "maintainer:test", source
+    )
+
+    assert reconciled == [(source.resolve(), tmp_path / "runtime", "maintainer:test")]
+    assert receipt["profileSuiteRoot"] == desired_root
+    assert receipt["profileContractMutation"] == "not-permitted"
+
+
 def test_fresh_recovery_failure_keeps_public_executable_next_actions(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary

- Recover an exact retained historical Work Control Profile lifecycle for a fresh SessionAttempt.
- Keep the retained Profile bytes and WorkRef immutable; do not require newer Profile Work hooks.
- Preserve resume/new-attempt semantics and forbid admit, claim, and kickoff effects.

## Acceptance evidence

- Exact source head: `0fb42a07c809633b3a77c93a8579994adf48cdd9`
- Protected base used for validation: `e39c21e469f3060f252a7a817051c7dcd7967b17`
- `./shifu check:source`: 1191 tests, 1180 passed, 11 skipped, zero failures; zero-write gate passed
- `./shifu test:work-authority`: 17 Node + 25 Python passed
- responsibility map, function-risk, and `git diff --check` passed

## Claim boundary

This change only makes the public fresh-recovery path activate an exact retained Profile lifecycle for a new attempt. It does not replay Assignment lifecycle actions, rewrite sealed roots, impersonate an old attempt, add compatibility fallback, or assert that recovery itself completes the governed work.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded recovery correction implements the already-reviewed fresh-recovery protocol without changing an architecture decision."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] No architecture decision change
- [x] No release or tag
- [x] No Assignment state rewrite

## Checklist

- [x] Commits are signed off (DCO)