### PR TITLE
fix(release): bind equivalent-tree candidate reuse

### DIFF
--- a/scripts/assemble-kungfu-publication-gate.mjs
+++ b/scripts/assemble-kungfu-publication-gate.mjs
@@ -203,6 +203,40 @@ export function createKungfuPublicationGateAggregate({
   return { ...payload, digest: `sha256:${sha256Json(payload)}` };
 }
 
+export function bindKungfuPublicationGateAggregate({
+  aggregate,
+  evidenceSourceSha,
+  targetSourceSha,
+  targetSourceTreeSha,
+  expectedSourceTreeSha,
+  rebindPublicationGateAggregateForEquivalentTree,
+}) {
+  if (targetSourceTreeSha !== expectedSourceTreeSha)
+    throw new Error(
+      'promotion source tree does not match the release candidate',
+    );
+  return rebindPublicationGateAggregateForEquivalentTree(aggregate, {
+    evidenceSourceSha,
+    targetSourceSha,
+    targetSourceTreeSha,
+    expectedSourceTreeSha,
+  });
+}
+
+export function validateKungfuReleaseCandidatePassport({
+  candidate,
+  passport,
+  targetRef,
+  buildSummary,
+}) {
+  return candidate.validateReleaseCandidatePassport({
+    passport,
+    repository: 'kungfu-systems/kungfu',
+    targetChannel: targetRef,
+    buildSummary,
+  });
+}
+
 export async function assembleKungfuPublicationGate({
   root = ROOT,
   subjectRoot = root,
@@ -244,6 +278,11 @@ export async function assembleKungfuPublicationGate({
       path.join(runtimeRoot, 'packages/core/controller-evidence.js'),
     ).href
   );
+  const recovery = await import(
+    pathToFileURL(
+      path.join(runtimeRoot, 'packages/core/release-candidate-recovery.js'),
+    ).href
+  );
 
   const passport = oneJson(
     path.join(evidenceRoot, 'passport'),
@@ -270,11 +309,10 @@ export async function assembleKungfuPublicationGate({
     'downloaded manifests',
   );
 
-  const passportValidation = candidate.validateReleaseCandidatePassport({
+  const passportValidation = validateKungfuReleaseCandidatePassport({
+    candidate,
     passport,
-    repository: 'kungfu-systems/kungfu',
-    targetChannel: targetRef,
-    sourceHeadSha: sourceSha,
+    targetRef,
     buildSummary,
   });
   if (!passportValidation.ok)
@@ -285,10 +323,6 @@ export async function assembleKungfuPublicationGate({
     cwd: subjectRoot,
     encoding: 'utf8',
   }).trim();
-  if (passport.source?.treeHash !== promotionTree)
-    throw new Error(
-      'promotion source tree does not match the release candidate',
-    );
 
   const controllerValidation = controllers.validateControllerReceipt(
     controllerReceipt,
@@ -402,13 +436,22 @@ export async function assembleKungfuPublicationGate({
       },
       writer: process.stderr,
     });
-    const aggregate = createKungfuPublicationGateAggregate({
-      sourceSha,
+    const candidateAggregate = createKungfuPublicationGateAggregate({
+      sourceSha: passport.source.headSha,
       registry,
       gateReceipt,
       manifestSet,
       publicationAuthorityDigest: authority.publicationAuthorityDigest,
       sha256Json: candidate.sha256Json,
+    });
+    const aggregate = bindKungfuPublicationGateAggregate({
+      aggregate: candidateAggregate,
+      evidenceSourceSha: passport.source.headSha,
+      targetSourceSha: sourceSha,
+      targetSourceTreeSha: promotionTree,
+      expectedSourceTreeSha: passport.source.treeHash,
+      rebindPublicationGateAggregateForEquivalentTree:
+        recovery.rebindPublicationGateAggregateForEquivalentTree,
     });
     fs.mkdirSync(path.dirname(outputPath), { recursive: true });
     fs.writeFileSync(outputPath, `${JSON.stringify(aggregate, null, 2)}\n`);

--- a/scripts/assemble-kungfu-publication-gate.mjs
+++ b/scripts/assemble-kungfu-publication-gate.mjs
@@ -223,6 +223,30 @@ export function bindKungfuPublicationGateAggregate({
   });
 }
 
+export function resolveGitTreeSha({ repositoryRoot, sourceSha }) {
+  if (!/^[0-9a-f]{40}$/.test(sourceSha))
+    throw new Error('promotion source SHA must be an exact commit SHA');
+  let treeSha;
+  try {
+    treeSha = execFileSync(
+      'git',
+      ['rev-parse', '--verify', `${sourceSha}^{tree}`],
+      {
+        cwd: repositoryRoot,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    ).trim();
+  } catch {
+    throw new Error(
+      `promotion source commit is unavailable in the publication subject: ${sourceSha}`,
+    );
+  }
+  if (!/^[0-9a-f]{40}$/.test(treeSha))
+    throw new Error('promotion source did not resolve to an exact Git tree');
+  return treeSha;
+}
+
 export function validateKungfuReleaseCandidatePassport({
   candidate,
   passport,
@@ -319,10 +343,10 @@ export async function assembleKungfuPublicationGate({
     throw new Error(
       `release-candidate passport is invalid: ${passportValidation.errors.join('; ')}`,
     );
-  const promotionTree = execFileSync('git', ['rev-parse', 'HEAD^{tree}'], {
-    cwd: subjectRoot,
-    encoding: 'utf8',
-  }).trim();
+  const promotionTree = resolveGitTreeSha({
+    repositoryRoot: subjectRoot,
+    sourceSha,
+  });
 
   const controllerValidation = controllers.validateControllerReceipt(
     controllerReceipt,

--- a/scripts/assemble-kungfu-publication-gate.test.mjs
+++ b/scripts/assemble-kungfu-publication-gate.test.mjs
@@ -7,7 +7,11 @@ import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
-import { createKungfuPublicationGateAggregate } from './assemble-kungfu-publication-gate.mjs';
+import {
+  bindKungfuPublicationGateAggregate,
+  createKungfuPublicationGateAggregate,
+  validateKungfuReleaseCandidatePassport,
+} from './assemble-kungfu-publication-gate.mjs';
 
 const SOURCE_SHA = '1'.repeat(40);
 const PLATFORMS = ['linux-x64', 'linux-arm64', 'macos-arm64', 'windows-x64'];
@@ -81,6 +85,73 @@ test('publication Gate aggregate binds the exact four-platform artifact set', ()
   assert.deepEqual(aggregate.omitted, []);
   assert.deepEqual(aggregate.issues, []);
   assert.equal(aggregate.digest, `sha256:${'5'.repeat(64)}`);
+});
+
+test('publication Gate aggregate reuses candidate evidence for an exact target tree', () => {
+  const evidenceSourceSha = '6'.repeat(40);
+  const targetSourceSha = '7'.repeat(40);
+  const sourceTreeSha = '8'.repeat(40);
+  const aggregate = { sourceSha: evidenceSourceSha, digest: 'old-digest' };
+  const rebound = bindKungfuPublicationGateAggregate({
+    aggregate,
+    evidenceSourceSha,
+    targetSourceSha,
+    targetSourceTreeSha: sourceTreeSha,
+    expectedSourceTreeSha: sourceTreeSha,
+    rebindPublicationGateAggregateForEquivalentTree: (value, binding) => ({
+      ...value,
+      sourceSha: binding.targetSourceSha,
+      candidateReuse: {
+        action: 'reused',
+        evidenceSourceSha: binding.evidenceSourceSha,
+        sourceTreeSha: binding.expectedSourceTreeSha,
+      },
+    }),
+  });
+
+  assert.equal(rebound.sourceSha, targetSourceSha);
+  assert.deepEqual(rebound.candidateReuse, {
+    action: 'reused',
+    evidenceSourceSha,
+    sourceTreeSha,
+  });
+});
+
+test('release candidate Passport remains bound to its evidence source before promotion rebinding', () => {
+  let validationOptions;
+  const result = validateKungfuReleaseCandidatePassport({
+    candidate: {
+      validateReleaseCandidatePassport: (options) => {
+        validationOptions = options;
+        return { ok: true, errors: [] };
+      },
+    },
+    passport: { source: { headSha: '6'.repeat(40) } },
+    targetRef: 'alpha/v4/v4.0',
+    buildSummary: { status: 'pass' },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(validationOptions.repository, 'kungfu-systems/kungfu');
+  assert.equal(validationOptions.targetChannel, 'alpha/v4/v4.0');
+  assert.equal('sourceHeadSha' in validationOptions, false);
+});
+
+test('publication Gate aggregate rejects candidate reuse for a different target tree', () => {
+  assert.throws(
+    () =>
+      bindKungfuPublicationGateAggregate({
+        aggregate: { sourceSha: '6'.repeat(40), digest: 'old-digest' },
+        evidenceSourceSha: '6'.repeat(40),
+        targetSourceSha: '7'.repeat(40),
+        targetSourceTreeSha: '8'.repeat(40),
+        expectedSourceTreeSha: '9'.repeat(40),
+        rebindPublicationGateAggregateForEquivalentTree: () => {
+          throw new Error('rebind must not run for a mismatched tree');
+        },
+      }),
+    /promotion source tree does not match the release candidate/,
+  );
 });
 
 test('real Buildchain validation starts with empty GitHub command files', () => {

--- a/scripts/assemble-kungfu-publication-gate.test.mjs
+++ b/scripts/assemble-kungfu-publication-gate.test.mjs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -10,6 +10,7 @@ import { fileURLToPath } from 'node:url';
 import {
   bindKungfuPublicationGateAggregate,
   createKungfuPublicationGateAggregate,
+  resolveGitTreeSha,
   validateKungfuReleaseCandidatePassport,
 } from './assemble-kungfu-publication-gate.mjs';
 
@@ -56,6 +57,44 @@ function fixture() {
   return { registry, gateReceipt, manifestSet };
 }
 
+function git(repositoryRoot, ...args) {
+  return execFileSync('git', args, {
+    cwd: repositoryRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function gitTreeFixture() {
+  const repositoryRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-publication-tree-test-'),
+  );
+  git(repositoryRoot, 'init', '--quiet');
+  git(repositoryRoot, 'config', 'user.name', 'Kungfu Test');
+  git(repositoryRoot, 'config', 'user.email', 'test@kungfu.invalid');
+  fs.writeFileSync(path.join(repositoryRoot, 'candidate.txt'), 'candidate\n');
+  git(repositoryRoot, 'add', 'candidate.txt');
+  git(repositoryRoot, 'commit', '--quiet', '-m', 'candidate');
+  const evidenceSourceSha = git(repositoryRoot, 'rev-parse', 'HEAD');
+  const evidenceSourceTreeSha = git(repositoryRoot, 'rev-parse', 'HEAD^{tree}');
+
+  git(repositoryRoot, 'commit', '--quiet', '--allow-empty', '-m', 'promotion');
+  const equivalentTargetSourceSha = git(repositoryRoot, 'rev-parse', 'HEAD');
+
+  fs.writeFileSync(path.join(repositoryRoot, 'candidate.txt'), 'different\n');
+  git(repositoryRoot, 'add', 'candidate.txt');
+  git(repositoryRoot, 'commit', '--quiet', '-m', 'different');
+  const differentTargetSourceSha = git(repositoryRoot, 'rev-parse', 'HEAD');
+
+  return {
+    repositoryRoot,
+    evidenceSourceSha,
+    evidenceSourceTreeSha,
+    equivalentTargetSourceSha,
+    differentTargetSourceSha,
+  };
+}
+
 test('publication Gate aggregate binds the exact four-platform artifact set', () => {
   const value = fixture();
   const aggregate = createKungfuPublicationGateAggregate({
@@ -88,33 +127,42 @@ test('publication Gate aggregate binds the exact four-platform artifact set', ()
 });
 
 test('publication Gate aggregate reuses candidate evidence for an exact target tree', () => {
-  const evidenceSourceSha = '6'.repeat(40);
-  const targetSourceSha = '7'.repeat(40);
-  const sourceTreeSha = '8'.repeat(40);
-  const aggregate = { sourceSha: evidenceSourceSha, digest: 'old-digest' };
-  const rebound = bindKungfuPublicationGateAggregate({
-    aggregate,
-    evidenceSourceSha,
-    targetSourceSha,
-    targetSourceTreeSha: sourceTreeSha,
-    expectedSourceTreeSha: sourceTreeSha,
-    rebindPublicationGateAggregateForEquivalentTree: (value, binding) => ({
-      ...value,
-      sourceSha: binding.targetSourceSha,
-      candidateReuse: {
-        action: 'reused',
-        evidenceSourceSha: binding.evidenceSourceSha,
-        sourceTreeSha: binding.expectedSourceTreeSha,
-      },
-    }),
-  });
+  const fixture = gitTreeFixture();
+  try {
+    const targetSourceTreeSha = resolveGitTreeSha({
+      repositoryRoot: fixture.repositoryRoot,
+      sourceSha: fixture.equivalentTargetSourceSha,
+    });
+    const aggregate = {
+      sourceSha: fixture.evidenceSourceSha,
+      digest: 'old-digest',
+    };
+    const rebound = bindKungfuPublicationGateAggregate({
+      aggregate,
+      evidenceSourceSha: fixture.evidenceSourceSha,
+      targetSourceSha: fixture.equivalentTargetSourceSha,
+      targetSourceTreeSha,
+      expectedSourceTreeSha: fixture.evidenceSourceTreeSha,
+      rebindPublicationGateAggregateForEquivalentTree: (value, binding) => ({
+        ...value,
+        sourceSha: binding.targetSourceSha,
+        candidateReuse: {
+          action: 'reused',
+          evidenceSourceSha: binding.evidenceSourceSha,
+          sourceTreeSha: binding.expectedSourceTreeSha,
+        },
+      }),
+    });
 
-  assert.equal(rebound.sourceSha, targetSourceSha);
-  assert.deepEqual(rebound.candidateReuse, {
-    action: 'reused',
-    evidenceSourceSha,
-    sourceTreeSha,
-  });
+    assert.equal(rebound.sourceSha, fixture.equivalentTargetSourceSha);
+    assert.deepEqual(rebound.candidateReuse, {
+      action: 'reused',
+      evidenceSourceSha: fixture.evidenceSourceSha,
+      sourceTreeSha: fixture.evidenceSourceTreeSha,
+    });
+  } finally {
+    fs.rmSync(fixture.repositoryRoot, { recursive: true, force: true });
+  }
 });
 
 test('release candidate Passport remains bound to its evidence source before promotion rebinding', () => {
@@ -138,20 +186,33 @@ test('release candidate Passport remains bound to its evidence source before pro
 });
 
 test('publication Gate aggregate rejects candidate reuse for a different target tree', () => {
-  assert.throws(
-    () =>
-      bindKungfuPublicationGateAggregate({
-        aggregate: { sourceSha: '6'.repeat(40), digest: 'old-digest' },
-        evidenceSourceSha: '6'.repeat(40),
-        targetSourceSha: '7'.repeat(40),
-        targetSourceTreeSha: '8'.repeat(40),
-        expectedSourceTreeSha: '9'.repeat(40),
-        rebindPublicationGateAggregateForEquivalentTree: () => {
-          throw new Error('rebind must not run for a mismatched tree');
-        },
-      }),
-    /promotion source tree does not match the release candidate/,
-  );
+  const fixture = gitTreeFixture();
+  try {
+    const targetSourceTreeSha = resolveGitTreeSha({
+      repositoryRoot: fixture.repositoryRoot,
+      sourceSha: fixture.differentTargetSourceSha,
+    });
+    assert.notEqual(targetSourceTreeSha, fixture.evidenceSourceTreeSha);
+    assert.throws(
+      () =>
+        bindKungfuPublicationGateAggregate({
+          aggregate: {
+            sourceSha: fixture.evidenceSourceSha,
+            digest: 'old-digest',
+          },
+          evidenceSourceSha: fixture.evidenceSourceSha,
+          targetSourceSha: fixture.differentTargetSourceSha,
+          targetSourceTreeSha,
+          expectedSourceTreeSha: fixture.evidenceSourceTreeSha,
+          rebindPublicationGateAggregateForEquivalentTree: () => {
+            throw new Error('rebind must not run for a mismatched tree');
+          },
+        }),
+      /promotion source tree does not match the release candidate/,
+    );
+  } finally {
+    fs.rmSync(fixture.repositoryRoot, { recursive: true, force: true });
+  }
 });
 
 test('real Buildchain validation starts with empty GitHub command files', () => {


### PR DESCRIPTION
## Summary

- validate the sealed release-candidate Passport against its original candidate evidence source
- rebind the qualifying publication Gate to the protected promotion SHA only when Git proves identical target and candidate trees
- preserve controller and artifact evidence on the original candidate and fail closed for any tree mismatch

This is the release-gate successor to #3475 and the Work Design closure line originating at #3453.

## Verification

- `./shifu test:release-admission`
- `./shifu check:source`

## Governance

- [x] Release evidence and provenance remain exact and fail closed
- [x] DCO sign-off is present
- [x] No architecture contract changes; existing candidate-reuse design already specifies identical-tree rebinding
- [x] No Work Design, Assignment, Project Cut, signing, artifact, or protected-branch gate is reduced

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This fixes exact-tree release candidate transport binding without changing an architecture contract."
}
-->