### PR TITLE
fix(agent): bind prompt consoles to project runtime

### DIFF
--- a/framework/core/src/python/kungfu/agent/native_launch.py
+++ b/framework/core/src/python/kungfu/agent/native_launch.py
@@ -104,7 +104,7 @@ def managed_workspace_id(work: Mapping[str, Any] | None, workspace_root: str) ->
 def managed_runtime_dir(
     work: Mapping[str, Any] | None, workspace_root: str, fallback_runtime_dir: str
 ) -> str:
-    """Use the stable Project runtime for a Project-scoped managed Console."""
+    """Use the stable qualified Project runtime for a managed Console."""
 
     workspace_identity = inspect_workspace(workspace_root, cwd=workspace_root)
     if (

--- a/framework/core/src/python/kungfu/agent/native_launch.py
+++ b/framework/core/src/python/kungfu/agent/native_launch.py
@@ -101,6 +101,33 @@ def managed_workspace_id(work: Mapping[str, Any] | None, workspace_root: str) ->
     )
 
 
+def managed_runtime_dir(
+    work: Mapping[str, Any] | None, workspace_root: str, fallback_runtime_dir: str
+) -> str:
+    """Use the stable Project runtime for a Project-scoped managed Console."""
+
+    workspace_identity = inspect_workspace(workspace_root, cwd=workspace_root)
+    if (
+        workspace_identity is None
+        or workspace_identity.workspace_kind != "project"
+        or workspace_identity.identity_state != "qualified"
+        or (
+            work is not None
+            and str(work.get("workspaceId") or "") != workspace_identity.workspace_id
+        )
+    ):
+        return fallback_runtime_dir
+    target = resolve_workspace_target("read-only", workspace_root, cwd=workspace_root)
+    return str(target.runtime_dir)
+
+
+def managed_console_scope(cwd, home, work, fallback_runtime_dir):
+    """Pair a managed Console cwd with its qualified Project runtime."""
+
+    exact_root = str(cwd or home or os.path.expanduser("~"))
+    return cwd, managed_runtime_dir(work, exact_root, fallback_runtime_dir)
+
+
 def resolve_native_launch_target(ctx, workspace_root=None, *, cwd=None):
     """Resolve native provider cwd without requiring durable Project Work."""
 

--- a/framework/core/src/python/kungfu/agent/run_agent.py
+++ b/framework/core/src/python/kungfu/agent/run_agent.py
@@ -31,6 +31,7 @@ from kungfu.agent.native_launch import (
     NativeLaunchCoordinator,
     apply_platform_tls_trust,
     encode_wrapper_prompt as _encode_windows_wrapper_prompt,
+    managed_console_scope as _managed_console_scope,
     managed_workspace_id as _managed_workspace_id,
     native_environment as _native_environment,
     native_provider_adapter,
@@ -891,7 +892,12 @@ def execute(
         elif work != continuation_value["workRef"]:
             raise ValueError("WorkRef does not match the continuation envelope")
     provider = str(selected["provider"])
-    cwd = _cwd(selected, workspace_root=workspace_root, home=home)
+    cwd, runtime_dir = _managed_console_scope(
+        _cwd(selected, workspace_root=workspace_root, home=home),
+        home,
+        work,
+        runtime_dir,
+    )
     argv = launch_argv(
         selected,
         prompt,

--- a/framework/core/tests/python/test_run_product_path.py
+++ b/framework/core/tests/python/test_run_product_path.py
@@ -1901,6 +1901,7 @@ def test_prompt_only_agent_console_uses_exact_project_workspace_identity(
     environment = launched[0]["env"]
     envelope = json.loads(environment["KUNGFU_AGENT_CONSOLE_ENVELOPE"])
     assert environment["KUNGFU_WORKSPACE_ROOT"] == str(project)
+    # Prompt-only Consoles must share the qualified Project authority runtime.
     assert environment["KUNGFU_AGENT_RUNTIME_DIR"] == str(project_target.runtime_dir)
     assert envelope["workspaceId"] == project_target.identity.workspace_id
     assert envelope["consoleId"].startswith(

--- a/framework/core/tests/python/test_run_product_path.py
+++ b/framework/core/tests/python/test_run_product_path.py
@@ -15,6 +15,7 @@ from kungfu.agent import native_launch
 from kungfu.agent import run_agent
 from kungfu.cli.commands import assignment, assignment_review, kfc, run
 from kungfu.workspace import (
+    ensure_workspace_data_home,
     inspect_workspace,
     resolve_workspace_target,
     select_workspace,
@@ -1858,6 +1859,13 @@ def test_prompt_only_agent_console_uses_exact_project_workspace_identity(
 ):
     project = tmp_path / "project"
     project.mkdir()
+    project_candidate = resolve_workspace_target(
+        "capture-only", str(project), cwd=str(project)
+    )
+    ensure_workspace_data_home(project_candidate.identity, "workspace-identity-fixture")
+    project_target = resolve_workspace_target(
+        "read-only", str(project), cwd=str(project)
+    )
     launched = []
     monkeypatch.setattr(
         run_agent,
@@ -1877,13 +1885,6 @@ def test_prompt_only_agent_console_uses_exact_project_workspace_identity(
         "verify_profile",
         lambda _profile: {"ok": True, "version": "arbitrary-version"},
     )
-    monkeypatch.setattr(
-        native_launch,
-        "inspect_workspace",
-        lambda *_args, **_kwargs: SimpleNamespace(
-            workspace_kind="project", workspace_id="project:exact"
-        ),
-    )
 
     def run_process(*_args, **kwargs):
         launched.append(kwargs)
@@ -1900,19 +1901,27 @@ def test_prompt_only_agent_console_uses_exact_project_workspace_identity(
     environment = launched[0]["env"]
     envelope = json.loads(environment["KUNGFU_AGENT_CONSOLE_ENVELOPE"])
     assert environment["KUNGFU_WORKSPACE_ROOT"] == str(project)
-    assert envelope["workspaceId"] == "project:exact"
-    assert envelope["consoleId"].startswith("assistant:project:exact:agent-")
+    assert environment["KUNGFU_AGENT_RUNTIME_DIR"] == str(project_target.runtime_dir)
+    assert envelope["workspaceId"] == project_target.identity.workspace_id
+    assert envelope["consoleId"].startswith(
+        f"assistant:{project_target.identity.workspace_id}:agent-"
+    )
     assert envelope["workRef"] is None
 
+    unqualified = tmp_path / "unqualified"
+    unqualified.mkdir()
     monkeypatch.setattr(
         native_launch, "inspect_workspace", lambda *_args, **_kwargs: None
     )
     run_agent.execute(
         prompt="inspect unqualified directory",
         runtime_dir=str(tmp_path / "fallback-runtime"),
-        workspace_root=str(project),
+        workspace_root=str(unqualified),
         process_runner=run_process,
     )
     fallback_envelope = json.loads(launched[1]["env"]["KUNGFU_AGENT_CONSOLE_ENVELOPE"])
-    assert fallback_envelope["workspaceId"] == str(project)
-    assert fallback_envelope["consoleId"].startswith(f"assistant:{project}:agent-")
+    assert launched[1]["env"]["KUNGFU_AGENT_RUNTIME_DIR"] == str(
+        tmp_path / "fallback-runtime"
+    )
+    assert fallback_envelope["workspaceId"] == str(unqualified)
+    assert fallback_envelope["consoleId"].startswith(f"assistant:{unqualified}:agent-")

--- a/framework/maintainability/agent-python-responsibility-map.json
+++ b/framework/maintainability/agent-python-responsibility-map.json
@@ -44,7 +44,7 @@
         "functionRisk": { "functions": 22, "total": 171, "maximum": 28 }
       },
       "current": {
-        "physicalLines": 1204,
+        "physicalLines": 1210,
         "responsibilities": 34,
         "functionRisk": { "functions": 21, "total": 143, "maximum": 27 }
       },


### PR DESCRIPTION
## Summary

- Pair prompt-only managed Agent Console cwd with the stable runtime of the exact qualified Kungfu Project.
- Require explicit WorkRef workspace identity to match before selecting the Project runtime.
- Preserve the existing fallback runtime for unqualified directories and all non-Project launch behavior.

## Acceptance evidence

- Exact source head: `5ad7f58c6c928288f778c668f4ecab7564b6c86a`
- Protected base used for validation: `abafce0bac53662def68787ef8e6c7186bf770d1`
- `./shifu check:source`: 1191 tests, 1180 passed, 11 skipped, zero failures; Python type baseline and zero-write gate passed
- `./shifu test:project-work-runtime`: 76 passed
- `./shifu test:agent-console-contract`: 134 passed, 3 skipped
- `./shifu test:work-authority`: 17 Node + 25 Python passed
- responsibility-map, function-risk ratchet, complexity tests, and `git diff --check` passed

## Claim boundary

This change selects an already-qualified Project runtime for a managed prompt Console whose cwd and WorkRef identity agree with that Project. It does not bind Work by itself, replay lifecycle actions, admit, claim, kickoff, rewrite Assignment state, or change unqualified-directory fallback behavior.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded runtime selection correction makes existing Agent launch and Project authority surfaces agree without changing an architecture decision."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] No architecture decision change
- [x] No release or tag
- [x] No automatic Work mutation

## Checklist

- [x] Commits are signed off (DCO)
