### PR TITLE
fix(agent): recover injected console session surface

### DIFF
--- a/framework/core/src/python/kungfu/agent/run_agent.py
+++ b/framework/core/src/python/kungfu/agent/run_agent.py
@@ -173,8 +173,6 @@ def bind_current_native_work(
     actor_id = os.environ.get("KUNGFU_AGENT_SESSION_ACTOR", f"cli:{os.getpid()}")
 
     def invoke_session(request):
-        if injected:
-            return session_surface.invoke(request)
         return session_surface.invoke_for_project(
             request,
             fallback_runtime_dir=project_runtime_dir,

--- a/framework/core/tests/python/test_agent_console_contract.py
+++ b/framework/core/tests/python/test_agent_console_contract.py
@@ -1844,6 +1844,7 @@ def test_current_native_console_uses_project_runtime_when_cli_context_is_home(
     monkeypatch, tmp_path
 ):
     requests = []
+    observed_endpoints = []
     observed_runtime_dirs = []
     project = tmp_path / "project"
     project_runtime = project / ".kungfu" / "runtime"
@@ -1892,6 +1893,7 @@ def test_current_native_console_uses_project_runtime_when_cli_context_is_home(
 
     def invoke(request, **_kwargs):
         requests.append(request)
+        observed_endpoints.append(_kwargs.get("endpoint"))
         if request["operation"] == "plan-native-bind-work":
             return {
                 "operation": "native-bind-work",
@@ -1914,6 +1916,10 @@ def test_current_native_console_uses_project_runtime_when_cli_context_is_home(
     assert [request["operation"] for request in requests] == [
         "plan-native-bind-work",
         "bind-native-work",
+    ]
+    assert observed_endpoints == [
+        run_agent.session_surface.endpoint_for_runtime(project_runtime),
+        run_agent.session_surface.endpoint_for_runtime(project_runtime),
     ]
     assert requests[1]["expectedPlanRoot"] == ROOT_HASH
 

--- a/framework/maintainability/agent-python-responsibility-map.json
+++ b/framework/maintainability/agent-python-responsibility-map.json
@@ -44,9 +44,9 @@
         "functionRisk": { "functions": 22, "total": 171, "maximum": 28 }
       },
       "current": {
-        "physicalLines": 1211,
+        "physicalLines": 1209,
         "responsibilities": 33,
-        "functionRisk": { "functions": 21, "total": 143, "maximum": 27 }
+        "functionRisk": { "functions": 21, "total": 137, "maximum": 27 }
       },
       "ownerFiles": [
         "framework/core/src/python/kungfu/agent/native_launch.py"


### PR DESCRIPTION
## Summary

Make managed fresh Console recovery resolve the Agent Session surface from the verified Project runtime when the injected Console envelope has no explicit endpoint. This closes the concrete acceptance gap found by the real installer Assignment recovery without changing the public recovery protocol or lifecycle semantics.

## Related issue

Follow-up to #3483 and the existing fresh-recovery delivery.

## Changes

- route injected and ambient native-work binding through the same project-scoped Agent Session resolver
- preserve explicit endpoints when present and revive the verified Project runtime surface when absent
- add a regression assertion for the no-endpoint injected Console case
- refresh the required Python responsibility projection for the smaller function body

## Verification

- 94 relevant Python tests passed
- exact-base changed-code function-risk check passed with zero findings
- full `./shifu check:source` passed: 1186 passed, 11 skipped, 0 failed
- no release or tag is created by this PR

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded runtime recovery correction preserves the existing public fresh-recovery protocol and architecture contract."
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [x] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

Boundary: this touches generic Agent Session/CLI runtime resolution only; it adds no provider-specific schema, external call, credential, billing, or usage behavior.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required; public protocol and CLI shape are unchanged)
