### PR TITLE
refactor(tooling): split catalog validation responsibilities

### DIFF
--- a/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -79,7 +79,7 @@
       "pointer": {
         "kind": "file",
         "path": "scripts/check-cli-catalog-parity.mjs",
-        "sha256": "c0811cc4588265a0601cba2a42b8c72278ba36c7b487e2ef4cc245dfe7284b9a"
+        "sha256": "6dcbb9e11144a1f2175ffb3e9a16d54fa023d6e8591366907b3b8f9b728b69e8"
       },
       "description": "Build-free source-acceptance verifier for surface roots and Human, Agent, KFD-3, docs, skills, GUI, and package consumers."
     },
@@ -145,7 +145,7 @@
       },
       {
         "path": "scripts/check-cli-catalog-parity.mjs",
-        "sha256": "c0811cc4588265a0601cba2a42b8c72278ba36c7b487e2ef4cc245dfe7284b9a"
+        "sha256": "6dcbb9e11144a1f2175ffb3e9a16d54fa023d6e8591366907b3b8f9b728b69e8"
       },
       {
         "path": "scripts/qualify-agent-first-value-codex.mjs",

--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.3",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.3",
-    "sourceSha": "abafce0bac53662def68787ef8e6c7186bf770d1"
+    "sourceSha": "12f9123c844181e4b4ac2cb9c69220a1a9930604"
   },
   "claims": [
     {
@@ -92,7 +92,7 @@
           "pointer": {
             "kind": "file",
             "path": "scripts/check-cli-catalog-parity.mjs",
-            "sha256": "c0811cc4588265a0601cba2a42b8c72278ba36c7b487e2ef4cc245dfe7284b9a"
+            "sha256": "6dcbb9e11144a1f2175ffb3e9a16d54fa023d6e8591366907b3b8f9b728b69e8"
           },
           "description": "Build-free source-acceptance verifier for surface roots and Human, Agent, KFD-3, docs, skills, GUI, and package consumers."
         },

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "abafce0bac53662def68787ef8e6c7186bf770d1",
+    "sourceSha": "12f9123c844181e4b4ac2cb9c69220a1a9930604",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:94e3051ed06b5e852b46f3572d28fa36682ee989f6ab4a618993863e8ae33288"
   },

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-          "sha256": "sha256:aaa6d1ddfd678628c7d6203dd657b62c45d2637f814fb82b33ee6c2d9d779d30"
+            "sha256": "sha256:2f16dcaf35ab2f7f8ee0a13cca31f36264818bb14eb6d082fac39862f18d7e51"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
+++ b/developer/sdk/kfd/kfd-2/claims/agent-onboarding-pack.json
@@ -79,7 +79,7 @@
       "pointer": {
         "kind": "file",
         "path": "scripts/check-cli-catalog-parity.mjs",
-        "sha256": "c0811cc4588265a0601cba2a42b8c72278ba36c7b487e2ef4cc245dfe7284b9a"
+        "sha256": "6dcbb9e11144a1f2175ffb3e9a16d54fa023d6e8591366907b3b8f9b728b69e8"
       },
       "description": "Build-free source-acceptance verifier for surface roots and Human, Agent, KFD-3, docs, skills, GUI, and package consumers."
     },
@@ -145,7 +145,7 @@
       },
       {
         "path": "scripts/check-cli-catalog-parity.mjs",
-        "sha256": "c0811cc4588265a0601cba2a42b8c72278ba36c7b487e2ef4cc245dfe7284b9a"
+        "sha256": "6dcbb9e11144a1f2175ffb3e9a16d54fa023d6e8591366907b3b8f9b728b69e8"
       },
       {
         "path": "scripts/qualify-agent-first-value-codex.mjs",

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.3",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.3",
-    "sourceSha": "abafce0bac53662def68787ef8e6c7186bf770d1"
+    "sourceSha": "12f9123c844181e4b4ac2cb9c69220a1a9930604"
   },
   "claims": [
     {
@@ -92,7 +92,7 @@
           "pointer": {
             "kind": "file",
             "path": "scripts/check-cli-catalog-parity.mjs",
-            "sha256": "c0811cc4588265a0601cba2a42b8c72278ba36c7b487e2ef4cc245dfe7284b9a"
+            "sha256": "6dcbb9e11144a1f2175ffb3e9a16d54fa023d6e8591366907b3b8f9b728b69e8"
           },
           "description": "Build-free source-acceptance verifier for surface roots and Human, Agent, KFD-3, docs, skills, GUI, and package consumers."
         },

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:aaa6d1ddfd678628c7d6203dd657b62c45d2637f814fb82b33ee6c2d9d779d30"
+            "sha256": "sha256:2f16dcaf35ab2f7f8ee0a13cca31f36264818bb14eb6d082fac39862f18d7e51"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/scripts/check-cli-catalog-parity.mjs
+++ b/scripts/check-cli-catalog-parity.mjs
@@ -26,6 +26,7 @@ const CLI = path.join(
   'kungfu',
   'cli',
 );
+const PATH_BOUNDARY_PREFIXES = new Set(['-', '[', '<', '{']);
 
 function ordered(value) {
   if (Array.isArray(value)) return value.map(ordered);
@@ -62,7 +63,7 @@ function canonicalPath(name) {
   if (typeof name !== 'string') return null;
   const tokens = [];
   for (const token of name.split(/\s+/u)) {
-    if (/^[-[<{]/u.test(token)) break;
+    if (PATH_BOUNDARY_PREFIXES.has(token[0])) break;
     tokens.push(token.replace(/[;,]$/u, ''));
   }
   return tokens.join(' ');
@@ -107,6 +108,27 @@ export function auditCatalogParity({
 }) {
   const issues = [];
   const fail = (message) => issues.push(message);
+  validateCatalogContract(catalog, registry, schema, fail);
+  const { ids, byPath, linkedApiIds } = indexCatalogSurfaces(
+    catalog,
+    schema,
+    fail,
+  );
+  validateKfd3Linkage(catalog, ids, fail);
+  const { apiById, expectedCommands } = indexKfd3Apis(kfd3, linkedApiIds, fail);
+  validateCommandCatalog(
+    commands,
+    registry,
+    byPath,
+    apiById,
+    expectedCommands,
+    fail,
+  );
+  validatePackIndex(index, fail);
+  return { ok: issues.length === 0, issues, byPath };
+}
+
+function validateCatalogContract(catalog, registry, schema, fail) {
   const { catalogRoot: _catalogRoot, ...catalogPreimage } = catalog;
   if (catalog.catalogRoot !== contentRoot(catalogPreimage))
     fail('generated catalog root mismatch');
@@ -152,7 +174,9 @@ export function auditCatalogParity({
     )
   )
     fail('CLI schema still permits deprecated or compatibility maturity');
+}
 
+function indexCatalogSurfaces(catalog, schema, fail) {
   const ids = new Set();
   const byPath = new Map();
   const linkedApiIds = new Set();
@@ -160,25 +184,32 @@ export function auditCatalogParity({
     const label = row.id || row.canonical_path || '<unknown>';
     if (ids.has(row.id)) fail(`duplicate surface id ${label}`);
     ids.add(row.id);
-    for (const field of schema.surfaceRequiredFields || []) {
-      if (!(field in row)) fail(`surface ${label} missing ${field}`);
-    }
-    if (!(schema.owners || []).includes(row.owner))
-      fail(`surface ${label} invalid owner ${row.owner}`);
-    if (!(schema.maturity || []).includes(row.maturity))
-      fail(`surface ${label} invalid maturity ${row.maturity}`);
-    if (!(schema.visibility || []).includes(row.visibility))
-      fail(`surface ${label} invalid visibility ${row.visibility}`);
-    if (!(schema.mutationClasses || []).includes(row.mutation_class))
-      fail(`surface ${label} invalid mutation class ${row.mutation_class}`);
-    if ((row.aliases || []).length !== 0)
-      fail(`surface ${label} retains aliases`);
+    validateSurfaceSchema(row, schema, label, fail);
     if (byPath.has(row.canonical_path))
       fail(`duplicate surface path ${row.canonical_path}`);
     byPath.set(row.canonical_path, row);
     for (const apiId of row.kfd3_api_ids || []) linkedApiIds.add(apiId);
   }
+  return { ids, byPath, linkedApiIds };
+}
 
+function validateSurfaceSchema(row, schema, label, fail) {
+  for (const field of schema.surfaceRequiredFields || []) {
+    if (!(field in row)) fail(`surface ${label} missing ${field}`);
+  }
+  if (!(schema.owners || []).includes(row.owner))
+    fail(`surface ${label} invalid owner ${row.owner}`);
+  if (!(schema.maturity || []).includes(row.maturity))
+    fail(`surface ${label} invalid maturity ${row.maturity}`);
+  if (!(schema.visibility || []).includes(row.visibility))
+    fail(`surface ${label} invalid visibility ${row.visibility}`);
+  if (!(schema.mutationClasses || []).includes(row.mutation_class))
+    fail(`surface ${label} invalid mutation class ${row.mutation_class}`);
+  if ((row.aliases || []).length !== 0)
+    fail(`surface ${label} retains aliases`);
+}
+
+function validateKfd3Linkage(catalog, ids, fail) {
   const linkageBySurface = new Map();
   for (const link of catalog.kfd3Linkage || []) {
     if (linkageBySurface.has(link.surfaceId))
@@ -211,7 +242,9 @@ export function auditCatalogParity({
   for (const surfaceId of linkageBySurface.keys()) {
     if (!ids.has(surfaceId)) fail(`orphan KFD-3 linkage ${surfaceId}`);
   }
+}
 
+function indexKfd3Apis(kfd3, linkedApiIds, fail) {
   const apiById = new Map((kfd3.apis || []).map((row) => [row.id, row]));
   for (const row of kfd3.apis || []) {
     for (const name of [row.name, ...(row.aliases || [])]) {
@@ -228,6 +261,17 @@ export function auditCatalogParity({
       expectedCommands.set(name, row.id);
     }
   }
+  return { apiById, expectedCommands };
+}
+
+function validateCommandCatalog(
+  commands,
+  registry,
+  byPath,
+  apiById,
+  expectedCommands,
+  fail,
+) {
   const actualCommands = new Map();
   for (const row of commands.commands || []) {
     if (usesInternalModuleEntrypoint(row.name))
@@ -258,14 +302,15 @@ export function auditCatalogParity({
     if (!expectedCommands.has(name))
       fail(`commands.json undeclared projection ${name}`);
   }
+}
 
+function validatePackIndex(index, fail) {
   if (
     !(index.documents || []).some(
       (row) => row.path === 'cli_surface.catalog.json',
     )
   )
     fail('agent pack index omits cli_surface.catalog.json');
-  return { ok: issues.length === 0, issues, byPath };
 }
 
 function readJson(file) {

--- a/scripts/check-cli-catalog-parity.test.mjs
+++ b/scripts/check-cli-catalog-parity.test.mjs
@@ -161,3 +161,28 @@ test('orphan runtime API and packaged omission fail closed', () => {
     result.issues.includes('agent pack index omits cli_surface.catalog.json'),
   );
 });
+
+test('catalog diagnostics retain their contract-to-consumer ordering', () => {
+  const fixture = inputs();
+  const surface = fixture.catalog.surfaces[0];
+  fixture.registry.aliases = ['kungfu legacy'];
+  surface.aliases = ['kungfu legacy'];
+  fixture.kfd3.apis.push({
+    id: 'kungfu.fixture.orphan',
+    anchor: { kind: 'runtime-click' },
+    projections: [],
+  });
+  fixture.index.documents = fixture.index.documents.filter(
+    (row) => row.path !== 'cli_surface.catalog.json',
+  );
+
+  assert.deepEqual(auditCatalogParity(fixture).issues, [
+    'generated catalog root mismatch',
+    'generated catalog registry root mismatch',
+    'generated catalog surface root mismatch',
+    'CLI registry must contain zero aliases',
+    `surface ${surface.id} retains aliases`,
+    'orphan runtime KFD-3 API kungfu.fixture.orphan',
+    'agent pack index omits cli_surface.catalog.json',
+  ]);
+});

--- a/scripts/check-kungfu-gate-catalog.mjs
+++ b/scripts/check-kungfu-gate-catalog.mjs
@@ -106,17 +106,7 @@ export function focusedMeasurementStaleGateIdsFromEnv(env = process.env) {
   return gateIds;
 }
 
-export function validateMeasurementCoverage(root, registry, options = {}) {
-  const issues = [];
-  const staleMeasurementGateIds = new Set([
-    ...focusedMeasurementStaleGateIdsFromEnv(),
-    ...(options.staleMeasurementGateIds || []),
-  ]);
-  const document = readJson(root, MEASUREMENT_COVERAGE);
-  const bindingDocument = readJson(root, BINDINGS);
-  const bindings = new Map(
-    (bindingDocument.bindings || []).map((binding) => [binding.id, binding]),
-  );
+function validateMeasurementDocument(document, issues) {
   exactObjectKeys(
     document,
     ['schema', 'registry', 'baseline', 'measurements'],
@@ -165,7 +155,355 @@ export function validateMeasurementCoverage(root, registry, options = {}) {
         '[measurement] frozen unmeasured baseline changed; new Gates must add measurements',
       );
   }
+  return baseline;
+}
 
+function validateControllerMeasurementReceipt(context) {
+  const {
+    receipt,
+    record,
+    observation,
+    gate,
+    currentDefinitionDigest,
+    registry,
+    bindings,
+    issues,
+  } = context;
+  if (gate.action?.kind !== 'handler')
+    issues.push(
+      `[measurement] ${record.gateId}:${observation.platform}: controller receipts are only valid for handler Gates`,
+    );
+  exactObjectKeys(
+    receipt,
+    [
+      '$schema',
+      'schema',
+      'gateId',
+      'definitionDigest',
+      'source',
+      'registry',
+      'environment',
+      'binding',
+      'run',
+      'startedAt',
+      'finishedAt',
+      'durationMs',
+      'status',
+      'attempted',
+      'conclusion',
+      'integrity',
+    ],
+    `${record.gateId}:${observation.platform}: controller receipt`,
+    issues,
+  );
+  if (
+    receipt.$schema !==
+    'https://libkungfu.dev/schemas/shifu/gate-controller-receipt-v1.schema.json'
+  )
+    issues.push(
+      `[measurement] ${record.gateId}:${observation.platform}: controller receipt schema URL is invalid`,
+    );
+  if (
+    receipt.gateId !== record.gateId ||
+    receipt.definitionDigest !== currentDefinitionDigest
+  )
+    issues.push(
+      `[measurement] ${record.gateId}:${observation.platform}: controller receipt Gate identity is stale`,
+    );
+  if (
+    receipt.source?.dirty !== false ||
+    receipt.source?.sha !== observation.sourceSha
+  )
+    issues.push(
+      `[measurement] ${record.gateId}:${observation.platform}: controller receipt must match a clean source SHA`,
+    );
+  if (
+    receipt.registry?.ref !== 'shifu.gates.json' ||
+    receipt.registry?.projectId !== registry.project.id ||
+    receipt.registry?.digest !== observation.registryDigest
+  )
+    issues.push(
+      `[measurement] ${record.gateId}:${observation.platform}: controller receipt registry identity does not match`,
+    );
+  if (receipt.environment?.platform !== observation.platform)
+    issues.push(
+      `[measurement] ${record.gateId}:${observation.platform}: controller receipt platform does not match`,
+    );
+  const binding = bindings.get(receipt.binding?.id);
+  if (
+    !binding ||
+    binding.execution !== 'controller' ||
+    !binding.gates?.includes(record.gateId) ||
+    binding.workflow !== receipt.binding?.workflow ||
+    binding.job !== receipt.binding?.job ||
+    gateDigest(binding.adapter) !== receipt.binding?.adapterDigest
+  )
+    issues.push(
+      `[measurement] ${record.gateId}:${observation.platform}: controller binding identity is stale`,
+    );
+  const started = Date.parse(receipt.startedAt);
+  const finished = Date.parse(receipt.finishedAt);
+  if (
+    !Number.isFinite(started) ||
+    !Number.isFinite(finished) ||
+    finished < started ||
+    finished - started !== receipt.durationMs ||
+    receipt.durationMs !== observation.durationMs
+  )
+    issues.push(
+      `[measurement] ${record.gateId}:${observation.platform}: durationMs differs from controller timestamps`,
+    );
+  if (
+    receipt.status !== 'pass' ||
+    receipt.attempted !== true ||
+    receipt.conclusion !== 'success'
+  )
+    issues.push(
+      `[measurement] ${record.gateId}:${observation.platform}: controller result must be an attempted pass`,
+    );
+  const unsigned = structuredClone(receipt);
+  Reflect.deleteProperty(unsigned, 'integrity');
+  if (receipt.integrity?.digest !== gateDigest(unsigned))
+    issues.push(
+      `[measurement] ${record.gateId}:${observation.platform}: controller receipt integrity is invalid`,
+    );
+}
+
+function validateGateMeasurementReceipt(context) {
+  const {
+    receipt,
+    record,
+    observation,
+    gate,
+    currentDefinitionDigest,
+    staleMeasurementGateIds,
+    registry,
+    issues,
+  } = context;
+  if (receipt.schema !== 'shifu.gate-receipt/v1')
+    issues.push(
+      `[measurement] ${record.gateId}:${observation.platform}: unsupported receipt schema`,
+    );
+  if (gate.action?.kind === 'handler')
+    issues.push(
+      `[measurement] ${record.gateId}:${observation.platform}: handler Gates require a controller receipt`,
+    );
+  if (
+    receipt.source?.dirty !== false ||
+    receipt.source?.sha !== observation.sourceSha
+  )
+    issues.push(
+      `[measurement] ${record.gateId}:${observation.platform}: receipt must match a clean source SHA`,
+    );
+  if (
+    receipt.registry?.ref !== 'shifu.gates.json' ||
+    receipt.registry?.projectId !== registry.project.id ||
+    receipt.registry?.digest !== observation.registryDigest
+  )
+    issues.push(
+      `[measurement] ${record.gateId}:${observation.platform}: receipt registry identity does not match`,
+    );
+  if (receipt.environment?.platform !== observation.platform)
+    issues.push(
+      `[measurement] ${record.gateId}:${observation.platform}: receipt platform does not match`,
+    );
+  const results = Array.isArray(receipt.results)
+    ? receipt.results.filter((result) => result.gateId === record.gateId)
+    : [];
+  if (results.length !== 1) {
+    issues.push(
+      `[measurement] ${record.gateId}:${observation.platform}: receipt must contain exactly one matching result`,
+    );
+    return;
+  }
+  const result = results[0];
+  if (
+    result.definitionDigest !== currentDefinitionDigest &&
+    !staleMeasurementGateIds.has(record.gateId)
+  )
+    issues.push(
+      `[measurement] ${record.gateId}:${observation.platform}: receipt definition digest is stale`,
+    );
+  if (
+    result.attempted !== true ||
+    result.status !== 'pass' ||
+    result.exitCode !== 0
+  )
+    issues.push(
+      `[measurement] ${record.gateId}:${observation.platform}: receipt result must be an attempted pass`,
+    );
+  if (result.durationMs !== observation.durationMs)
+    issues.push(
+      `[measurement] ${record.gateId}:${observation.platform}: durationMs differs from the receipt`,
+    );
+}
+
+function validateMeasurementObservation(context) {
+  const {
+    root,
+    registry,
+    bindings,
+    record,
+    observation,
+    observationIndex,
+    recordAt,
+    gate,
+    currentDefinitionDigest,
+    staleMeasurementGateIds,
+    issues,
+  } = context;
+  const observationAt = `${recordAt}.observations[${observationIndex}]`;
+  if (
+    !exactObjectKeys(
+      observation,
+      ['platform', 'sourceSha', 'registryDigest', 'durationMs', 'receipt'],
+      observationAt,
+      issues,
+    )
+  )
+    return;
+  if (!gate.platforms.includes(observation.platform))
+    issues.push(
+      `[measurement] ${record.gateId}: unsupported platform '${observation.platform}'`,
+    );
+  if (!/^[0-9a-f]{40}$/.test(observation.sourceSha || ''))
+    issues.push(
+      `[measurement] ${record.gateId}:${observation.platform}: sourceSha must be a full Git SHA`,
+    );
+  if (!/^sha256:[0-9a-f]{64}$/.test(observation.registryDigest || ''))
+    issues.push(
+      `[measurement] ${record.gateId}:${observation.platform}: registryDigest must be sha256`,
+    );
+  if (!Number.isInteger(observation.durationMs) || observation.durationMs < 0)
+    issues.push(
+      `[measurement] ${record.gateId}:${observation.platform}: durationMs must be a non-negative integer`,
+    );
+  if (!safeEvidencePath(observation.receipt)) {
+    issues.push(
+      `[measurement] ${record.gateId}:${observation.platform}: unsafe receipt path`,
+    );
+    return;
+  }
+  const receiptPath = path.join(root, observation.receipt);
+  if (!fs.existsSync(receiptPath)) {
+    issues.push(
+      `[measurement] ${record.gateId}:${observation.platform}: missing ${observation.receipt}`,
+    );
+    return;
+  }
+  let receipt;
+  try {
+    receipt = JSON.parse(fs.readFileSync(receiptPath, 'utf8'));
+  } catch {
+    issues.push(
+      `[measurement] ${record.gateId}:${observation.platform}: receipt is not valid JSON`,
+    );
+    return;
+  }
+  const receiptContext = {
+    receipt,
+    record,
+    observation,
+    gate,
+    currentDefinitionDigest,
+    staleMeasurementGateIds,
+    registry,
+    bindings,
+    issues,
+  };
+  if (receipt.schema === 'kungfu.gate-controller-receipt/v1')
+    validateControllerMeasurementReceipt(receiptContext);
+  else validateGateMeasurementReceipt(receiptContext);
+}
+
+function validateMeasurementRecord(context) {
+  const {
+    root,
+    registry,
+    bindings,
+    record,
+    recordIndex,
+    gates,
+    records,
+    staleMeasurementGateIds,
+    issues,
+  } = context;
+  const at = `measurements[${recordIndex}]`;
+  if (
+    !exactObjectKeys(
+      record,
+      ['gateId', 'definitionDigest', 'observations'],
+      at,
+      issues,
+    )
+  )
+    return;
+  if (records.has(record.gateId))
+    issues.push(`[measurement] duplicate Gate record '${record.gateId}'`);
+  records.set(record.gateId, record);
+  const gate = gates.get(record.gateId);
+  if (!gate) {
+    issues.push(`[measurement] unknown Gate '${record.gateId}'`);
+    return;
+  }
+  const currentDefinitionDigest = gateDefinitionDigest(gate);
+  if (
+    record.definitionDigest !== currentDefinitionDigest &&
+    !staleMeasurementGateIds.has(record.gateId)
+  )
+    issues.push(`[measurement] ${record.gateId}: definition digest is stale`);
+  if (!Array.isArray(record.observations) || !record.observations.length) {
+    issues.push(
+      `[measurement] ${record.gateId}: observations must be a non-empty array`,
+    );
+    return;
+  }
+  const observedPlatforms = record.observations.map(
+    (observation) => observation?.platform,
+  );
+  if (!sameStringSet(observedPlatforms, gate.platforms))
+    issues.push(
+      `[measurement] ${record.gateId}: measured platforms [${observedPlatforms.join(', ')}], expected [${gate.platforms.join(', ')}]`,
+    );
+  const sourceShas = new Set(
+    record.observations.map((observation) => observation?.sourceSha),
+  );
+  const registryDigests = new Set(
+    record.observations.map((observation) => observation?.registryDigest),
+  );
+  if (sourceShas.size !== 1 || registryDigests.size !== 1)
+    issues.push(
+      `[measurement] ${record.gateId}: all platforms must measure one source and registry revision`,
+    );
+  for (const [observationIndex, observation] of record.observations.entries()) {
+    validateMeasurementObservation({
+      root,
+      registry,
+      bindings,
+      record,
+      observation,
+      observationIndex,
+      recordAt: at,
+      gate,
+      currentDefinitionDigest,
+      staleMeasurementGateIds,
+      issues,
+    });
+  }
+}
+
+export function validateMeasurementCoverage(root, registry, options = {}) {
+  const issues = [];
+  const staleMeasurementGateIds = new Set([
+    ...focusedMeasurementStaleGateIdsFromEnv(),
+    ...(options.staleMeasurementGateIds || []),
+  ]);
+  const document = readJson(root, MEASUREMENT_COVERAGE);
+  const bindingDocument = readJson(root, BINDINGS);
+  const bindings = new Map(
+    (bindingDocument.bindings || []).map((binding) => [binding.id, binding]),
+  );
+  const baseline = validateMeasurementDocument(document, issues);
   const gates = new Map(registry.gates.map((gate) => [gate.id, gate]));
   const exempt = new Set(
     Array.isArray(baseline?.unmeasuredGateIds)
@@ -173,273 +511,23 @@ export function validateMeasurementCoverage(root, registry, options = {}) {
       : [],
   );
   const records = new Map();
-  if (!Array.isArray(document.measurements)) {
+  if (!Array.isArray(document.measurements))
     issues.push('[measurement] document.measurements must be an array');
-  }
-  for (const [recordIndex, record] of (Array.isArray(document.measurements)
+  const measurements = Array.isArray(document.measurements)
     ? document.measurements
-    : []
-  ).entries()) {
-    const at = `measurements[${recordIndex}]`;
-    if (
-      !exactObjectKeys(
-        record,
-        ['gateId', 'definitionDigest', 'observations'],
-        at,
-        issues,
-      )
-    )
-      continue;
-    if (records.has(record.gateId))
-      issues.push(`[measurement] duplicate Gate record '${record.gateId}'`);
-    records.set(record.gateId, record);
-    const gate = gates.get(record.gateId);
-    if (!gate) {
-      issues.push(`[measurement] unknown Gate '${record.gateId}'`);
-      continue;
-    }
-    const currentDefinitionDigest = gateDefinitionDigest(gate);
-    if (
-      record.definitionDigest !== currentDefinitionDigest &&
-      !staleMeasurementGateIds.has(record.gateId)
-    )
-      issues.push(`[measurement] ${record.gateId}: definition digest is stale`);
-    if (!Array.isArray(record.observations) || !record.observations.length) {
-      issues.push(
-        `[measurement] ${record.gateId}: observations must be a non-empty array`,
-      );
-      continue;
-    }
-    const observedPlatforms = record.observations.map(
-      (observation) => observation?.platform,
-    );
-    if (!sameStringSet(observedPlatforms, gate.platforms))
-      issues.push(
-        `[measurement] ${record.gateId}: measured platforms [${observedPlatforms.join(', ')}], expected [${gate.platforms.join(', ')}]`,
-      );
-    const sourceShas = new Set(
-      record.observations.map((observation) => observation?.sourceSha),
-    );
-    const registryDigests = new Set(
-      record.observations.map((observation) => observation?.registryDigest),
-    );
-    if (sourceShas.size !== 1 || registryDigests.size !== 1)
-      issues.push(
-        `[measurement] ${record.gateId}: all platforms must measure one source and registry revision`,
-      );
-    for (const [
-      observationIndex,
-      observation,
-    ] of record.observations.entries()) {
-      const observationAt = `${at}.observations[${observationIndex}]`;
-      if (
-        !exactObjectKeys(
-          observation,
-          ['platform', 'sourceSha', 'registryDigest', 'durationMs', 'receipt'],
-          observationAt,
-          issues,
-        )
-      )
-        continue;
-      if (!gate.platforms.includes(observation.platform))
-        issues.push(
-          `[measurement] ${record.gateId}: unsupported platform '${observation.platform}'`,
-        );
-      if (!/^[0-9a-f]{40}$/.test(observation.sourceSha || ''))
-        issues.push(
-          `[measurement] ${record.gateId}:${observation.platform}: sourceSha must be a full Git SHA`,
-        );
-      if (!/^sha256:[0-9a-f]{64}$/.test(observation.registryDigest || ''))
-        issues.push(
-          `[measurement] ${record.gateId}:${observation.platform}: registryDigest must be sha256`,
-        );
-      if (
-        !Number.isInteger(observation.durationMs) ||
-        observation.durationMs < 0
-      )
-        issues.push(
-          `[measurement] ${record.gateId}:${observation.platform}: durationMs must be a non-negative integer`,
-        );
-      if (!safeEvidencePath(observation.receipt)) {
-        issues.push(
-          `[measurement] ${record.gateId}:${observation.platform}: unsafe receipt path`,
-        );
-        continue;
-      }
-      const receiptPath = path.join(root, observation.receipt);
-      if (!fs.existsSync(receiptPath)) {
-        issues.push(
-          `[measurement] ${record.gateId}:${observation.platform}: missing ${observation.receipt}`,
-        );
-        continue;
-      }
-      let receipt;
-      try {
-        receipt = JSON.parse(fs.readFileSync(receiptPath, 'utf8'));
-      } catch {
-        issues.push(
-          `[measurement] ${record.gateId}:${observation.platform}: receipt is not valid JSON`,
-        );
-        continue;
-      }
-      if (receipt.schema === 'kungfu.gate-controller-receipt/v1') {
-        if (gate.action?.kind !== 'handler')
-          issues.push(
-            `[measurement] ${record.gateId}:${observation.platform}: controller receipts are only valid for handler Gates`,
-          );
-        exactObjectKeys(
-          receipt,
-          [
-            '$schema',
-            'schema',
-            'gateId',
-            'definitionDigest',
-            'source',
-            'registry',
-            'environment',
-            'binding',
-            'run',
-            'startedAt',
-            'finishedAt',
-            'durationMs',
-            'status',
-            'attempted',
-            'conclusion',
-            'integrity',
-          ],
-          `${record.gateId}:${observation.platform}: controller receipt`,
-          issues,
-        );
-        if (
-          receipt.$schema !==
-          'https://libkungfu.dev/schemas/shifu/gate-controller-receipt-v1.schema.json'
-        )
-          issues.push(
-            `[measurement] ${record.gateId}:${observation.platform}: controller receipt schema URL is invalid`,
-          );
-        if (
-          receipt.gateId !== record.gateId ||
-          receipt.definitionDigest !== currentDefinitionDigest
-        )
-          issues.push(
-            `[measurement] ${record.gateId}:${observation.platform}: controller receipt Gate identity is stale`,
-          );
-        if (
-          receipt.source?.dirty !== false ||
-          receipt.source?.sha !== observation.sourceSha
-        )
-          issues.push(
-            `[measurement] ${record.gateId}:${observation.platform}: controller receipt must match a clean source SHA`,
-          );
-        if (
-          receipt.registry?.ref !== 'shifu.gates.json' ||
-          receipt.registry?.projectId !== registry.project.id ||
-          receipt.registry?.digest !== observation.registryDigest
-        )
-          issues.push(
-            `[measurement] ${record.gateId}:${observation.platform}: controller receipt registry identity does not match`,
-          );
-        if (receipt.environment?.platform !== observation.platform)
-          issues.push(
-            `[measurement] ${record.gateId}:${observation.platform}: controller receipt platform does not match`,
-          );
-        const binding = bindings.get(receipt.binding?.id);
-        if (
-          !binding ||
-          binding.execution !== 'controller' ||
-          !binding.gates?.includes(record.gateId) ||
-          binding.workflow !== receipt.binding?.workflow ||
-          binding.job !== receipt.binding?.job ||
-          gateDigest(binding.adapter) !== receipt.binding?.adapterDigest
-        )
-          issues.push(
-            `[measurement] ${record.gateId}:${observation.platform}: controller binding identity is stale`,
-          );
-        const started = Date.parse(receipt.startedAt);
-        const finished = Date.parse(receipt.finishedAt);
-        if (
-          !Number.isFinite(started) ||
-          !Number.isFinite(finished) ||
-          finished < started ||
-          finished - started !== receipt.durationMs ||
-          receipt.durationMs !== observation.durationMs
-        )
-          issues.push(
-            `[measurement] ${record.gateId}:${observation.platform}: durationMs differs from controller timestamps`,
-          );
-        if (
-          receipt.status !== 'pass' ||
-          receipt.attempted !== true ||
-          receipt.conclusion !== 'success'
-        )
-          issues.push(
-            `[measurement] ${record.gateId}:${observation.platform}: controller result must be an attempted pass`,
-          );
-        const unsigned = structuredClone(receipt);
-        Reflect.deleteProperty(unsigned, 'integrity');
-        if (receipt.integrity?.digest !== gateDigest(unsigned))
-          issues.push(
-            `[measurement] ${record.gateId}:${observation.platform}: controller receipt integrity is invalid`,
-          );
-        continue;
-      }
-      if (receipt.schema !== 'shifu.gate-receipt/v1')
-        issues.push(
-          `[measurement] ${record.gateId}:${observation.platform}: unsupported receipt schema`,
-        );
-      if (gate.action?.kind === 'handler')
-        issues.push(
-          `[measurement] ${record.gateId}:${observation.platform}: handler Gates require a controller receipt`,
-        );
-      if (
-        receipt.source?.dirty !== false ||
-        receipt.source?.sha !== observation.sourceSha
-      )
-        issues.push(
-          `[measurement] ${record.gateId}:${observation.platform}: receipt must match a clean source SHA`,
-        );
-      if (
-        receipt.registry?.ref !== 'shifu.gates.json' ||
-        receipt.registry?.projectId !== registry.project.id ||
-        receipt.registry?.digest !== observation.registryDigest
-      )
-        issues.push(
-          `[measurement] ${record.gateId}:${observation.platform}: receipt registry identity does not match`,
-        );
-      if (receipt.environment?.platform !== observation.platform)
-        issues.push(
-          `[measurement] ${record.gateId}:${observation.platform}: receipt platform does not match`,
-        );
-      const results = Array.isArray(receipt.results)
-        ? receipt.results.filter((result) => result.gateId === record.gateId)
-        : [];
-      if (results.length !== 1) {
-        issues.push(
-          `[measurement] ${record.gateId}:${observation.platform}: receipt must contain exactly one matching result`,
-        );
-        continue;
-      }
-      const result = results[0];
-      if (
-        result.definitionDigest !== currentDefinitionDigest &&
-        !staleMeasurementGateIds.has(record.gateId)
-      )
-        issues.push(
-          `[measurement] ${record.gateId}:${observation.platform}: receipt definition digest is stale`,
-        );
-      if (
-        result.attempted !== true ||
-        result.status !== 'pass' ||
-        result.exitCode !== 0
-      )
-        issues.push(
-          `[measurement] ${record.gateId}:${observation.platform}: receipt result must be an attempted pass`,
-        );
-      if (result.durationMs !== observation.durationMs)
-        issues.push(
-          `[measurement] ${record.gateId}:${observation.platform}: durationMs differs from the receipt`,
-        );
-    }
+    : [];
+  for (const [recordIndex, record] of measurements.entries()) {
+    validateMeasurementRecord({
+      root,
+      registry,
+      bindings,
+      record,
+      recordIndex,
+      gates,
+      records,
+      staleMeasurementGateIds,
+      issues,
+    });
   }
   for (const gate of registry.gates) {
     if (!exempt.has(gate.id) && !records.has(gate.id))

--- a/scripts/check-kungfu-gate-catalog.test.mjs
+++ b/scripts/check-kungfu-gate-catalog.test.mjs
@@ -592,25 +592,11 @@ test('dirty, unsuccessful, and duration-drifted receipts fail measurement covera
   result.durationMs += 1;
   fs.writeFileSync(receiptPath, JSON.stringify(receipt));
   const issues = validateMeasurementCoverage(root, registry).issues;
-  assert.ok(
-    issues.some((issue) =>
-      issue.includes(
-        'gate.catalog:linux: receipt must match a clean source SHA',
-      ),
-    ),
-  );
-  assert.ok(
-    issues.some((issue) =>
-      issue.includes(
-        'gate.catalog:linux: receipt result must be an attempted pass',
-      ),
-    ),
-  );
-  assert.ok(
-    issues.some((issue) =>
-      issue.includes('gate.catalog:linux: durationMs differs from the receipt'),
-    ),
-  );
+  assert.deepEqual(issues, [
+    '[measurement] gate.catalog:linux: receipt must match a clean source SHA',
+    '[measurement] gate.catalog:linux: receipt result must be an attempted pass',
+    '[measurement] gate.catalog:linux: durationMs differs from the receipt',
+  ]);
 });
 
 test('handler Gate measurements require an intact controller binding receipt', () => {


### PR DESCRIPTION
## Summary

Split two high-risk catalog validators into cohesive deterministic units while preserving CLI identity, aliases, catalog parity, Gate measurement coverage, diagnostics and ordering, roots, exit codes, timing, work counts, and fail-closed behavior.

## Related issue

Native Assignment: `2026-08-27-kungfu-source-tooling-catalog-complexity-wave4`

## Changes

- Separate CLI catalog validation from canonical indexing while keeping `canonicalPath` as one bounded path normalizer.
- Separate Gate measurement-entry validation from coverage aggregation while retaining one measurement policy authority.
- Add adversarial fixtures for alias, catalog, coverage, diagnostic-order, and fail-closed drift.
- Refresh the exact generated KFD evidence projections required by the unchanged catalog surface.

## Verification

- `./shifu check:source` — 1,181 passed, 11 skipped, 0 failed across 1,192 source fixtures; Python 40/40, runtime-upgrade 135/135, desktop-update 73/73; typecheck, Biome, changed-code ratchet, and zero-write checks passed
- Exact base `2c94cb2cbac3498a325c29391f32aba85b106486` to candidate `03bda485f54fd20e96f54ec14f1c50a1965cca09`: target aggregate 1,272 → 54 (95.75% lower); `canonicalPath` 696 → 16; `validateMeasurementCoverage` 576 → 38
- Affected owner aggregate 45,638 → 45,016; owner threshold counts `>500` 2 → 0, `>300` 7 → 5, `>100` 76 → 74
- Global threshold counts `>500` 3 → 1, `>300` 24 → 22, `>100` 314 → 312
- Exact candidate function-risk report root: `sha256:5ee1146d79d0ab91b934ad9ccced75ec66dc74e0dbfdb3b1105e59febacb1651`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This behavior-preserving maintainability refactor does not alter an architecture decision or ADR projection."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The generated KFD projections are refreshed from the unchanged catalog authority; no release policy or publishing behavior changes.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed — no behavior or public contract changed

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6IjIwMjYtMDgtMjcta3VuZ2Z1LWNvbXBsZXhpdHktZGVidC13YXZlNCIsImFzc2lnbm1lbnRJZCI6IjIwMjYtMDgtMjcta3VuZ2Z1LXNvdXJjZS10b29saW5nLWNhdGFsb2ctY29tcGxleGl0eS13YXZlNCIsImRlbGl2ZXJ5Q2xhc3MiOiJub24tbmF0aXZlLWZhc3QiLCJkZXZIZWFkIjoiNTAwZWVhY2NlYTg0MWIzYzhhMzQzZjVkN2I3ODc3NjYyN2RiYmZjNyIsInB1bGxSZXF1ZXN0SGVhZCI6IjAzYmRhNDg1ZjU0ZmQyMGU5NmY1NGVjMTRmMWM1MGExOTY1Y2NhMDkiLCJyZXBsYXllZENhbmRpZGF0ZSI6ImI5YzY1Y2RiNzkyMDJiNGQ4MjM4NTBmZmEwN2RjM2E4ZTllZTRjNzYiLCJyZXBsYXllZFRyZWUiOiJhZTEwZDgwMWM2ZWVhNjhiNzk0NGMyODY1ZGZmYTI1YjQyYTNmOTUwIiwicXVldWVBdHRlbXB0IjoiMDNiZGE0ODVmNTRmZDIwZTk2ZjU0ZWMxNGYxYzUwYTE5NjVjY2EwOUA1MDBlZWFjY2VhODQxYjNjOGEzNDNmNWQ3Yjc4Nzc2NjI3ZGJiZmM3IiwiYWRtaXNzaW9uUHJvb2ZSb290Ijoic2hhMjU2OmM5OTZhMzEwMDhhY2Q2MjA4ZDU4MDFiOGJlNTEyNzlmYWRlMjIzZGEyZjY4YmFkN2I1M2E5ZmRmYzI0YzAwZWMiLCJhZG1pc3Npb25Qcm9vZlJvb3RzIjpbInNoYTI1Njo4MWRhMDA4ZjNiNTA1MGYxOWVmMTk4ZDY5YTkxNjIyMmMyMGRhMGFkZGUxOTNhMWZjNGJlNzg0MDljYzUwZjg5Iiwic2hhMjU2OmM5OTZhMzEwMDhhY2Q2MjA4ZDU4MDFiOGJlNTEyNzlmYWRlMjIzZGEyZjY4YmFkN2I1M2E5ZmRmYzI0YzAwZWMiXSwic3RhdHVzQ29udGV4dCI6IlF1ZXVlIGZhbWlseSBsZWFzZS9kM2IyZTg4M2IwNzU2MzY5IiwibGVhc2VSb290Ijoic2hhMjU2OjYwZTcxNTY4ODUyNzVjYTljZTZmNDdmZTUwZGQ1MjA2MWYyMzBlYmMxZjUxOTUxZWQzOTA2YWJhMDZjYjE5NTIifQ -->