### PR TITLE
fix(agent): bind prompt consoles to project identity

### DIFF
--- a/framework/core/src/python/kungfu/agent/native_launch.py
+++ b/framework/core/src/python/kungfu/agent/native_launch.py
@@ -32,6 +32,7 @@ from kungfu.agent.provider_bootstrap import (
 from kungfu.skill import build_skill_context
 from kungfu.workspace import (
     WorkspaceTargetRequired,
+    inspect_workspace,
     load_workspace_registry,
     resolve_workspace_target,
 )
@@ -84,6 +85,20 @@ def unbound_work_selection(workspace_id):
         "selectionAuthority": "kungfu-work-cli",
         "entrypoint": "kungfu work status",
     }
+
+
+def managed_workspace_id(work: Mapping[str, Any] | None, workspace_root: str) -> str:
+    """Use exact Project identity for an unbound managed Agent Console."""
+
+    if work is not None:
+        return str(work["workspaceId"])
+    workspace_identity = inspect_workspace(workspace_root, cwd=workspace_root)
+    return str(
+        workspace_identity.workspace_id
+        if workspace_identity is not None
+        and workspace_identity.workspace_kind == "project"
+        else workspace_root
+    )
 
 
 def resolve_native_launch_target(ctx, workspace_root=None, *, cwd=None):

--- a/framework/core/src/python/kungfu/agent/run_agent.py
+++ b/framework/core/src/python/kungfu/agent/run_agent.py
@@ -31,6 +31,7 @@ from kungfu.agent.native_launch import (
     NativeLaunchCoordinator,
     apply_platform_tls_trust,
     encode_wrapper_prompt as _encode_windows_wrapper_prompt,
+    managed_workspace_id as _managed_workspace_id,
     native_environment as _native_environment,
     native_provider_adapter,
     provider_interactive_argv as interactive_launch_argv,
@@ -913,9 +914,8 @@ def execute(
         .expanduser()
         .resolve()
     )
-    workspace_id = str(
-        work.get("workspaceId") if work is not None else cwd or runtime_home
-    )
+    workspace_root = str(cwd or runtime_home)
+    workspace_id = _managed_workspace_id(work, workspace_root)
     managed_session_ref = (
         _session_ref(work, run_id)
         if work is not None
@@ -936,7 +936,7 @@ def execute(
         runtime_dir=runtime_dir,
         config_home=effective_config_home,
         runtime_home=runtime_home,
-        workspace_root=str(cwd or runtime_home),
+        workspace_root=workspace_root,
         work_ref=work,
         work_selection={"workspaceId": workspace_id},
         profile=selected,

--- a/framework/core/tests/python/test_run_product_path.py
+++ b/framework/core/tests/python/test_run_product_path.py
@@ -1851,3 +1851,68 @@ def test_direct_provider_starts_native_work_before_process_launch(
     assert managed_env["KUNGFU_SKILL_AUDIT_FILE"].endswith("-events.jsonl")
     assert Path(managed_env["KUNGFU_SKILL_RUNTIME_AUDIT_FILE"]).is_file()
     assert Path(managed_env["KUNGFU_SKILL_RUNTIME_AUDIT_FINAL_FILE"]).is_file()
+
+
+def test_prompt_only_agent_console_uses_exact_project_workspace_identity(
+    tmp_path, monkeypatch
+):
+    project = tmp_path / "project"
+    project.mkdir()
+    launched = []
+    monkeypatch.setattr(
+        run_agent,
+        "select_profile",
+        lambda *_args, **_kwargs: (
+            {
+                "id": "opencode.test",
+                "provider": "opencode",
+                "cwdPolicy": "workspace-root",
+                "launch": {"executable": "/usr/bin/opencode", "argv": []},
+            },
+            {},
+        ),
+    )
+    monkeypatch.setattr(
+        run_agent.runtime_profiles,
+        "verify_profile",
+        lambda _profile: {"ok": True, "version": "arbitrary-version"},
+    )
+    monkeypatch.setattr(
+        native_launch,
+        "inspect_workspace",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            workspace_kind="project", workspace_id="project:exact"
+        ),
+    )
+
+    def run_process(*_args, **kwargs):
+        launched.append(kwargs)
+        return run_agent.ProcessResult(0, '{"type":"text"}\n', "", False, False)
+
+    result = run_agent.execute(
+        prompt="inspect project",
+        runtime_dir=str(tmp_path / "runtime"),
+        workspace_root=str(project),
+        process_runner=run_process,
+    )
+
+    assert result["launch"]["exitCode"] == 0
+    environment = launched[0]["env"]
+    envelope = json.loads(environment["KUNGFU_AGENT_CONSOLE_ENVELOPE"])
+    assert environment["KUNGFU_WORKSPACE_ROOT"] == str(project)
+    assert envelope["workspaceId"] == "project:exact"
+    assert envelope["consoleId"].startswith("assistant:project:exact:agent-")
+    assert envelope["workRef"] is None
+
+    monkeypatch.setattr(
+        native_launch, "inspect_workspace", lambda *_args, **_kwargs: None
+    )
+    run_agent.execute(
+        prompt="inspect unqualified directory",
+        runtime_dir=str(tmp_path / "fallback-runtime"),
+        workspace_root=str(project),
+        process_runner=run_process,
+    )
+    fallback_envelope = json.loads(launched[1]["env"]["KUNGFU_AGENT_CONSOLE_ENVELOPE"])
+    assert fallback_envelope["workspaceId"] == str(project)
+    assert fallback_envelope["consoleId"].startswith(f"assistant:{project}:agent-")


### PR DESCRIPTION
## Summary

- Give prompt-only managed Agent Consoles the exact qualified Kungfu Project identity when one is available.
- Keep explicit WorkRef identity and non-Project path behavior unchanged.
- Allow the public fresh-recovery path to bind a genuine new prompt Console without path-versus-Project identity drift.

## Acceptance evidence

- Exact source head: `a2b5afab6dfb38cfcfa65fbe48ec0fe9280adfd5`
- Protected base used for validation: `eb78d334cb033c8c5c6fa36387b2861a558b8bde`
- `./shifu check:source`: 1191 tests, 1180 passed, 11 skipped, zero failures; Python type baseline and zero-write gate passed
- `./shifu test:project-work-runtime`: 76 passed
- `./shifu test:agent-console-contract`: 134 passed, 3 skipped
- `./shifu test:work-authority`: 17 Node + 25 Python passed
- function-risk ratchet and `git diff --check` passed

## Claim boundary

This change aligns prompt-only Console identity with an already-qualified Project. It does not bind Work by itself, replay lifecycle actions, admit, claim, kickoff, rewrite Assignment state, or change explicit WorkRef and unqualified-directory behavior.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded identity correction makes two existing Agent launch and Work recovery surfaces agree without changing an architecture decision."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] No architecture decision change
- [x] No release or tag
- [x] No automatic Work mutation

## Checklist

- [x] Commits are signed off (DCO)
