### PR TITLE
refactor(terminal): bound JSON observation parsing

### DIFF
--- a/framework/maintainability/terminal-evidence-matrix.test.mjs
+++ b/framework/maintainability/terminal-evidence-matrix.test.mjs
@@ -606,6 +606,17 @@ test('live observation parser preserves object and array authority payloads', ()
     [{ id: 1 }, { id: 2 }],
   );
   assert.deepEqual(
+    parseCommandJson(
+      '{"stale":true}\n[unfinished diagnostic\n  {"ok":true}\n',
+      'latest object',
+    ),
+    { ok: true },
+  );
+  assert.throws(
+    () => parseCommandJson('[unfinished diagnostic\n', 'broken tool'),
+    /broken tool did not return a terminal JSON document/u,
+  );
+  assert.deepEqual(
     parseTerminalReviewAttestation('{"schema":"test","ok":true}'),
     { schema: 'test', ok: true },
   );

--- a/framework/terminal-evidence/live-observations.mjs
+++ b/framework/terminal-evidence/live-observations.mjs
@@ -14,6 +14,7 @@ const ROOT = path.resolve(
   '../..',
 );
 const ROOT_PATTERN = /^sha256:[0-9a-f]{64}$/u;
+const TERMINAL_JSON_START_PATTERN = /(?:^|\n)\s*([\[{])/gu;
 
 function command(program, args, cwd = ROOT) {
   const result = spawnSync(program, args, {
@@ -35,7 +36,7 @@ function command(program, args, cwd = ROOT) {
 
 function jsonOutput(output, label) {
   const starts = [];
-  for (const match of output.matchAll(/(?:^|\n)\s*([\[{])/gu)) {
+  for (const match of output.matchAll(TERMINAL_JSON_START_PATTERN)) {
     starts.push((match.index || 0) + match[0].lastIndexOf(match[1]));
   }
   for (const start of starts.reverse()) {


### PR DESCRIPTION
## Summary

Keep terminal evidence JSON parsing behavior unchanged while moving its start matcher outside `jsonOutput`, so the maintained source analyzer no longer consumes the remainder of the module as one function.

## Related issue

Native Assignment: `2026-08-27-kungfu-terminal-evidence-complexity-wave4`

## Changes

- Preserve latest terminal JSON object/array selection, stdout/stderr boundaries, labels, errors, cache, timing, roots, and fail-closed behavior.
- Add adversarial coverage for malformed bracket-prefixed diagnostics before a valid terminal document.
- Reduce `jsonOutput` base risk from 807 to 21 and the terminal-evidence owner aggregate from 1753 to 967 without transferring a hotspot.

## Verification

- `node --test framework/maintainability/terminal-evidence-matrix.test.mjs` — 11/11 passed
- generated report authority tests — 42/42 passed
- function-risk report — 0 blocking findings; owner `>100` count 4 to 3; global `>500` 4 to 3, `>300` 25 to 24, `>100` 315 to 314
- staged repository gate passed before commit

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "dev-delivery",
  "intent": "stage-ready",
  "adrs": ["KF-ADR-019f9f04-f8bd-7002-a702-1b9f66827ec0"],
  "summary": "Preserve exact-head terminal evidence semantics while completing a bounded maintainability stage.",
  "verification": ["terminal evidence parser contract tests", "generated report authority tests", "function-risk report", "staged repository gate"]
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The parser remains behavior-identical; only its module-scoped matcher placement and adversarial tests change.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed — no behavior or public contract changed

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6IjIwMjYtMDgtMjcta3VuZ2Z1LWNvbXBsZXhpdHktZGVidC13YXZlNCIsImFzc2lnbm1lbnRJZCI6IjIwMjYtMDgtMjcta3VuZ2Z1LXRlcm1pbmFsLWV2aWRlbmNlLWNvbXBsZXhpdHktd2F2ZTQiLCJkZWxpdmVyeUNsYXNzIjoibm9uLW5hdGl2ZS1mYXN0IiwiZGV2SGVhZCI6Ijg1YTVlNzhhMzFhODQ1MmUzNzVhNWFjZDAwZjcxZWM4YWQ4MmYyNDciLCJwdWxsUmVxdWVzdEhlYWQiOiIyZjk0ZmU1NWQwN2M2YWJkOTg2YzZlNmM3NGEyNzg5MzE5MDRmYWViIiwicmVwbGF5ZWRDYW5kaWRhdGUiOiJhZGYxZTFkNmU3NmJmNDQwNzNiMDJlZmFlNzFiNmFiNmI2YjExMmY2IiwicmVwbGF5ZWRUcmVlIjoiNTBlNWFjMjQ3NWVmNTlkODBkNjNmZDQ4ZjViY2JiMDU1MDk0NTg5OSIsInF1ZXVlQXR0ZW1wdCI6IjJmOTRmZTU1ZDA3YzZhYmQ5ODZjNmU2Yzc0YTI3ODkzMTkwNGZhZWJAODVhNWU3OGEzMWE4NDUyZTM3NWE1YWNkMDBmNzFlYzhhZDgyZjI0NyIsImFkbWlzc2lvblByb29mUm9vdCI6InNoYTI1Njo3NTE1YzEzNmU1OTZiYmYwNmY0NGFhOTFlNjI0ZWVlM2ZiNWM4YTY5ZTYwNzJlZDY1YmY5MjI0MDVlMzBjOGE1IiwiYWRtaXNzaW9uUHJvb2ZSb290cyI6WyJzaGEyNTY6NzUxNWMxMzZlNTk2YmJmMDZmNDRhYTkxZTYyNGVlZTNmYjVjOGE2OWU2MDcyZWQ2NWJmOTIyNDA1ZTMwYzhhNSIsInNoYTI1NjplOWIxZDE3ZGRjNDAyZGQ0NGNjOTAxYjQyMWIyOWUyOTU2MWQ1OTA1MzdiMDdhMjQ4MTU0MWQ1NmRlNGU0YjJiIl0sInN0YXR1c0NvbnRleHQiOiJRdWV1ZSBmYW1pbHkgbGVhc2UvZDNiMmU4ODNiMDc1NjM2OSIsImxlYXNlUm9vdCI6InNoYTI1Njo4NGE5MTYwZGZlZjU4ZjUzNDIwYjQyYmY4ZmQwZjc5YzcxNWQyZjg5YTkwODg2OGQ4MmI5MDg5MzhhZmM4YTc3In0 -->