### PR TITLE
fix(work): bind ambient console during fresh recovery

### DIFF
--- a/framework/core/src/python/kungfu/assignment_runtime/fresh_recovery.py
+++ b/framework/core/src/python/kungfu/assignment_runtime/fresh_recovery.py
@@ -633,6 +633,24 @@ def _apply_from_ports(
     ) or identity.identity_root != workspace.get("identityRoot"):
         raise ValueError("fresh recovery workspace identity changed")
     _verify_recovery_profile_source(plan, recovery_profile_source, runtime_dir)
+    current = session_surface.current_native_console(str(ctx.runtime_dir))
+    if current is None:
+        raise ValueError("fresh recovery requires a current native Agent Console")
+    current_source = str(current.get("source") or "")
+    envelope = dict(current.get("envelope") or {})
+    current_session = {
+        "workConsoleId": str(envelope.get("consoleId") or ""),
+        "sessionAttemptId": str(envelope.get("attemptId") or ""),
+    }
+    if current_source == "injected-native-console":
+        bind_options: JsonObject = {}
+    elif current_source == "ambient-provider-session":
+        bind_options = {
+            "envelope_override": envelope,
+            "console_workspace_root": str(current.get("workspaceRoot") or ""),
+        }
+    else:
+        raise ValueError("fresh recovery requires an exact native Console source")
     receipt = apply_plan(
         plan,
         expected_plan_root=expected_plan_root,
@@ -640,7 +658,7 @@ def _apply_from_ports(
         status_reader=lambda: _retained_status(
             runtime_dir, initiative_id, assignment_id
         ),
-        session_reader=lambda: _current_session(str(ctx.runtime_dir)),
+        session_reader=lambda: dict(current_session),
         prepare_profile=lambda actor: prepare_resume_profile(
             runtime_dir, actor, recovery_profile_source
         ),
@@ -652,6 +670,7 @@ def _apply_from_ports(
                 work_workspace_root=workspace_root,
                 work_profile_source=recovery_profile_source,
                 expected_binding=expected,
+                **bind_options,
             )
             or {}
         ),

--- a/framework/core/src/python/kungfu/assignment_runtime/fresh_recovery.py
+++ b/framework/core/src/python/kungfu/assignment_runtime/fresh_recovery.py
@@ -550,6 +550,28 @@ def _verify_recovery_profile_source(
         raise ValueError("fresh recovery Profile source differs from the plan")
 
 
+def _current_binding_context(runtime_dir: str) -> tuple[JsonObject, JsonObject]:
+    current = session_surface.current_native_console(runtime_dir)
+    if current is None:
+        raise ValueError("fresh recovery requires a current native Agent Console")
+    source = str(current["source"])
+    envelope = dict(current["envelope"])
+    session = {
+        "workConsoleId": str(envelope["consoleId"]),
+        "sessionAttemptId": str(envelope["attemptId"]),
+    }
+    if source not in {"injected-native-console", "ambient-provider-session"}:
+        raise ValueError("fresh recovery requires an exact native Console source")
+    options = {
+        "injected-native-console": {},
+        "ambient-provider-session": {
+            "envelope_override": envelope,
+            "console_workspace_root": str(current["workspaceRoot"]),
+        },
+    }
+    return session, options[source]
+
+
 def _plan_from_ports(
     *,
     ctx,
@@ -633,24 +655,7 @@ def _apply_from_ports(
     ) or identity.identity_root != workspace.get("identityRoot"):
         raise ValueError("fresh recovery workspace identity changed")
     _verify_recovery_profile_source(plan, recovery_profile_source, runtime_dir)
-    current = session_surface.current_native_console(str(ctx.runtime_dir))
-    if current is None:
-        raise ValueError("fresh recovery requires a current native Agent Console")
-    current_source = str(current.get("source") or "")
-    envelope = dict(current.get("envelope") or {})
-    current_session = {
-        "workConsoleId": str(envelope.get("consoleId") or ""),
-        "sessionAttemptId": str(envelope.get("attemptId") or ""),
-    }
-    if current_source == "injected-native-console":
-        bind_options: JsonObject = {}
-    elif current_source == "ambient-provider-session":
-        bind_options = {
-            "envelope_override": envelope,
-            "console_workspace_root": str(current.get("workspaceRoot") or ""),
-        }
-    else:
-        raise ValueError("fresh recovery requires an exact native Console source")
+    current_session, bind_options = _current_binding_context(str(ctx.runtime_dir))
     receipt = apply_plan(
         plan,
         expected_plan_root=expected_plan_root,

--- a/framework/core/tests/python/test_work_authority_surface.py
+++ b/framework/core/tests/python/test_work_authority_surface.py
@@ -6,6 +6,7 @@ import json
 from types import SimpleNamespace
 
 from click.testing import CliRunner
+import pytest
 
 from kungfu import (
     assignment_close,
@@ -1204,8 +1205,15 @@ def test_fresh_recovery_prepare_does_not_require_newer_profile_work_hooks(
     assert receipt["profileContractMutation"] == "not-permitted"
 
 
-def test_fresh_recovery_apply_passes_explicit_profile_source_to_binder(
-    tmp_path, monkeypatch
+@pytest.mark.parametrize(
+    ("console_source", "expects_override"),
+    [
+        ("ambient-provider-session", True),
+        ("injected-native-console", False),
+    ],
+)
+def test_fresh_recovery_apply_passes_exact_console_context_to_binder(
+    tmp_path, monkeypatch, console_source, expects_override
 ):
     status, binding, plan = _fresh_recovery_fixture()
     workspace_root = tmp_path / "project"
@@ -1232,10 +1240,18 @@ def test_fresh_recovery_apply_passes_explicit_profile_source_to_binder(
         "_retained_status",
         lambda *_args: json.loads(json.dumps(status)),
     )
+    console_envelope = {
+        "consoleId": binding["session"]["workConsoleId"],
+        "attemptId": binding["session"]["sessionAttemptId"],
+    }
     monkeypatch.setattr(
-        assignment_fresh_recovery,
-        "_current_session",
-        lambda _runtime_dir: dict(binding["session"]),
+        assignment_fresh_recovery.session_surface,
+        "current_native_console",
+        lambda _runtime_dir: {
+            "source": console_source,
+            "envelope": console_envelope,
+            "workspaceRoot": str(workspace_root),
+        },
     )
 
     def bind_current_native_work(*_args, **kwargs):
@@ -1270,6 +1286,12 @@ def test_fresh_recovery_apply_passes_explicit_profile_source_to_binder(
 
     assert receipt["ok"] is True
     assert observed["work_profile_source"] == profile_source
+    if expects_override:
+        assert observed["envelope_override"] == console_envelope
+        assert observed["console_workspace_root"] == str(workspace_root)
+    else:
+        assert "envelope_override" not in observed
+        assert "console_workspace_root" not in observed
     assert observed["expected_binding"] == {
         "workRef": plan["workRef"],
         "session": binding["session"],


### PR DESCRIPTION
## Summary

- pass the exact verified ambient Console envelope and workspace root into fresh-recovery binding
- observe the current native Console once at the apply boundary and retain exact expected SessionAttempt/WorkRef checks
- preserve the existing injected Console path and fail closed on unknown Console sources

## Verification

- `./shifu test:work-authority` — 17 Node tests and 32 Python tests passed
- combined `test_work_authority_surface.py`, `test_agent_console_ambient_adoption.py`, and `test_assignment_runtime.py` — 84 passed
- signed commit staged gate — passed
- independent exact-head review of commit `18c6f94c4ea7d5c3867b9989556d03e984c671a6` / tree `8202b20fb2fa9d8109293f4e800e15ae9d1332dc` — FIT, no findings
- `./shifu test:agent-console-contract` in independent review — 140 passed, 3 skipped

## Boundaries

This is the minimum acceptance correction for the public fresh-recovery protocol. It does not add admit, claim, kickoff, retry, fallback authority, Assignment lifecycle writes, or a release. Failed real recovery attempts remain terminal and will not be retried.

<!-- kungfu-adr-release:v1
{
  "schema":"kungfu.adr-release-pr/v1",
  "kind":"adr-neutral",
  "reason":"This maintenance fix passes the already verified ambient Console coordinates through the existing public binder without changing fresh-recovery semantics."
}
-->