### PR TITLE
fix(work): reuse verified ref during fresh recovery

### DIFF
--- a/framework/core/src/python/kungfu/agent/run_agent.py
+++ b/framework/core/src/python/kungfu/agent/run_agent.py
@@ -48,7 +48,6 @@ from kungfu.agent.provider_output import (
     public_command_preview as public_command_preview,
 )
 from kungfu.content_hash import compute_content_hash_value
-from kungfu.initiative_family import canonical as assignment_canonical
 from kungfu.skill import build_skill_context
 from kungfu.workspace import resolve_workspace_target
 from kungfu.rewind import (
@@ -148,22 +147,17 @@ def bind_current_native_work(
         if work_workspace_id != str(envelope["workspaceId"]):
             binding_scope = "explicit-external-project"
 
-    status = work_commands._status(work_runtime_dir, initiative_id, assignment_id)
-    work_control = _work_profile_inspection(
-        work_profile_source, work_commands.profile_source, work_runtime_dir
+    work_ref = session_contract.resolve_native_work_ref(
+        work_commands,
+        profile_inspection=_work_profile_inspection,
+        runtime_dir=work_runtime_dir,
+        workspace_id=work_workspace_id,
+        profile_source=work_profile_source,
+        initiative_id=initiative_id,
+        assignment_id=assignment_id,
+        expected_binding=expected_binding,
+        explicit_workspace=work_workspace_root is not None,
     )
-    work_ref = {
-        "schema": "kungfu.work-ref/v1",
-        "workspaceId": work_workspace_id,
-        "profileId": work_control["profile"]["id"],
-        "profileRoot": work_control["profile_suite_root"],
-        "entityType": "assignment",
-        "entityId": assignment_id,
-        "entityRoot": assignment_canonical.semantic_root(status["assignment"]),
-        "purpose": "continue-project-assignment",
-        "systemTimeCut": status["query_proof_root"],
-        "initiativeId": initiative_id,
-    }
     session_contract.validate_work_ref(work_ref)
     session = {
         "workConsoleId": str(envelope["consoleId"]),

--- a/framework/core/src/python/kungfu/agent/session_contract.py
+++ b/framework/core/src/python/kungfu/agent/session_contract.py
@@ -14,6 +14,8 @@ import json
 import re
 from typing import Any, Mapping, overload
 
+from kungfu.initiative_family import canonical as assignment_canonical
+
 
 WORK_REF_SCHEMA = "kungfu.work-ref/v1"
 AGENT_CONSOLE_ENVELOPE_SCHEMA = "kungfu.agent-console-envelope/v1"
@@ -146,6 +148,85 @@ def validate_work_ref(
     elif "initiativeId" in result:
         raise ValueError("WorkRef.initiativeId is only valid for assignment identity")
     return result
+
+
+def _planned_work_ref(
+    expected_binding,
+    *,
+    workspace_id,
+    work_control,
+    initiative_id,
+    assignment_id,
+):
+    work_ref = validate_work_ref(dict(expected_binding.get("workRef") or {}))
+    expected_coordinates = (
+        workspace_id,
+        work_control["profile"]["id"],
+        work_control["profile_suite_root"],
+        "assignment",
+        assignment_id,
+        "continue-project-assignment",
+        initiative_id,
+    )
+    actual_coordinates = tuple(
+        work_ref[field]
+        for field in (
+            "workspaceId",
+            "profileId",
+            "profileRoot",
+            "entityType",
+            "entityId",
+            "purpose",
+            "initiativeId",
+        )
+    )
+    if actual_coordinates != expected_coordinates:
+        raise ValueError("planned native Work binding coordinates changed")
+    return work_ref
+
+
+def resolve_native_work_ref(
+    work_commands,
+    *,
+    profile_inspection,
+    runtime_dir,
+    workspace_id,
+    profile_source,
+    initiative_id,
+    assignment_id,
+    expected_binding,
+    explicit_workspace,
+):
+    """Reuse a planned WorkRef, or resolve ordinary binding from live authority."""
+
+    work_control = profile_inspection(
+        profile_source, work_commands.profile_source, runtime_dir
+    )
+    if expected_binding is not None:
+        if not explicit_workspace or profile_source is None:
+            raise ValueError(
+                "planned native Work binding requires explicit workspace and Profile source"
+            )
+        return _planned_work_ref(
+            expected_binding,
+            workspace_id=workspace_id,
+            work_control=work_control,
+            initiative_id=initiative_id,
+            assignment_id=assignment_id,
+        )
+    status = work_commands._status(runtime_dir, initiative_id, assignment_id)
+    return {
+        "schema": WORK_REF_SCHEMA,
+        "workspaceId": workspace_id,
+        "profileId": work_control["profile"]["id"],
+        "profileRoot": work_control["profile_suite_root"],
+        "entityType": "assignment",
+        "entityId": assignment_id,
+        "entityRoot": assignment_canonical.semantic_root(status["assignment"]),
+        "purpose": "continue-project-assignment",
+        "systemTimeCut": status["query_proof_root"],
+        "initiativeId": initiative_id,
+    }
 
 
 def require_expected_binding(expected, work_ref, session) -> None:

--- a/framework/core/tests/python/test_assignment_profile_source.py
+++ b/framework/core/tests/python/test_assignment_profile_source.py
@@ -4,6 +4,8 @@ import importlib
 import json
 from types import SimpleNamespace
 
+import pytest
+
 from kungfu import assignment_orchestration
 from kungfu.agent import run_agent
 from kungfu.workspace import resolve_workspace_target
@@ -156,8 +158,9 @@ def test_assignment_profile_source_prefers_native_source_layout(tmp_path, monkey
     assert ASSIGNMENT_CLI._profile_source() == native
 
 
+@pytest.mark.parametrize("planned_recovery", [False, True])
 def test_agent_session_can_observe_work_from_explicit_external_project_and_profile(
-    monkeypatch, tmp_path
+    monkeypatch, tmp_path, planned_recovery
 ):
     requests = []
     observed_runtime_dirs = []
@@ -191,6 +194,8 @@ def test_agent_session_can_observe_work_from_explicit_external_project_and_profi
     monkeypatch.setenv("KUNGFU_AGENT_RUNTIME_DIR", str(console_runtime))
 
     def status(runtime_dir, *_args):
+        if planned_recovery:
+            raise AssertionError("planned recovery must reuse its verified WorkRef")
         observed_runtime_dirs.append(runtime_dir)
         return {
             "assignment": {"assignment_id": "assignment:external"},
@@ -230,16 +235,46 @@ def test_agent_session_can_observe_work_from_explicit_external_project_and_profi
         return {"status": "bound", "receiptRoot": ROOT_HASH}
 
     monkeypatch.setattr(run_agent.session_surface, "invoke", invoke)
+    expected_work_ref = {
+        "schema": "kungfu.work-ref/v1",
+        "workspaceId": work_target.identity.workspace_id,
+        "profileId": "kungfu.work-control",
+        "profileRoot": ROOT_HASH,
+        "entityType": "assignment",
+        "entityId": "assignment:external",
+        "entityRoot": ROOT_HASH,
+        "purpose": "continue-project-assignment",
+        "systemTimeCut": ROOT_HASH,
+        "initiativeId": "initiative:external",
+    }
+    expected_binding = (
+        {
+            "workRef": expected_work_ref,
+            "session": {
+                "workConsoleId": envelope["consoleId"],
+                "sessionAttemptId": envelope["attemptId"],
+            },
+        }
+        if planned_recovery
+        else None
+    )
     result = run_agent.bind_current_native_work(
         str(work_runtime),
         "initiative:external",
         "assignment:external",
         work_workspace_root=str(work_project),
         work_profile_source=work_profile_source,
+        expected_binding=expected_binding,
     )
 
-    assert observed_runtime_dirs == [str(work_runtime), str(work_runtime)]
+    assert observed_runtime_dirs == (
+        [str(work_runtime)]
+        if planned_recovery
+        else [str(work_runtime), str(work_runtime)]
+    )
     assert result["workRef"]["workspaceId"] == work_target.identity.workspace_id
+    if planned_recovery:
+        assert result["workRef"] == expected_work_ref
     assert result["session"]["workConsoleId"] == envelope["consoleId"]
     assert requests[0]["input"]["bindingScope"] == "explicit-external-project"
     assert requests[0]["input"]["sourceWorkspaceId"] == envelope["workspaceId"]

--- a/framework/maintainability/agent-python-responsibility-map.json
+++ b/framework/maintainability/agent-python-responsibility-map.json
@@ -44,8 +44,8 @@
         "functionRisk": { "functions": 22, "total": 171, "maximum": 28 }
       },
       "current": {
-        "physicalLines": 1211,
-        "responsibilities": 33,
+        "physicalLines": 1205,
+        "responsibilities": 32,
         "functionRisk": { "functions": 21, "total": 143, "maximum": 27 }
       },
       "ownerFiles": [


### PR DESCRIPTION
## Summary

- Reuse the exact WorkRef already verified by the public fresh-recovery plan when binding the new native attempt.
- Require exact workspace, Work Control profile source, Assignment, profile, and purpose coordinates on that planned path.
- Preserve ordinary bind-work and first-attempt live status discovery unchanged.

## Related issue

Follow-up to #3451 and the real retained installer Assignment acceptance run.

## Changes

- Split native WorkRef resolution into live-status and planned-recovery paths.
- Pass the plan-verified expected WorkRef into native session binding.
- Add regression coverage proving planned recovery does not rediscover ambient Work Control authority and ordinary binding still does.
- Refresh the maintainability responsibility map to the smaller owner surface.

## Verification

- Exact source head: `14e678ce3d3471d87945f9ab9b6db186ff2aad4e`
- Protected base: `c89392e7adb43c5004d152792c4d4aa4585fc195`
- `./shifu check:source`: passed with zero-write tracked and untracked roots unchanged
- `./shifu test:work-authority`: 17 Node + 26 Python passed
- `./shifu test:project-work-runtime`: 76 passed
- `./shifu test:agent-console-contract`: 134 passed, 3 skipped
- Agent Python responsibility map: 8 Node tests passed
- Function-risk ratchet and direct documentation contract: passed
- `git diff --check`: passed

## Claim boundary

This patch only lets a new attempt bind the immutable WorkRef already verified by the content-addressed fresh-recovery plan. It does not replay admit, claim, or kickoff; reset phase or counters; rewrite sealed roots; infer completion; create a second authority; or alter ordinary first-attempt and bind-work behavior.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded binding correction preserves the existing fresh-recovery protocol and authority boundaries."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required; public protocol is unchanged)

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA4LTI1LWt1bmdmdS1hc3NpZ25tZW50LWZyZXNoLWNvbnNvbGUtcmVjb3ZlcnkiLCJkZWxpdmVyeUNsYXNzIjoicHJvdGVjdGVkLXdvcmstY29udHJvbC1yZWNvdmVyeSIsImRldkhlYWQiOiJjODkzOTJlN2FkYjQzYzUwMDRkMTUyNzkyYzRkNGFhNDU4NWZjMTk1IiwicHVsbFJlcXVlc3RIZWFkIjoiMTRlNjc4Y2UzZDM0NzFkODc5NDVmOWFiOWI2ZGIxODZmZjJhYWQ0ZSIsInJlcGxheWVkQ2FuZGlkYXRlIjoiZjIzN2UzNjI5N2Y5ZjE0NGFhMjZmMjU2ZjdiY2ZmZDhmOTExZmExMSIsInJlcGxheWVkVHJlZSI6ImM4NWE0OGRkZDMzNzhmOWU1NTRhYWEwZjQwYTI1NmFmZGZjZjIxM2YiLCJxdWV1ZUF0dGVtcHQiOiIxNGU2NzhjZTNkMzQ3MWQ4Nzk0NWY5YWI5YjZkYjE4NmZmMmFhZDRlQGM4OTM5MmU3YWRiNDNjNTAwNGQxNTI3OTJjNGQ0YWE0NTg1ZmMxOTUiLCJhZG1pc3Npb25Qcm9vZlJvb3QiOiJzaGEyNTY6ZWI3MmZjYmEzYzdlZWM0OGU4ZjEwMzMyM2U0ZjMyMDEzMzM4NGU0ZWU3YzA0NmNhMTczNmVmYTI3NjQxMjMwMCIsImFkbWlzc2lvblByb29mUm9vdHMiOlsic2hhMjU2OjcxMzZkZGJlOGNiN2UyMDNhMjU2ZTdjOGNmOGU5ODBkMjY0ZGJlOGQ3NjhlODVmYWU5YzY5MGRmNGFmOTAyYjIiLCJzaGEyNTY6ZWI3MmZjYmEzYzdlZWM0OGU4ZjEwMzMyM2U0ZjMyMDEzMzM4NGU0ZWU3YzA0NmNhMTczNmVmYTI3NjQxMjMwMCJdLCJzdGF0dXNDb250ZXh0IjoiUXVldWUgZmFtaWx5IGxlYXNlL2Q5OWYzYTkxNjY3MzllMGQiLCJsZWFzZVJvb3QiOiJzaGEyNTY6OGIyZmNhODUxMTdlMzliZTM4ZmNlNjY0ZGE3ZWE0ODIwOWUyYjQ0NDE0ZjUyMjE0YjlkOTM3NWQ4NDY3MmMzMSJ9 -->