### PR TITLE
fix(work): retain recovery profile source at bind

### DIFF
--- a/framework/core/src/python/kungfu/agent/native_launch.py
+++ b/framework/core/src/python/kungfu/agent/native_launch.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, Callable, Mapping
 import uuid
 
+from kungfu import profile_sdk
 from kungfu.agent.work_projection import WorkProjectionPort
 from kungfu.agent import resources as agent_resources
 from kungfu.agent import runtime_profiles
@@ -42,6 +43,17 @@ _DARWIN_DEFAULT_SSL_CERT_FILE = Path("/etc/ssl/cert.pem")
 COMMAND_WRAPPER_SUFFIXES = _COMMAND_WRAPPER_SUFFIXES
 encode_wrapper_prompt = _encode_wrapper_prompt
 resolve_command_wrapper = _resolve_command_wrapper
+
+
+def work_profile_inspection(
+    source: str | Path | None,
+    fallback: Callable[[], str | Path],
+    runtime_dir: str | Path,
+) -> Mapping[str, Any]:
+    """Validate an explicit retained Work profile or the ordinary bound source."""
+
+    resolved = Path(source).expanduser().resolve() if source is not None else fallback()
+    return profile_sdk.validate_source(resolved, runtime_dir)["inspection"]
 
 
 def provider_interactive_argv(profile: Mapping[str, Any]) -> list[str]:

--- a/framework/core/src/python/kungfu/agent/run_agent.py
+++ b/framework/core/src/python/kungfu/agent/run_agent.py
@@ -38,6 +38,7 @@ from kungfu.agent.native_launch import (
     provider_interactive_argv as interactive_launch_argv,
     provider_runtime_health as _provider_runtime_health,
     resolve_command_wrapper as _resolve_windows_command_wrapper,
+    work_profile_inspection as _work_profile_inspection,
 )
 from kungfu.agent.provider_bootstrap import refresh_native_skill_runtime_audit
 from kungfu.agent.managed_run import ManagedRunCoordinator
@@ -72,6 +73,7 @@ def bind_current_native_work(
     assignment_id: str,
     *,
     work_workspace_root: str | None = None,
+    work_profile_source: str | Path | None = None,
     envelope_override: Mapping[str, Any] | None = None,
     console_workspace_root: str | None = None,
     expected_binding: Mapping[str, Any] | None = None,
@@ -89,7 +91,6 @@ def bind_current_native_work(
             dict(envelope_override or {})
         )
     )
-    from kungfu import profile_sdk
     from kungfu.cli.commands import assignment as work_commands
 
     workspace_root = (
@@ -148,9 +149,9 @@ def bind_current_native_work(
             binding_scope = "explicit-external-project"
 
     status = work_commands._status(work_runtime_dir, initiative_id, assignment_id)
-    work_control = profile_sdk.validate_source(
-        work_commands.profile_source(), work_runtime_dir
-    )["inspection"]
+    work_control = _work_profile_inspection(
+        work_profile_source, work_commands.profile_source, work_runtime_dir
+    )
     work_ref = {
         "schema": "kungfu.work-ref/v1",
         "workspaceId": work_workspace_id,

--- a/framework/core/src/python/kungfu/assignment_runtime/fresh_recovery.py
+++ b/framework/core/src/python/kungfu/assignment_runtime/fresh_recovery.py
@@ -613,6 +613,7 @@ def _apply_from_ports(
                 initiative_id,
                 assignment_id,
                 work_workspace_root=workspace_root,
+                work_profile_source=recovery_profile_source,
                 expected_binding=expected,
             )
             or {}

--- a/framework/core/tests/python/test_assignment_profile_source.py
+++ b/framework/core/tests/python/test_assignment_profile_source.py
@@ -156,7 +156,7 @@ def test_assignment_profile_source_prefers_native_source_layout(tmp_path, monkey
     assert ASSIGNMENT_CLI._profile_source() == native
 
 
-def test_agent_session_can_observe_work_from_explicit_external_project(
+def test_agent_session_can_observe_work_from_explicit_external_project_and_profile(
     monkeypatch, tmp_path
 ):
     requests = []
@@ -173,6 +173,8 @@ def test_agent_session_can_observe_work_from_explicit_external_project(
     work_target = resolve_workspace_target(
         "read-only", str(work_project), cwd=str(work_project)
     )
+    work_profile_source = tmp_path / "retained-work-control"
+    work_profile_source.mkdir()
     envelope = {
         "workspaceId": console_target.identity.workspace_id,
         "consoleId": f"assistant:{console_target.identity.workspace_id}:native:one",
@@ -196,9 +198,16 @@ def test_agent_session_can_observe_work_from_explicit_external_project(
         }
 
     monkeypatch.setattr(ASSIGNMENT_CLI, "_status", status)
-    monkeypatch.setattr(ASSIGNMENT_CLI, "_profile_source", lambda: tmp_path)
+    monkeypatch.setattr(
+        ASSIGNMENT_CLI,
+        "profile_source",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("explicit recovery source must not be rediscovered")
+        ),
+    )
 
-    def validate_source(_source, runtime_dir):
+    def validate_source(source, runtime_dir):
+        assert source == work_profile_source.resolve()
         observed_runtime_dirs.append(runtime_dir)
         return {
             "inspection": {
@@ -226,6 +235,7 @@ def test_agent_session_can_observe_work_from_explicit_external_project(
         "initiative:external",
         "assignment:external",
         work_workspace_root=str(work_project),
+        work_profile_source=work_profile_source,
     )
 
     assert observed_runtime_dirs == [str(work_runtime), str(work_runtime)]

--- a/framework/core/tests/python/test_work_authority_surface.py
+++ b/framework/core/tests/python/test_work_authority_surface.py
@@ -973,6 +973,78 @@ def test_fresh_recovery_prepare_does_not_require_newer_profile_work_hooks(
     assert receipt["profileContractMutation"] == "not-permitted"
 
 
+def test_fresh_recovery_apply_passes_explicit_profile_source_to_binder(
+    tmp_path, monkeypatch
+):
+    status, binding, plan = _fresh_recovery_fixture()
+    workspace_root = tmp_path / "project"
+    workspace_root.mkdir()
+    profile_source = tmp_path / "retained-work-control"
+    profile_source.mkdir()
+    plan["workspace"]["root"] = str(workspace_root)
+    plan["generatedAt"] = "2099-01-01T00:00:00Z"
+    plan["expiresAt"] = "2099-01-01T00:10:00Z"
+    plan["planRoot"] = assignment_fresh_recovery._root(
+        {key: value for key, value in plan.items() if key != "planRoot"}
+    )
+    plan_file = tmp_path / "plan.json"
+    plan_file.write_text(json.dumps(plan), encoding="utf-8")
+    observed = {}
+
+    monkeypatch.setattr(
+        assignment_fresh_recovery,
+        "_verify_recovery_profile_source",
+        lambda *_args: None,
+    )
+    monkeypatch.setattr(
+        assignment_fresh_recovery,
+        "_retained_status",
+        lambda *_args: json.loads(json.dumps(status)),
+    )
+    monkeypatch.setattr(
+        assignment_fresh_recovery,
+        "_current_session",
+        lambda _runtime_dir: dict(binding["session"]),
+    )
+
+    def bind_current_native_work(*_args, **kwargs):
+        observed.update(kwargs)
+        return {
+            "workRef": dict(plan["workRef"]),
+            "receipt": {"receiptRoot": f"sha256:{'8' * 64}"},
+        }
+
+    monkeypatch.setattr(
+        assignment_fresh_recovery.run_agent,
+        "bind_current_native_work",
+        bind_current_native_work,
+    )
+    identity = SimpleNamespace(
+        workspace_id=plan["workspace"]["id"],
+        identity_root=plan["workspace"]["identityRoot"],
+    )
+    receipt = assignment_fresh_recovery._apply_from_ports(
+        ctx=SimpleNamespace(runtime_dir=tmp_path / "console-runtime"),
+        plan_file=plan_file,
+        expected_plan_root=plan["planRoot"],
+        authorized_by="maintainer:test",
+        recovery_profile_source=profile_source,
+        runtime=lambda *_args: (identity, workspace_root / ".kungfu/runtime", {}),
+        status=lambda *_args: status,
+        prepare_resume_profile=lambda *_args: {
+            "status": "ready",
+            "profileSuiteRoot": plan["workRef"]["profileRoot"],
+        },
+    )
+
+    assert receipt["ok"] is True
+    assert observed["work_profile_source"] == profile_source
+    assert observed["expected_binding"] == {
+        "workRef": plan["workRef"],
+        "session": binding["session"],
+    }
+
+
 def test_fresh_recovery_failure_keeps_public_executable_next_actions(
     tmp_path, monkeypatch
 ):

--- a/framework/maintainability/agent-python-responsibility-map.json
+++ b/framework/maintainability/agent-python-responsibility-map.json
@@ -44,8 +44,8 @@
         "functionRisk": { "functions": 22, "total": 171, "maximum": 28 }
       },
       "current": {
-        "physicalLines": 1210,
-        "responsibilities": 34,
+        "physicalLines": 1211,
+        "responsibilities": 33,
         "functionRisk": { "functions": 21, "total": 143, "maximum": 27 }
       },
       "ownerFiles": [


### PR DESCRIPTION
## Summary

- Pass the already verified retained Work Control Profile source through the public fresh-recovery apply boundary into native Work binding.
- Keep ordinary `bind-work` source discovery unchanged when no explicit recovery source is supplied.
- Keep the source validation owner outside the process runner responsibility surface.

## Acceptance evidence

- Exact source head: `9bfbfa327db6f8ae97d37d549ea54324fb3c2948`
- Protected base used for validation: `2548395cc90bc65ad5f2029aae5ef1d5969fb187`
- `./shifu check:source`: 1191 tests, 1180 passed, 11 skipped, zero failures; Python type baseline, function-risk, responsibility map, and zero-write gate passed
- `./shifu test:work-authority`: 17 Node + 26 Python passed
- `./shifu test:agent-console-contract`: 134 passed, 3 skipped
- `./shifu test:project-work-runtime`: 76 passed
- Exact retained-source binder and fresh-recovery port tests: 2 passed
- `git diff --check`: passed

## Real acceptance gap

An exact `bfe443a461…` product opened a genuinely fresh Console for the retained installer Assignment. The generated plan was `resume/new-attempt`, retained the exact original WorkRef, and contained no admit, claim, kickoff, or Assignment write. Apply then failed closed because the binder discarded the explicit retained profile source and independently required ambient `KF_BUNDLED_EXTENSION_ROOT` / `KF_EXTENSION_PATH`. This patch carries the validated source across that one boundary; it does not add a fallback.

## Claim boundary

This change enables a new attempt to bind an existing immutable Assignment only after the public fresh-recovery planner and retained profile validator have resolved an exact source. It does not replay admit, claim, or kickoff; reset lifecycle counters; rewrite sealed roots; infer completion; or alter ordinary first-attempt and bind-work behavior.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded data-flow correction preserves the existing fresh-recovery protocol and authority boundaries."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] No architecture decision change
- [x] No release or tag
- [x] No Assignment lifecycle mutation
- [x] No compatibility fallback or second authority

## Checklist

- [x] Commits are signed off (DCO)