### PR TITLE
fix(agent): restore native Work Control binding

### DIFF
--- a/framework/core/src/python/kungfu/agent/native_authority.py
+++ b/framework/core/src/python/kungfu/agent/native_authority.py
@@ -22,6 +22,58 @@ class ConformanceOracleDisabled(RuntimeError):
     pass
 
 
+def profile_adapter_runtime_failure(
+    error: profile_sdk.ProfileSdkError,
+    *,
+    write: bool,
+    operation: str,
+    retained_codes: set[str],
+) -> dict[str, Any]:
+    """Normalize a Profile adapter failure without importing its caller runtime."""
+
+    code = str(error.diagnosis.get("code") or "")
+    if (
+        write
+        and code == "member-adapter-invoke-failed"
+        and isinstance(error.__cause__, ValueError)
+    ):
+        return {
+            "code": "invalid-command",
+            "message": str(error.__cause__),
+            "details": {"operation": operation},
+        }
+    if code in {
+        "member-resolution-failed",
+        "profile-member-ambiguous",
+        "profile-source-ambiguous",
+    }:
+        return {
+            "code": "ambiguous-identity",
+            "message": "Work Control authority does not resolve exactly once",
+        }
+    retained = code in retained_codes
+    message = str(error) if retained else "Work Control authority is unavailable"
+    return {
+        "code": "backend-unavailable",
+        "message": message,
+        "diagnostics": [
+            {
+                "code": code or "work-control-unavailable",
+                "message": (
+                    message
+                    if retained
+                    else "The exact active Work Control Profile could not be invoked"
+                ),
+                "severity": "error",
+                "recovery": [
+                    "kungfu profile manager --json",
+                    "kungfu profile history kungfu.work-control --json",
+                ],
+            }
+        ],
+    }
+
+
 def _file_root(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as stream:

--- a/framework/core/src/python/kungfu/agent/native_launch.py
+++ b/framework/core/src/python/kungfu/agent/native_launch.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import json
 import os
 import shlex
-import shutil
 import subprocess
 import sys
 import threading
@@ -18,7 +17,6 @@ from pathlib import Path
 from typing import Any, Callable, Mapping
 import uuid
 
-from kungfu import profile_sdk
 from kungfu.agent.work_projection import WorkProjectionPort
 from kungfu.agent import resources as agent_resources
 from kungfu.agent import runtime_profiles
@@ -43,17 +41,6 @@ _DARWIN_DEFAULT_SSL_CERT_FILE = Path("/etc/ssl/cert.pem")
 COMMAND_WRAPPER_SUFFIXES = _COMMAND_WRAPPER_SUFFIXES
 encode_wrapper_prompt = _encode_wrapper_prompt
 resolve_command_wrapper = _resolve_command_wrapper
-
-
-def work_profile_inspection(
-    source: str | Path | None,
-    fallback: Callable[[], str | Path],
-    runtime_dir: str | Path,
-) -> Mapping[str, Any]:
-    """Validate an explicit retained Work profile or the ordinary bound source."""
-
-    resolved = Path(source).expanduser().resolve() if source is not None else fallback()
-    return profile_sdk.validate_source(resolved, runtime_dir)["inspection"]
 
 
 def provider_interactive_argv(profile: Mapping[str, Any]) -> list[str]:
@@ -356,24 +343,7 @@ def native_environment(
         # valid terminal types remain untouched.
         env["TERM"] = "xterm"
         env["KUNGFU_AGENT_TERMINAL_RECOVERY"] = f"{ambient_term or 'unset'}->xterm"
-    configured_cli = str(ambient.get("KUNGFU_CLI_BIN") or "").strip()
-    cli_candidate = configured_cli or shutil.which(
-        "kungfu", path=str(ambient.get("PATH") or "")
-    )
-    if configured_cli and not os.path.isabs(os.path.expanduser(configured_cli)):
-        cli_candidate = shutil.which(
-            configured_cli, path=str(ambient.get("PATH") or "")
-        )
-    if cli_candidate:
-        cli_path = Path(cli_candidate).expanduser().absolute()
-        if not cli_path.is_file() or not os.access(cli_path, os.X_OK):
-            raise ValueError(
-                "KUNGFU_CLI_BIN must identify an executable Kungfu front door"
-            )
-        cli_bin = str(cli_path)
-        env["KUNGFU_CLI_BIN"] = cli_bin
-    else:
-        cli_bin = "kungfu"
+    cli_bin = session_contract.native_cli_front_door(ambient, env)
     bind_work_entrypoint = [
         cli_bin,
         "agent",
@@ -387,6 +357,9 @@ def native_environment(
     ]
     selected = dict(profile or {})
     profile_id = str(selected.get("id") or f"kungfu.agent-runtime.{provider}")
+    work_control_profile = session_contract.qualified_work_control_profile(
+        runtime_dir, work_ref
+    )
     bootstrap_receipt = (
         agent_resources.native_bootstrap_receipt(
             provider,
@@ -422,6 +395,7 @@ def native_environment(
         },
         "bootstrap": bootstrap_context,
         "workSelection": dict(work_selection),
+        "activeProfiles": [dict(work_control_profile)] if work_control_profile else [],
         "terminal": {
             "stdioAttached": terminal_attached,
             "ambientTerm": ambient_term or None,
@@ -503,15 +477,8 @@ def native_environment(
             "attemptId": str(session_ref["sessionAttemptId"]),
             "runtimeProfileId": profile_id,
             "provider": provider,
-            "activeProfiles": (
-                [
-                    {
-                        "id": str(work_ref["profileId"]),
-                        "root": str(work_ref["profileRoot"]),
-                    }
-                ]
-                if work_ref is not None
-                else []
+            "activeProfiles": session_contract.active_profile_roots(
+                work_control_profile
             ),
             "workRef": dict(work_ref) if work_ref is not None else None,
             "entrypoints": {
@@ -635,6 +602,8 @@ def native_environment(
             env["KUNGFU_SKILL_WORK_REF"] = skill_work_ref
         if session_endpoint:
             env["KUNGFU_AGENT_SESSION_ENDPOINT"] = session_endpoint
+    if work_control_profile is not None:
+        env["KUNGFU_WORK_CONTROL_PROFILE_SOURCE"] = work_control_profile["source"]
     if work_ref is not None:
         env["KUNGFU_WORK_REF"] = json.dumps(
             dict(work_ref),

--- a/framework/core/src/python/kungfu/agent/run_agent.py
+++ b/framework/core/src/python/kungfu/agent/run_agent.py
@@ -38,7 +38,6 @@ from kungfu.agent.native_launch import (
     provider_interactive_argv as interactive_launch_argv,
     provider_runtime_health as _provider_runtime_health,
     resolve_command_wrapper as _resolve_windows_command_wrapper,
-    work_profile_inspection as _work_profile_inspection,
 )
 from kungfu.agent.provider_bootstrap import refresh_native_skill_runtime_audit
 from kungfu.agent.managed_run import ManagedRunCoordinator
@@ -149,14 +148,15 @@ def bind_current_native_work(
             binding_scope = "explicit-external-project"
 
     status = work_commands._status(work_runtime_dir, initiative_id, assignment_id)
-    work_control = _work_profile_inspection(
-        work_profile_source, work_commands.profile_source, work_runtime_dir
+    work_control = work_commands.profile_lifecycle.resolve_qualified_work_profile(
+        work_runtime_dir,
+        source=work_profile_source,
     )
     work_ref = {
         "schema": "kungfu.work-ref/v1",
         "workspaceId": work_workspace_id,
-        "profileId": work_control["profile"]["id"],
-        "profileRoot": work_control["profile_suite_root"],
+        "profileId": work_control["id"],
+        "profileRoot": work_control["root"],
         "entityType": "assignment",
         "entityId": assignment_id,
         "entityRoot": assignment_canonical.semantic_root(status["assignment"]),

--- a/framework/core/src/python/kungfu/agent/session_contract.py
+++ b/framework/core/src/python/kungfu/agent/session_contract.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
+import shutil
+from pathlib import Path
 from typing import Any, Mapping, overload
 
 
@@ -50,6 +53,59 @@ _ENVELOPE_FIELDS = {
     "envelopeRoot",
 }
 _ENVELOPE_REQUIRED_FIELDS = _ENVELOPE_FIELDS - {"bootstrap", "skillRuntimeAudit"}
+
+
+def native_cli_front_door(ambient: Mapping[str, Any], env: dict[str, str]) -> str:
+    """Resolve the executable Kungfu front door exposed to a native Agent."""
+
+    configured = str(ambient.get("KUNGFU_CLI_BIN") or "").strip()
+    candidate = configured or shutil.which(
+        "kungfu", path=str(ambient.get("PATH") or "")
+    )
+    if configured and not os.path.isabs(os.path.expanduser(configured)):
+        candidate = shutil.which(configured, path=str(ambient.get("PATH") or ""))
+    if not candidate:
+        return "kungfu"
+    cli_path = Path(candidate).expanduser().absolute()
+    if not cli_path.is_file() or not os.access(cli_path, os.X_OK):
+        raise ValueError("KUNGFU_CLI_BIN must identify an executable Kungfu front door")
+    env["KUNGFU_CLI_BIN"] = str(cli_path)
+    return str(cli_path)
+
+
+def qualified_work_control_profile(
+    runtime_dir: str, work_ref: Mapping[str, Any] | None
+):
+    """Resolve and verify the exact Work Control Profile for native launch."""
+
+    from kungfu.assignment_runtime import profile_lifecycle
+
+    profile = profile_lifecycle.resolve_qualified_work_profile(
+        runtime_dir, required=False
+    )
+    if work_ref is not None:
+        if profile is None:
+            raise ValueError(
+                "bound native Agent Console requires a qualified active Work Control Profile"
+            )
+        if (
+            str(work_ref.get("profileId") or "") != profile["id"]
+            or str(work_ref.get("profileRoot") or "") != profile["root"]
+        ):
+            raise ValueError(
+                "native Agent WorkRef does not match the exact qualified Work Control Profile root"
+            )
+    return profile
+
+
+def active_profile_roots(
+    profile: Mapping[str, Any] | None,
+) -> list[dict[str, str]]:
+    """Project a qualified profile into the public Agent Console envelope."""
+
+    if profile is None:
+        return []
+    return [{"id": str(profile["id"]), "root": str(profile["root"])}]
 
 
 def canonical_json(value: Any) -> str:

--- a/framework/core/src/python/kungfu/agent/session_surface.py
+++ b/framework/core/src/python/kungfu/agent/session_surface.py
@@ -240,6 +240,25 @@ def _active_work_profiles(work_ref):
     return [{"id": work_ref["profileId"], "root": work_ref["profileRoot"]}]
 
 
+def _qualified_active_work_profiles(runtime_dir, work_ref):
+    from kungfu.assignment_runtime import profile_lifecycle
+
+    profile = profile_lifecycle.resolve_qualified_work_profile(
+        runtime_dir, required=False
+    )
+    if work_ref is not None and (
+        profile is None
+        or work_ref.get("profileId") != profile["id"]
+        or work_ref.get("profileRoot") != profile["root"]
+    ):
+        raise ValueError(
+            "native Agent WorkRef does not match the exact qualified Work Control Profile root"
+        )
+    return (
+        [{"id": profile["id"], "root": profile["root"]}] if profile is not None else []
+    )
+
+
 class ReturnCodeResult(Protocol):
     returncode: int
 
@@ -720,7 +739,7 @@ def current_native_console(
         "attemptId": session["sessionAttemptId"],
         "runtimeProfileId": "kungfu.agent-runtime.codex.ambient",
         "provider": "codex",
-        "activeProfiles": _active_work_profiles(work_ref),
+        "activeProfiles": _qualified_active_work_profiles(target.runtime_dir, work_ref),
         "workRef": work_ref,
         "entrypoints": {
             "context": [cli_bin, "agent", "context", "--json"],

--- a/framework/core/src/python/kungfu/assignment_runtime/__init__.py
+++ b/framework/core/src/python/kungfu/assignment_runtime/__init__.py
@@ -126,7 +126,6 @@ def create_runtime_host_command(
             runtime_dir,
             realm_id=identity.workspace_id,
             generation=identity.identity_root,
-            profile_source=profile_source(),
         )
         try:
             serve(
@@ -411,7 +410,10 @@ class LocalAssignmentRuntimeApplication:
         self.runtime_dir = Path(runtime_dir).expanduser().resolve()
         self.client_id = _stable(client_id, "clientId")
         self.kind = kind
-        self.source = source or profile_source()
+        # A caller-provided source is an explicit recovery/install coordinate.
+        # Ordinary reads and commands resolve the qualified retained source from
+        # this exact runtime inside WorkControlAuthority.
+        self.source = source
         self.realm_id, self.generation = _workspace_realm(self.runtime_dir)
 
     def _runtime(self) -> EmbeddedLocalAssignmentRuntime:

--- a/framework/core/src/python/kungfu/assignment_runtime/authority.py
+++ b/framework/core/src/python/kungfu/assignment_runtime/authority.py
@@ -109,6 +109,13 @@ _COMMAND_BINDINGS = {
 _ASSESSMENT_EXECUTOR_PROFILES = {"inline", "thread", "process"}
 _PROCESS_WRITERS: set[str] = set()
 _PROCESS_WRITERS_GUARD = threading.Lock()
+_RETAINED_PROFILE_ERRORS = {
+    "work-control-profile-not-installed",
+    "work-control-profile-removed",
+    "work-control-profile-not-qualified",
+    "work-control-profile-source-unavailable",
+    "work-control-profile-source-root-drift",
+}
 
 
 def _root(value: Any) -> str:
@@ -369,15 +376,15 @@ class WorkControlAuthority:
         self._source = str(Path(source).resolve()) if source is not None else ""
 
     def _profile_source(self) -> str:
-        from kungfu import profile_sdk
+        from kungfu.assignment_runtime import profile_lifecycle
 
         if self._source:
+            from kungfu import profile_sdk
+
             profile_sdk.validate_source(self._source, self.runtime_dir)
             return self._source
-        discovered = profile_sdk.discover_source(
-            "kungfu.work-control", self.runtime_dir
-        )
-        self._source = str(discovered["source"])
+        resolved = profile_lifecycle.resolve_qualified_work_profile(self.runtime_dir)
+        self._source = str(resolved["source"])
         return self._source
 
     def _invoke(
@@ -397,45 +404,15 @@ class WorkControlAuthority:
                 inactive_projection_read=not write,
             )
         except profile_sdk.ProfileSdkError as error:
-            code = str(error.diagnosis.get("code") or "")
-            fallback = {
-                "member-resolution-failed": LocalRuntimeError(
-                    "ambiguous-identity",
-                    "Work Control authority does not resolve exactly once",
-                ),
-                "profile-member-ambiguous": LocalRuntimeError(
-                    "ambiguous-identity",
-                    "Work Control authority does not resolve exactly once",
-                ),
-                "profile-source-ambiguous": LocalRuntimeError(
-                    "ambiguous-identity",
-                    "Work Control authority does not resolve exactly once",
-                ),
-            }.get(
-                code,
-                LocalRuntimeError(
-                    "backend-unavailable",
-                    "Work Control authority is unavailable",
-                    diagnostics=[
-                        {
-                            "code": "work-control-unavailable",
-                            "message": "The exact active Work Control Profile could not be invoked",
-                            "severity": "error",
-                            "recovery": ["diagnostics.get", "recovery.plan"],
-                        }
-                    ],
-                ),
+            from kungfu.agent import native_authority
+
+            failure = native_authority.profile_adapter_runtime_failure(
+                error,
+                write=write,
+                operation=operation,
+                retained_codes=_RETAINED_PROFILE_ERRORS,
             )
-            raise {
-                (True, "member-adapter-invoke-failed", True): LocalRuntimeError(
-                    "invalid-command",
-                    str(error.__cause__),
-                    details={"operation": operation},
-                )
-            }.get(
-                (write, code, isinstance(error.__cause__, ValueError)),
-                fallback,
-            ) from error
+            raise LocalRuntimeError(**failure) from error
 
     @staticmethod
     def _record(row: Mapping[str, Any]) -> dict[str, Any]:

--- a/framework/core/src/python/kungfu/assignment_runtime/profile_lifecycle.py
+++ b/framework/core/src/python/kungfu/assignment_runtime/profile_lifecycle.py
@@ -6,10 +6,138 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal, NoReturn, overload
 
 from kungfu import profile_sdk
 from kungfu.storage import service as storage_service
+
+
+WORK_CONTROL_PROFILE_ID = "kungfu.work-control"
+
+
+def _missing_profile(runtime_dir: str | Path, message: str, **details: Any) -> NoReturn:
+    raise profile_sdk.ProfileSdkError(
+        details.pop("code"),
+        message,
+        profileId=WORK_CONTROL_PROFILE_ID,
+        runtimeDir=str(Path(runtime_dir).expanduser().resolve()),
+        **details,
+    )
+
+
+def _qualified_profile_state(
+    runtime_dir: str | Path, *, required: bool
+) -> dict[str, Any] | None:
+    try:
+        state = storage_service.profile_lifecycle(
+            runtime_dir, "get", profile_id=WORK_CONTROL_PROFILE_ID
+        )
+    except ValueError as error:
+        if not required and str(error).startswith("Profile not found:"):
+            return None
+        _missing_profile(
+            runtime_dir,
+            "Work Control Profile is not installed in the selected Project runtime",
+            code="work-control-profile-not-installed",
+        )
+    if state.get("removed"):
+        if not required:
+            return None
+        _missing_profile(
+            runtime_dir,
+            "Work Control Profile is removed from the selected Project runtime",
+            code="work-control-profile-removed",
+        )
+    if state.get("qualified") and state.get("activated"):
+        return state
+    if not required:
+        return None
+    _missing_profile(
+        runtime_dir,
+        "Work Control Profile must be qualified and active in the selected Project runtime",
+        code="work-control-profile-not-qualified",
+        qualified=bool(state.get("qualified")),
+        activated=bool(state.get("activated")),
+    )
+
+
+def _retained_profile_source(runtime_dir: str | Path, state: dict[str, Any]) -> Path:
+    closure = dict((state.get("latest_event") or {}).get("closure") or {})
+    profile_path = Path(str(closure.get("profile_path") or "")).expanduser()
+    if not profile_path.is_file():
+        _missing_profile(
+            runtime_dir,
+            "Qualified Work Control Profile retained source is unavailable",
+            code="work-control-profile-source-unavailable",
+            profilePath=str(profile_path),
+        )
+    return profile_path.resolve().parent
+
+
+@overload
+def resolve_qualified_work_profile(
+    runtime_dir: str | Path,
+    *,
+    required: Literal[True] = True,
+    source: str | Path | None = None,
+) -> dict[str, str]: ...
+
+
+@overload
+def resolve_qualified_work_profile(
+    runtime_dir: str | Path,
+    *,
+    required: Literal[False],
+    source: str | Path | None = None,
+) -> dict[str, str] | None: ...
+
+
+def resolve_qualified_work_profile(
+    runtime_dir: str | Path,
+    *,
+    required: bool = True,
+    source: str | Path | None = None,
+) -> dict[str, str] | None:
+    """Resolve the retained exact source for the qualified Work authority.
+
+    Profile lifecycle state, rather than the caller's ambient extension search
+    path, owns the source/root association.  This keeps a native Agent Console
+    usable when its ``KF_RUNTIME_DIR`` and an explicit Work ``--workspace`` are
+    different Projects.
+    """
+
+    state = _qualified_profile_state(runtime_dir, required=required)
+    if state is None:
+        return None
+    retained_source = _retained_profile_source(runtime_dir, state)
+    if source is not None and Path(source).expanduser().resolve() != retained_source:
+        raise profile_sdk.ProfileSdkError(
+            "work-control-profile-source-drift",
+            "Explicit Work Control Profile source does not match the qualified retained source",
+            profileId=WORK_CONTROL_PROFILE_ID,
+            retainedSource=str(retained_source),
+            observedSource=str(Path(source).expanduser().resolve()),
+        )
+    validated = profile_sdk.validate_source(retained_source, runtime_dir)
+    inspection = validated["inspection"]
+    profile_id = str((inspection.get("profile") or {}).get("id") or "")
+    profile_root = str(inspection.get("profile_suite_root") or "")
+    retained_root = str(state.get("profile_suite_root") or "")
+    if profile_id != WORK_CONTROL_PROFILE_ID or profile_root != retained_root:
+        raise profile_sdk.ProfileSdkError(
+            "work-control-profile-source-root-drift",
+            "Qualified Work Control Profile retained source no longer matches its exact root",
+            profileId=WORK_CONTROL_PROFILE_ID,
+            retainedRoot=retained_root,
+            observedProfileId=profile_id,
+            observedRoot=profile_root,
+            source=str(retained_source),
+        )
+    return {
+        "id": WORK_CONTROL_PROFILE_ID,
+        "root": retained_root,
+        "source": str(retained_source),
+    }
 
 
 def resolve_profile_source(

--- a/framework/core/tests/python/test_agent_console_ambient_adoption.py
+++ b/framework/core/tests/python/test_agent_console_ambient_adoption.py
@@ -97,6 +97,14 @@ def test_current_native_console_adopts_exact_ambient_process(monkeypatch, tmp_pa
     monkeypatch.setattr(
         session_surface, "resolve_workspace_target", lambda *_a, **_k: target
     )
+    monkeypatch.setattr(
+        "kungfu.assignment_runtime.profile_lifecycle.resolve_qualified_work_profile",
+        lambda *_args, **_kwargs: {
+            "id": "kungfu.work-control",
+            "root": ROOT_HASH,
+            "source": str(project / "extensions" / "work-control"),
+        },
+    )
     identity = process_identity()
     identity_root = session_contract.semantic_root(identity)
     requests = []
@@ -153,6 +161,10 @@ def test_current_native_console_adopts_exact_ambient_process(monkeypatch, tmp_pa
     assert current["source"] == "ambient-provider-session"
     assert current["processIdentityRoot"] == identity_root
     assert current["envelope"]["workspaceId"] == "project:exact"
+    assert current["envelope"]["workRef"] is None
+    assert current["envelope"]["activeProfiles"] == [
+        {"id": "kungfu.work-control", "root": ROOT_HASH}
+    ]
     assert "bootstrap" not in current["envelope"]
     session_contract.validate_agent_console_envelope(current["envelope"])
 
@@ -264,20 +276,19 @@ def test_public_bind_work_cli_selects_explicit_external_project(monkeypatch, tmp
         }
 
     monkeypatch.setattr("kungfu.cli.commands.assignment._status", status)
-    monkeypatch.setattr(
-        "kungfu.cli.commands.assignment.profile_source", lambda: tmp_path
-    )
 
-    def validate_source(_source, runtime_dir):
+    def resolve_profile(runtime_dir, **_kwargs):
         observed_runtime_dirs.append(runtime_dir)
         return {
-            "inspection": {
-                "profile": {"id": "kungfu.work-control"},
-                "profile_suite_root": ROOT_HASH,
-            }
+            "id": "kungfu.work-control",
+            "root": ROOT_HASH,
+            "source": str(tmp_path / "exact-work-control"),
         }
 
-    monkeypatch.setattr("kungfu.profile_sdk.validate_source", validate_source)
+    monkeypatch.setattr(
+        "kungfu.assignment_runtime.profile_lifecycle.resolve_qualified_work_profile",
+        resolve_profile,
+    )
 
     def invoke(request, **_kwargs):
         requests.append(request)

--- a/framework/core/tests/python/test_agent_console_contract.py
+++ b/framework/core/tests/python/test_agent_console_contract.py
@@ -1876,20 +1876,19 @@ def test_current_native_console_uses_project_runtime_when_cli_context_is_home(
         "kungfu.cli.commands.assignment._status",
         status,
     )
-    monkeypatch.setattr(
-        "kungfu.cli.commands.assignment.profile_source", lambda: tmp_path
-    )
 
-    def validate_source(_source, runtime_dir):
+    def resolve_profile(runtime_dir, **_kwargs):
         observed_runtime_dirs.append(runtime_dir)
         return {
-            "inspection": {
-                "profile": {"id": "kungfu.work-control"},
-                "profile_suite_root": ROOT_HASH,
-            }
+            "id": "kungfu.work-control",
+            "root": ROOT_HASH,
+            "source": str(tmp_path / "exact-work-control"),
         }
 
-    monkeypatch.setattr("kungfu.profile_sdk.validate_source", validate_source)
+    monkeypatch.setattr(
+        "kungfu.assignment_runtime.profile_lifecycle.resolve_qualified_work_profile",
+        resolve_profile,
+    )
 
     def invoke(request, **_kwargs):
         requests.append(request)
@@ -1963,16 +1962,12 @@ def test_public_bind_work_cli_preserves_stable_project_runtime_under_home(
         },
     )
     monkeypatch.setattr(
-        "kungfu.cli.commands.assignment.profile_source", lambda: tmp_path
-    )
-    monkeypatch.setattr(
-        "kungfu.profile_sdk.validate_source",
-        lambda _source, runtime_dir: {
-            "inspection": {
-                "profile": {"id": "kungfu.work-control"},
-                "profile_suite_root": ROOT_HASH,
-                "observedRuntimeDir": runtime_dir,
-            }
+        "kungfu.assignment_runtime.profile_lifecycle.resolve_qualified_work_profile",
+        lambda runtime_dir, **_kwargs: {
+            "id": "kungfu.work-control",
+            "root": ROOT_HASH,
+            "source": str(tmp_path / "exact-work-control"),
+            "observedRuntimeDir": runtime_dir,
         },
     )
 
@@ -2095,6 +2090,14 @@ def test_native_interactive_runner_reuses_work_console_with_fresh_attempts(
         lambda *_args, **_kwargs: {
             "schema": "kungfu.skill-context/v1",
             "catalog": [{"key": "kungfu-agent"}],
+        },
+    )
+    monkeypatch.setattr(
+        "kungfu.assignment_runtime.profile_lifecycle.resolve_qualified_work_profile",
+        lambda *_args, **_kwargs: {
+            "id": "kungfu.work-control",
+            "root": work_ref["profileRoot"],
+            "source": str(tmp_path / "exact-work-control"),
         },
     )
 

--- a/framework/core/tests/python/test_assignment_profile_source.py
+++ b/framework/core/tests/python/test_assignment_profile_source.py
@@ -4,7 +4,6 @@ import importlib
 import json
 from types import SimpleNamespace
 
-from kungfu import assignment_orchestration
 from kungfu.agent import run_agent
 from kungfu.workspace import resolve_workspace_target
 from agent_bootstrap_fixtures import verified_bootstrap_receipt
@@ -143,17 +142,62 @@ def test_claim_does_not_require_or_bind_agent_session(monkeypatch, tmp_path):
 
 
 def test_assignment_profile_source_prefers_native_source_layout(tmp_path, monkeypatch):
-    package = tmp_path / "package" / "kungfu"
-    package.mkdir(parents=True)
     checkout = tmp_path / "checkout"
     native = checkout / "extensions" / "work-control"
     native.mkdir(parents=True)
-    monkeypatch.setattr(assignment_orchestration, "__file__", package / "module.py")
+    extension_root = checkout / "extensions"
+    monkeypatch.setenv("KF_BUNDLED_EXTENSION_ROOT", str(extension_root))
+    monkeypatch.delenv("KF_EXTENSION_PATH", raising=False)
+
+    def discover(profile_id, *, search_roots):
+        assert profile_id == "kungfu.work-control"
+        assert search_roots == [extension_root]
+        return {"source": str(native)}
+
+    monkeypatch.setattr("kungfu.profile_sdk.discover_source", discover)
+
+    assert ASSIGNMENT_CLI.profile_source() == native
+
+
+def test_native_environment_injects_qualified_work_profile_without_binding(
+    monkeypatch, tmp_path
+):
+    runtime_dir = tmp_path / "project" / ".kungfu" / "runtime"
+    source = tmp_path / "installed" / "work-control"
     monkeypatch.setattr(
-        assignment_orchestration, "source_root", lambda *_starts: checkout
+        "kungfu.assignment_runtime.profile_lifecycle.resolve_qualified_work_profile",
+        lambda observed_runtime, **_kwargs: (
+            {
+                "id": "kungfu.work-control",
+                "root": ROOT_HASH,
+                "source": str(source),
+            }
+            if observed_runtime == str(runtime_dir)
+            else (_ for _ in ()).throw(AssertionError("wrong Project runtime"))
+        ),
     )
 
-    assert ASSIGNMENT_CLI._profile_source() == native
+    env = run_agent.native_environment(
+        "termagent",
+        runtime_dir=str(runtime_dir),
+        config_home=str(tmp_path / "config"),
+        runtime_home=str(tmp_path / "home"),
+        workspace_root=str(tmp_path / "project"),
+        work_ref=None,
+        work_selection={"schema": "kungfu.native-work-selection/v1", "state": "none"},
+        source={"PATH": "/usr/bin"},
+    )
+
+    context = json.loads(env["KUNGFU_AGENT_CONTEXT"])
+    assert context["workBinding"]["launchState"] == "unbound"
+    assert context["activeProfiles"] == [
+        {
+            "id": "kungfu.work-control",
+            "root": ROOT_HASH,
+            "source": str(source),
+        }
+    ]
+    assert env["KUNGFU_WORK_CONTROL_PROFILE_SOURCE"] == str(source)
 
 
 def test_agent_session_can_observe_work_from_explicit_external_project_and_profile(
@@ -198,25 +242,20 @@ def test_agent_session_can_observe_work_from_explicit_external_project_and_profi
         }
 
     monkeypatch.setattr(ASSIGNMENT_CLI, "_status", status)
-    monkeypatch.setattr(
-        ASSIGNMENT_CLI,
-        "profile_source",
-        lambda: (_ for _ in ()).throw(
-            AssertionError("explicit recovery source must not be rediscovered")
-        ),
-    )
 
-    def validate_source(source, runtime_dir):
-        assert source == work_profile_source.resolve()
+    def resolve_profile(runtime_dir, *, source=None, **_kwargs):
+        assert source == work_profile_source
         observed_runtime_dirs.append(runtime_dir)
         return {
-            "inspection": {
-                "profile": {"id": "kungfu.work-control"},
-                "profile_suite_root": ROOT_HASH,
-            }
+            "id": "kungfu.work-control",
+            "root": ROOT_HASH,
+            "source": str(work_profile_source.resolve()),
         }
 
-    monkeypatch.setattr("kungfu.profile_sdk.validate_source", validate_source)
+    monkeypatch.setattr(
+        "kungfu.assignment_runtime.profile_lifecycle.resolve_qualified_work_profile",
+        resolve_profile,
+    )
 
     def invoke(request, **_kwargs):
         requests.append(request)
@@ -247,3 +286,39 @@ def test_agent_session_can_observe_work_from_explicit_external_project_and_profi
         "plan-native-bind-work",
         "bind-native-work",
     ]
+
+
+def test_work_status_does_not_require_ambient_extension_search(monkeypatch, tmp_path):
+    status = {
+        "phase": "executing",
+        "assignment": {"assignment_id": "assignment:bound"},
+    }
+    monkeypatch.setattr(
+        ASSIGNMENT_CLI,
+        "profile_source",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("status must use the retained runtime Profile source")
+        ),
+    )
+    monkeypatch.setattr(
+        ASSIGNMENT_CLI.LocalAssignmentRuntimeApplication,
+        "status",
+        lambda self, initiative_id, assignment_id: dict(status),
+    )
+    monkeypatch.setattr(
+        "kungfu.assignment_runtime._workspace_realm",
+        lambda _runtime_dir: ("project:bound", ROOT_HASH),
+    )
+    monkeypatch.setattr(
+        ASSIGNMENT_CLI.orchestration,
+        "next_actions",
+        lambda value: [{"action": "stage", "phase": value["phase"]}],
+    )
+
+    result = ASSIGNMENT_CLI._status(
+        str(tmp_path / "work-runtime"),
+        "initiative:bound",
+        "assignment:bound",
+    )
+
+    assert result["next_actions"] == [{"action": "stage", "phase": "executing"}]

--- a/framework/core/tests/python/test_assignment_runtime.py
+++ b/framework/core/tests/python/test_assignment_runtime.py
@@ -790,12 +790,22 @@ def test_work_control_authority_normalizes_legacy_completion_context_roots(
     authority = WorkControlAuthority(tmp_path, source=PROFILE_SOURCE)
     captured = {}
 
-    def invoke(_source, _runtime, member, operation, values, *, authorized_action):
+    def invoke(
+        _source,
+        _runtime,
+        member,
+        operation,
+        values,
+        *,
+        authorized_action,
+        inactive_projection_read,
+    ):
         captured.update(
             member=member,
             operation=operation,
             values=values,
             write=authorized_action,
+            inactiveProjectionRead=inactive_projection_read,
         )
         return {"result": {"coreReceipt": {"status": "admitted"}}}
 
@@ -829,6 +839,7 @@ def test_work_control_authority_normalizes_legacy_completion_context_roots(
             "resultContextRoot": ROOT_B,
         },
         "write": True,
+        "inactiveProjectionRead": False,
     }
 
 
@@ -838,12 +849,22 @@ def test_work_semantics_commands_bind_exact_runtime_attempt_and_lease(
     authority = WorkControlAuthority(tmp_path, source=PROFILE_SOURCE)
     captured = {}
 
-    def invoke(_source, _runtime, member, operation, values, *, authorized_action):
+    def invoke(
+        _source,
+        _runtime,
+        member,
+        operation,
+        values,
+        *,
+        authorized_action,
+        inactive_projection_read,
+    ):
         captured.update(
             member=member,
             operation=operation,
             values=values,
             write=authorized_action,
+            inactiveProjectionRead=inactive_projection_read,
         )
         return {"result": {"coreReceipt": {"status": "admitted"}}}
 
@@ -879,6 +900,7 @@ def test_work_semantics_commands_bind_exact_runtime_attempt_and_lease(
             "leaseId": "lease-a",
         },
         "write": True,
+        "inactiveProjectionRead": False,
     }
 
 
@@ -1586,7 +1608,9 @@ def test_restart_recovers_legacy_completion_roots_without_rewriting_command_iden
         values,
         *,
         authorized_action=False,
+        inactive_projection_read=False,
     ):
+        assert inactive_projection_read is (not authorized_action)
         if operation == "portfolio":
             return {
                 "result": {

--- a/framework/core/tests/python/test_run_product_path.py
+++ b/framework/core/tests/python/test_run_product_path.py
@@ -1757,6 +1757,14 @@ def test_managed_session_retains_its_visible_terminal_answer(tmp_path, monkeypat
         "verify_profile",
         lambda _profile: {"ok": True, "version": "0.147.0"},
     )
+    monkeypatch.setattr(
+        "kungfu.assignment_runtime.profile_lifecycle.resolve_qualified_work_profile",
+        lambda *_args, **_kwargs: {
+            "id": "kungfu.work-control",
+            "root": "sha256:" + "1" * 64,
+            "source": str(tmp_path / "exact-work-control"),
+        },
+    )
 
     result = run_agent.execute(
         prompt="inspect README",
@@ -1815,6 +1823,14 @@ def test_direct_provider_starts_native_work_before_process_launch(
         run_agent.runtime_profiles,
         "verify_profile",
         lambda _profile: {"ok": True, "version": "arbitrary-version"},
+    )
+    monkeypatch.setattr(
+        "kungfu.assignment_runtime.profile_lifecycle.resolve_qualified_work_profile",
+        lambda *_args, **_kwargs: {
+            "id": "kungfu.work-control",
+            "root": work_ref["profileRoot"],
+            "source": str(tmp_path / "exact-work-control"),
+        },
     )
 
     def start_work(ref, started):

--- a/framework/core/tests/python/test_work_authority_surface.py
+++ b/framework/core/tests/python/test_work_authority_surface.py
@@ -13,12 +13,78 @@ from kungfu import (
     assignment_review_lifecycle,
 )
 from kungfu.assignment_runtime import fresh_recovery as assignment_fresh_recovery
+from kungfu.assignment_runtime import profile_lifecycle
+from kungfu.assignment_runtime.authority import LocalRuntimeError, WorkControlAuthority
 from kungfu.cli.commands import __registry__  # noqa: F401
 from kungfu.cli.commands import assignment_review
 from kungfu.cli.commands import kfc
 from kungfu.agent import run_agent, session_contract
 
 assignment_command = importlib.import_module("kungfu.cli.commands.assignment")
+
+
+def test_qualified_work_profile_resolves_retained_exact_source(monkeypatch, tmp_path):
+    source = tmp_path / "installed" / "work-control"
+    source.mkdir(parents=True)
+    (source / "profile.json").write_text("{}\n", encoding="utf-8")
+    profile_root = f"sha256:{'a' * 64}"
+    monkeypatch.setattr(
+        profile_lifecycle.storage_service,
+        "profile_lifecycle",
+        lambda *_args, **_kwargs: {
+            "profile_suite_root": profile_root,
+            "qualified": True,
+            "activated": True,
+            "removed": False,
+            "latest_event": {"closure": {"profile_path": str(source / "profile.json")}},
+        },
+    )
+    monkeypatch.setattr(
+        profile_lifecycle.profile_sdk,
+        "validate_source",
+        lambda observed_source, observed_runtime: (
+            {
+                "inspection": {
+                    "profile": {"id": "kungfu.work-control"},
+                    "profile_suite_root": profile_root,
+                }
+            }
+            if observed_source == source.resolve() and observed_runtime == tmp_path
+            else (_ for _ in ()).throw(AssertionError("source/runtime drift"))
+        ),
+    )
+
+    assert profile_lifecycle.resolve_qualified_work_profile(tmp_path) == {
+        "id": "kungfu.work-control",
+        "root": profile_root,
+        "source": str(source.resolve()),
+    }
+
+
+def test_missing_work_profile_has_specific_fail_closed_diagnosis(monkeypatch, tmp_path):
+    def missing(*_args, **_kwargs):
+        raise ValueError("Profile not found: kungfu.work-control")
+
+    monkeypatch.setattr(profile_lifecycle.storage_service, "profile_lifecycle", missing)
+
+    with __import__("pytest").raises(
+        profile_lifecycle.profile_sdk.ProfileSdkError,
+        match="Work Control Profile is not installed",
+    ) as error:
+        profile_lifecycle.resolve_qualified_work_profile(tmp_path)
+
+    assert error.value.diagnosis["code"] == "work-control-profile-not-installed"
+
+    with __import__("pytest").raises(
+        LocalRuntimeError,
+        match="Work Control Profile is not installed",
+    ) as runtime_error:
+        WorkControlAuthority(tmp_path).inspect()
+
+    assert runtime_error.value.code == "backend-unavailable"
+    assert runtime_error.value.diagnostics[0]["code"] == (
+        "work-control-profile-not-installed"
+    )
 
 
 def test_click_tree_exposes_one_work_family_and_no_assignment_alias():

--- a/scripts/run-agent-console-contract-tests.mjs
+++ b/scripts/run-agent-console-contract-tests.mjs
@@ -55,6 +55,14 @@ const result = spawnSync(
       'core',
       'tests',
       'python',
+      'test_assignment_profile_source.py',
+    ),
+    path.join(
+      root,
+      'framework',
+      'core',
+      'tests',
+      'python',
       'test_agent_native_terminal_contract.py',
     ),
     path.join(


### PR DESCRIPTION
## Summary

Restore native Agent Work Control authority when a Console starts unbound with `activeProfiles=[]` and `workRef=null`.

## Related issue

Native Work Control binding recovery regression.

## Changes

- Resolve the installed, activated, and qualified `kungfu.work-control` Profile from the target runtime lifecycle and retain its exact source and root.
- Project that exact Profile into native Agent bootstrap/context surfaces even before a Work binding exists.
- Use the same exact qualified Profile for `agent console bind-work`, Work authority reads, and post-bind status.
- Keep binding and fresh-recovery fail closed on Profile/root drift, missing qualification, single-writer conflicts, and SessionAttempt identity.
- Add focused regression coverage for distinct `KF_RUNTIME_DIR`/workspace roots, qualified active Profiles, unbound Consoles, post-bind status, missing Profiles, and root-preserving fresh recovery.

## Verification

- `./shifu test:agent-console-contract` — 140 passed, 3 skipped.
- `./shifu test:work-authority` — 17 Node and 28 Python tests passed.
- `./shifu test:assignment-runtime` — 41 Node, 53 Python, and 2 runtime-service tests passed.
- `./shifu test:project-work-runtime` — 76 passed.
- Exact mypy 1.20.2 — 264 source files passed.
- `python3 scripts/check-agent-python-responsibility-map.py` — 1204 lines and 34 responsibilities conserved.
- `./shifu check:source` — passed.
- Commit hooks and DCO — passed.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded bug fix restores the existing exact-root Profile, WorkRef, single-writer, and SessionAttempt contracts without changing an architecture decision or release channel."
}
-->

## Evolution Map impact

Evolution impact: extends

This adds implementation and regression evidence to the current Work Control stage; it does not open, settle, supersede, or renumber an Evolution authority.

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation is unchanged because this restores the existing public contract and adds regression coverage.