### PR TITLE
fix(profile): retain history across contract narrowing

### DIFF
--- a/framework/core/src/python/kungfu/profile_composition.py
+++ b/framework/core/src/python/kungfu/profile_composition.py
@@ -571,25 +571,11 @@ def contract_materialization_plan(
     )
     _validate_contract_material(inspection["profile"], composed, artifact)
     current = storage_service.fact_type_list(runtime_dir)
-    fact_state = storage_service.fact_state(runtime_dir)
-    admitted_sources: dict[tuple[str, str, str], set[str]] = {}
-    for row in fact_state.get("observation_history") or []:
-        if row.get("outcome") != "admitted":
-            continue
-        key = (
-            str(row.get("fact_surface_id") or ""),
-            str(row.get("schema_owner_root") or ""),
-            str(row.get("contract_world_id") or ""),
-        )
-        source_id = str(row.get("source_id") or "")
-        if all(key) and source_id:
-            admitted_sources.setdefault(key, set()).add(source_id)
     operations = contract_operations(
         artifact,
         current,
         fail=_fail,
         root=_root,
-        admitted_sources=admitted_sources,
     )
     identity = {
         "source": str(Path(source).resolve()),

--- a/framework/core/src/python/kungfu/profile_sdk_kfd3.py
+++ b/framework/core/src/python/kungfu/profile_sdk_kfd3.py
@@ -788,7 +788,6 @@ def contract_operations(
     *,
     fail: Callable[..., NoReturn],
     root: Callable[[Any], str],
-    admitted_sources: Mapping[tuple[str, str, str], set[str]],
 ) -> list[dict[str, str]]:
     world = artifact["contractWorld"]
     same_world = [
@@ -822,20 +821,11 @@ def contract_operations(
                     "contract-world-incompatible",
                     "existing contract world has another fact-surface register",
                 )
-            retired_with_facts = sorted(
-                surface_id
-                for surface_id in existing_surface_ids - declared_surface_ids
-                if any(
-                    key[0] == surface_id and key[2] == world["id"] and sources
-                    for key, sources in admitted_sources.items()
-                )
-            )
-            if retired_with_facts:
-                fail(
-                    "contract-world-surface-migration-required",
-                    "removed fact surfaces retain admitted facts and require an explicit migration",
-                    admittedFactSurfaces=retired_with_facts,
-                )
+            # A strict Profile narrowing retires the omitted surface from
+            # the current Profile without mutating the append-only Fact
+            # catalog.  The durable contract-world registration and every
+            # admitted fact remain available as historical evidence.  Only an
+            # expansion or reinterpretation requires an explicit migration.
     operations = []
     if not same_world:
         operations.append(
@@ -898,18 +888,10 @@ def contract_operations(
                     "existing fact surface differs from the Profile declaration",
                     factSurface=surface["id"],
                 )
-            observed_authorities = admitted_sources.get(
-                (surface["id"], schema_root, world["id"]),
-                set(),
-            )
-            retired_with_facts = sorted(observed_authorities - declared_authorities)
-            if retired_with_facts:
-                fail(
-                    "fact-surface-authority-migration-required",
-                    "removed source authorities retain admitted facts and require an explicit migration",
-                    factSurface=surface["id"],
-                    admittedSourceAuthorities=retired_with_facts,
-                )
+            # Retiring a writer from the current Profile does not rewrite the
+            # immutable Fact-surface registration.  Historical observations
+            # admitted by that writer stay readable, while the current Profile
+            # no longer exposes a route that can use the retired authority.
         else:
             operations.append(
                 {

--- a/framework/core/tests/python/test_profile_composition.py
+++ b/framework/core/tests/python/test_profile_composition.py
@@ -993,7 +993,9 @@ def test_contract_accepts_authority_narrowing_without_retired_source_facts(tmp_p
     )
 
 
-def test_contract_rejects_authority_narrowing_with_retired_source_facts(tmp_path):
+def test_contract_retains_history_when_current_profile_retires_a_source_authority(
+    tmp_path,
+):
     source = _dynamic_source(tmp_path)
     runtime = tmp_path / "runtime"
     _set_work_item_authorities(source, ["retired-owner", "workspace-owner"])
@@ -1022,12 +1024,16 @@ def test_contract_rejects_authority_narrowing_with_retired_source_facts(tmp_path
     _set_work_item_authorities(source, ["workspace-owner"])
     _upgrade(source, runtime)
 
-    with pytest.raises(profile_sdk.ProfileSdkError) as raised:
-        profile_composition.contract_materialization_plan(source, runtime)
-    assert raised.value.diagnosis["code"] == (
-        "fact-surface-authority-migration-required"
-    )
-    assert raised.value.diagnosis["admittedSourceAuthorities"] == ["retired-owner"]
+    plan = profile_composition.contract_materialization_plan(source, runtime)
+    assert plan["operations"] == []
+    catalog = storage_service.fact_type_list(runtime)
+    work_item = next(row for row in catalog["fact_types"] if row["id"] == "work-item")
+    assert set(work_item["source_authorities"]) == {
+        "retired-owner",
+        "workspace-owner",
+    }
+    history = storage_service.fact_state(runtime)["observation_history"]
+    assert any(row["observation_id"] == "week-1-retired" for row in history)
 
 
 def test_contract_accepts_surface_narrowing_without_retired_surface_facts(tmp_path):
@@ -1070,7 +1076,9 @@ def test_contract_rejects_surface_register_expansion(tmp_path):
     assert raised.value.diagnosis["code"] == "contract-world-incompatible"
 
 
-def test_contract_rejects_surface_narrowing_with_retired_surface_facts(tmp_path):
+def test_contract_retains_history_when_current_profile_retires_a_fact_surface(
+    tmp_path,
+):
     source = _dynamic_source(tmp_path)
     runtime = tmp_path / "runtime"
     _set_retired_fact_surface(source, present=True)
@@ -1099,9 +1107,9 @@ def test_contract_rejects_surface_narrowing_with_retired_surface_facts(tmp_path)
     _set_retired_fact_surface(source, present=False)
     _upgrade(source, runtime)
 
-    with pytest.raises(profile_sdk.ProfileSdkError) as raised:
-        profile_composition.contract_materialization_plan(source, runtime)
-    assert raised.value.diagnosis["code"] == (
-        "contract-world-surface-migration-required"
-    )
-    assert raised.value.diagnosis["admittedFactSurfaces"] == ["retired-item"]
+    plan = profile_composition.contract_materialization_plan(source, runtime)
+    assert plan["operations"] == []
+    catalog = storage_service.fact_type_list(runtime)
+    assert any(row["id"] == "retired-item" for row in catalog["fact_types"])
+    history = storage_service.fact_state(runtime)["observation_history"]
+    assert any(row["observation_id"] == "retired-1-retained" for row in history)


### PR DESCRIPTION
## Summary

- Treat strict current-Profile narrowing as a no-op for durable catalog compatibility.
- Preserve retired registrations, source authorities, and admitted observations as immutable history.
- Keep expansions, version changes, and schema reinterpretation fail-closed.

## Verification

- ./shifu test:profile-lifecycle
- ./shifu test:kfx-profile-suite
- ./shifu check
- Packaged CLI real-Home query: 765 components, 98 current/available, stable catalog cut, zero unresolved references.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix preserves durable history while narrowing the current Profile contract and does not alter an architecture decision."
}
-->

## Evolution

Evolution impact: none.

## Governance

No governance boundary changes. DCO sign-off is present.

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA4LTI3LWt1bmdmdS1kb2dmb29kLXF1ZXVlLWNsb3N1cmUiLCJkZWxpdmVyeUNsYXNzIjoibmF0aXZlLXByb29mLXJlcXVpcmVkIiwiZGV2SGVhZCI6IjEyZjkxMjNjODQ0MTgxZTRiNGFjMmNiOWM2OTIyMGExYTk5MzA2MDQiLCJwdWxsUmVxdWVzdEhlYWQiOiI3NmQ0ZGJkY2U5NjcwZTVmZTczZWYzM2Y1NWU1ZTMwNDhhNzNiYzhmIiwicmVwbGF5ZWRDYW5kaWRhdGUiOiJkOGY4YjIxMWNiM2NhYmU0OWNhNzYzNTg4NzVhMDYwZTk3Y2M0OTc3IiwicmVwbGF5ZWRUcmVlIjoiZTBjZjE1MDM5YWRjNGUwM2ZkYjMxYzA0ZGNkOTg5NTIzYTBhZDgxYSIsInF1ZXVlQXR0ZW1wdCI6Ijc2ZDRkYmRjZTk2NzBlNWZlNzNlZjMzZjU1ZTVlMzA0OGE3M2JjOGZAMTJmOTEyM2M4NDQxODFlNGI0YWMyY2I5YzY5MjIwYTFhOTkzMDYwNCIsImFkbWlzc2lvblByb29mUm9vdCI6InNoYTI1Njo4ZjkxMGE3YTFhNmRiMTMzYzRjYjY0NzkzYjMyZjBjZmRlMWYxZWJmOTk3Y2RjN2FlNTAyMWQzNmY1YWViODU4IiwiYWRtaXNzaW9uUHJvb2ZSb290cyI6WyJzaGEyNTY6OGY5MTBhN2ExYTZkYjEzM2M0Y2I2NDc5M2IzMmYwY2ZkZTFmMWViZjk5N2NkYzdhZTUwMjFkMzZmNWFlYjg1OCIsInNoYTI1NjpkZmVmMWE1OGUxNDljMjZjZTFiZGU2OWJkNmRiODI5MjA1ZDY4MGQ3YTQ1NGVjZWQwOWQ1NzNlZjBkMmRjMTk5Il0sInN0YXR1c0NvbnRleHQiOiJRdWV1ZSBmYW1pbHkgbGVhc2UvZDk5ZjNhOTE2NjczOWUwZCIsImxlYXNlUm9vdCI6InNoYTI1Njo0OTU0YjVmYjYzYTY3OGVjYmZlNDkxMmJhYzk2NzY3MGE5ODA1ZmI4M2FhNmVmYTg0ODliMjc2NWQ0Njk1MDRkIn0 -->