### PR TITLE
fix(product): expose packaged Agent Session entry

### DIFF
--- a/product/scripts/cli-launcher.mjs
+++ b/product/scripts/cli-launcher.mjs
@@ -11,6 +11,7 @@ export function cliLauncherContent(platform = process.platform) {
       'set "KF_BUNDLED_EXTENSION_ROOT=%~dp0extensions"',
       'set "KUNGFU_CLI_BIN=%~dp0kungfu.cmd"',
       'set "KUNGFU_AGENT_SESSION_EXECUTABLE=%~dp0runtime\\kungfu.exe"',
+      'set "KUNGFU_NATIVE_AGENT_SESSION_ENTRY=%~dp0tui\\native-agent-session.mjs"',
       'set "KUNGFU_CONTROLLER_ENTRYPOINT=%~dp0runtime\\kungfu.exe"',
       'set "PYTHONUTF8=1"',
       'set "PYTHONIOENCODING=utf-8"',
@@ -36,6 +37,7 @@ export KUNGFU_UPGRADE_MANIFEST="$here/upgrade/kungfu-release-manifest.json"
 export KF_BUNDLED_EXTENSION_ROOT="$here/extensions"
 export KUNGFU_CLI_BIN="$here/kungfu"
 export KUNGFU_AGENT_SESSION_EXECUTABLE="$here/runtime/kungfu"
+export KUNGFU_NATIVE_AGENT_SESSION_ENTRY="$here/tui/native-agent-session.mjs"
 export KUNGFU_CONTROLLER_ENTRYPOINT="$here/runtime/kungfu"
 exec "$here/runtime/kungfu" "$@"
 `;

--- a/product/scripts/cli-launcher.test.mjs
+++ b/product/scripts/cli-launcher.test.mjs
@@ -17,6 +17,10 @@ test('CLI launchers defer install ownership to the colocated product manifest', 
     posix,
     /KUNGFU_AGENT_SESSION_EXECUTABLE="\$here\/runtime\/kungfu"/,
   );
+  assert.match(
+    posix,
+    /KUNGFU_NATIVE_AGENT_SESSION_ENTRY="\$here\/tui\/native-agent-session\.mjs"/,
+  );
   assert.match(posix, /KUNGFU_CONTROLLER_ENTRYPOINT="\$here\/runtime\/kungfu"/);
   assert.match(posix, /while \[ -L "\$target" \]/);
   assert.match(posix, /exec "\$here\/runtime\/kungfu" "\$@"/);
@@ -31,6 +35,10 @@ test('CLI launchers defer install ownership to the colocated product manifest', 
   assert.match(
     windows,
     /KUNGFU_AGENT_SESSION_EXECUTABLE=%~dp0runtime\\kungfu\.exe/,
+  );
+  assert.match(
+    windows,
+    /KUNGFU_NATIVE_AGENT_SESSION_ENTRY=%~dp0tui\\native-agent-session\.mjs/,
   );
   assert.match(
     windows,


### PR DESCRIPTION
## Summary

Expose the packaged native Agent Session entry through the public CLI launchers so an installed Kungfu product can open an interactive Agent Console and execute the already-merged fresh-recovery protocol.

This is a launcher wiring fix only. It does not change Assignment lifecycle semantics, recovery-plan contents, WorkRef resolution, or release assets.

## Related issue

Follow-up acceptance gap found while validating the merged fresh Console recovery flow.

## Changes

- export `KUNGFU_NATIVE_AGENT_SESSION_ENTRY` from the POSIX packaged launcher
- set the same entry from the Windows packaged launcher
- assert both launcher contracts in the focused unit test

## Verification

- `./shifu exec node --test product/scripts/cli-launcher.test.mjs` (2/2 passed)
- staged Kungfu pre-commit/source gate passed for commit `4b5ee7b0bc812ef0243c31b99c7886b654cf406a`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This maintenance fix exposes an already-packaged Agent Session entry and does not alter an architecture contract."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Boundary: this changes only the environment exported by generated package launchers. CI and post-merge local product acceptance will verify that the colocated native Agent Session entry resolves without changing release identity or publishing any tag.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (no public syntax or documented behavior changed)
