### PR TITLE
fix(release): linearize sealed KFD Alpha candidate

### DIFF
--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.3",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.3",
-    "sourceSha": "8a61217a72a50a332899d471ce819b30334fd84d"
+    "sourceSha": "77fab2f93d96b7e5de161d40c1125aaea9755768"
   },
   "claims": [
     {

--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.3",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.3",
-    "sourceSha": "ab94032dd9cbb9e2bc5f8992898a39711553d57f"
+    "sourceSha": "8a61217a72a50a332899d471ce819b30334fd84d"
   },
   "claims": [
     {

--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.3",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.3",
-    "sourceSha": "77fab2f93d96b7e5de161d40c1125aaea9755768"
+    "sourceSha": "ab35fdf82db27a85ed7ca03d766fc519a85ed688"
   },
   "claims": [
     {

--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.3",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.3",
-    "sourceSha": "b900dfd7aba25ebb67ee22d493728f4cd40e9c85"
+    "sourceSha": "ab94032dd9cbb9e2bc5f8992898a39711553d57f"
   },
   "claims": [
     {

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "77fab2f93d96b7e5de161d40c1125aaea9755768",
+    "sourceSha": "ab35fdf82db27a85ed7ca03d766fc519a85ed688",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:94e3051ed06b5e852b46f3572d28fa36682ee989f6ab4a618993863e8ae33288"
   },

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "8a61217a72a50a332899d471ce819b30334fd84d",
+    "sourceSha": "77fab2f93d96b7e5de161d40c1125aaea9755768",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:94e3051ed06b5e852b46f3572d28fa36682ee989f6ab4a618993863e8ae33288"
   },

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "b900dfd7aba25ebb67ee22d493728f4cd40e9c85",
+    "sourceSha": "ab94032dd9cbb9e2bc5f8992898a39711553d57f",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:94e3051ed06b5e852b46f3572d28fa36682ee989f6ab4a618993863e8ae33288"
   },

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "ab94032dd9cbb9e2bc5f8992898a39711553d57f",
+    "sourceSha": "8a61217a72a50a332899d471ce819b30334fd84d",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:94e3051ed06b5e852b46f3572d28fa36682ee989f6ab4a618993863e8ae33288"
   },

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:1b7973d82a3b56ec2a6c8277597e220af84a0008e49da65f7e7bb1cda17ed9ca"
+            "sha256": "sha256:56a94a5ebbe0b62fa0921cfbd1bab6906b93126095bdd612345ec72344a7bbd0"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:56a94a5ebbe0b62fa0921cfbd1bab6906b93126095bdd612345ec72344a7bbd0"
+            "sha256": "sha256:09f3d4845bc4209f7ea2547a617a9b11148fa8aac63558d7314d3c91db40f901"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-          "sha256": "sha256:57edd08ced28e67da22fea86aa542dde8fb18441211be2505125ccdfbdd02102"
+            "sha256": "sha256:c2f4f077dd49e54bb49a9a72f49e4870d8e247a6c5764f4478e71433ffddcdea"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:c2f4f077dd49e54bb49a9a72f49e4870d8e247a6c5764f4478e71433ffddcdea"
+            "sha256": "sha256:1b7973d82a3b56ec2a6c8277597e220af84a0008e49da65f7e7bb1cda17ed9ca"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.3",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.3",
-    "sourceSha": "8a61217a72a50a332899d471ce819b30334fd84d"
+    "sourceSha": "77fab2f93d96b7e5de161d40c1125aaea9755768"
   },
   "claims": [
     {

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.3",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.3",
-    "sourceSha": "ab94032dd9cbb9e2bc5f8992898a39711553d57f"
+    "sourceSha": "8a61217a72a50a332899d471ce819b30334fd84d"
   },
   "claims": [
     {

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.3",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.3",
-    "sourceSha": "77fab2f93d96b7e5de161d40c1125aaea9755768"
+    "sourceSha": "ab35fdf82db27a85ed7ca03d766fc519a85ed688"
   },
   "claims": [
     {

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.3",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.3",
-    "sourceSha": "b900dfd7aba25ebb67ee22d493728f4cd40e9c85"
+    "sourceSha": "ab94032dd9cbb9e2bc5f8992898a39711553d57f"
   },
   "claims": [
     {

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:1b7973d82a3b56ec2a6c8277597e220af84a0008e49da65f7e7bb1cda17ed9ca"
+            "sha256": "sha256:56a94a5ebbe0b62fa0921cfbd1bab6906b93126095bdd612345ec72344a7bbd0"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:56a94a5ebbe0b62fa0921cfbd1bab6906b93126095bdd612345ec72344a7bbd0"
+            "sha256": "sha256:09f3d4845bc4209f7ea2547a617a9b11148fa8aac63558d7314d3c91db40f901"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:c2f4f077dd49e54bb49a9a72f49e4870d8e247a6c5764f4478e71433ffddcdea"
+            "sha256": "sha256:1b7973d82a3b56ec2a6c8277597e220af84a0008e49da65f7e7bb1cda17ed9ca"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:57edd08ced28e67da22fea86aa542dde8fb18441211be2505125ccdfbdd02102"
+            "sha256": "sha256:c2f4f077dd49e54bb49a9a72f49e4870d8e247a6c5764f4478e71433ffddcdea"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/framework/core/src/python/kungfu/assignment_runtime/fresh_recovery.py
+++ b/framework/core/src/python/kungfu/assignment_runtime/fresh_recovery.py
@@ -54,10 +54,12 @@ def _current_session(runtime_dir: str) -> JsonObject:
 
 
 def preserved_state(status: Mapping[str, Any]) -> JsonObject:
-    """Retain every native lifecycle field while excluding the query proof cut."""
+    """Retain native lifecycle authority, not reader-specific projections."""
 
     return {
-        str(key): value for key, value in status.items() if key != "query_proof_root"
+        str(key): value
+        for key, value in status.items()
+        if key not in {"query_proof_root", "work_semantics"}
     }
 
 

--- a/framework/core/src/python/kungfu/cli/commands/agent_work_lab.py
+++ b/framework/core/src/python/kungfu/cli/commands/agent_work_lab.py
@@ -11,6 +11,7 @@ from kungfu import agent as agent_pack
 from kungfu import agent_work_lab as lab
 from kungfu import assignment_orchestration as orchestration
 from kungfu import config as kungfu_config
+from kungfu import profile_sdk
 from kungfu import project_template
 from kungfu.project_tour import orchestration as project_tour_runtime
 from kungfu import projects as project_registry
@@ -624,6 +625,7 @@ class _NativeProjectTourOperations:
 @click.option("--allow-foreign-binding", is_flag=True, hidden=True)
 @kfd3_api("kungfu.agent-work-lab")
 @kfc.pass_context()
+@profile_sdk.validation_scope()
 def project_tour_run(
     ctx,
     destination,

--- a/framework/core/src/python/kungfu/cli/tui_runtime.py
+++ b/framework/core/src/python/kungfu/cli/tui_runtime.py
@@ -10,6 +10,7 @@
 # command, alias, or compatibility shim.
 
 import os
+import subprocess
 import sys
 
 import click
@@ -57,6 +58,17 @@ def _configure_tui_skill_runtime_audit(home, runtime_dir):
     return output
 
 
+def _run_tui_entry(entry, commands=()):
+    controller = os.environ.get("KUNGFU_CONTROLLER_ENTRYPOINT")
+    if controller and os.path.isfile(controller):
+        # The installed controller loads Node with native-addon symbols globally.
+        environment = os.environ.copy()
+        environment["KUNGFU_AS_VARIANT"] = "node"
+        environment["KUNGFU_NODE_VARIANT_ENTRY"] = entry
+        return subprocess.call([controller, entry, *commands], env=environment)
+    return kungfu.__binding__.libnode.run(sys.argv[0], entry, *commands)
+
+
 def run_tui(ctx, commands=()):
     """Launch the shipped TUI without creating a second command authority."""
 
@@ -68,5 +80,4 @@ def run_tui(ctx, commands=()):
             "kungfu TUI bundle not found; the packaged app ships it under "
             "Resources/tui, or set KUNGFU_TUI_ENTRY to a built tui.mjs"
         )
-    argv = [sys.argv[0], entry, *commands]
-    return kungfu.__binding__.libnode.run(*argv)
+    return _run_tui_entry(entry, commands)

--- a/framework/core/tests/python/test_agent_work_lab.py
+++ b/framework/core/tests/python/test_agent_work_lab.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
-from kungfu import agent_work_lab, assignment_evidence
+from kungfu import agent_work_lab, assignment_evidence, profile_sdk
 from kungfu.agent import runtime_profiles
 from kungfu.cli.commands import kfc
 from kungfu.cli.commands import agent_work_lab as agent_work_lab_commands  # noqa: F401
@@ -375,7 +375,9 @@ def test_project_tour_episode_cli_invokes_one_native_controller(monkeypatch, tmp
     observed = []
 
     def run_episode(request, operations, emit):
-        observed.append((request, operations))
+        observed.append(
+            (request, operations, profile_sdk._VALIDATION_SCOPE.get() is not None)
+        )
         emit(
             {
                 "schema": "kungfu.project-tour.episode-event/v1",
@@ -425,11 +427,13 @@ def test_project_tour_episode_cli_invokes_one_native_controller(monkeypatch, tmp
 
     assert result.exit_code == 0, result.output
     assert len(observed) == 1
-    request, operations = observed[0]
+    request, operations, validation_scoped = observed[0]
     assert request.destination == str(destination.resolve())
     assert request.episode == "2"
     assert request.resume is True
     assert operations.__class__.__name__ == "_NativeProjectTourOperations"
+    assert validation_scoped is True
+    assert profile_sdk._VALIDATION_SCOPE.get() is None
     lines = [json.loads(line) for line in result.output.splitlines()]
     assert [line["schema"] for line in lines] == [
         "kungfu.project-tour.episode-event/v1",

--- a/framework/core/tests/python/test_tui_runtime.py
+++ b/framework/core/tests/python/test_tui_runtime.py
@@ -70,3 +70,47 @@ def test_packaged_tui_projects_one_shared_runtime_audit_file(tmp_path, monkeypat
     )
     assert os.environ["KF_SKILL_RUNTIME_AUDIT_FILE"] == output
     assert written == [(output, {"schema": "fixture", "home": str(tmp_path / "home")})]
+
+
+def test_installed_tui_uses_the_native_product_node_host(tmp_path, monkeypatch):
+    tui_runtime = _load_tui_runtime(monkeypatch)
+    controller = tmp_path / "runtime" / "kungfu"
+    controller.parent.mkdir()
+    controller.write_bytes(b"")
+    entry = tmp_path / "tui" / "tui.mjs"
+    entry.parent.mkdir()
+    entry.write_bytes(b"")
+    calls = []
+    monkeypatch.setenv("KUNGFU_CONTROLLER_ENTRYPOINT", str(controller))
+    monkeypatch.setattr(
+        tui_runtime.subprocess,
+        "call",
+        lambda argv, **kwargs: calls.append((argv, kwargs)) or 23,
+    )
+
+    status = tui_runtime._run_tui_entry(str(entry), ("--project-tour-episode", "1"))
+
+    assert status == 23
+    assert calls[0][0] == [
+        str(controller),
+        str(entry),
+        "--project-tour-episode",
+        "1",
+    ]
+    assert calls[0][1]["env"]["KUNGFU_AS_VARIANT"] == "node"
+    assert calls[0][1]["env"]["KUNGFU_NODE_VARIANT_ENTRY"] == str(entry)
+
+
+def test_source_tui_keeps_the_binding_fallback(tmp_path, monkeypatch):
+    tui_runtime = _load_tui_runtime(monkeypatch)
+    calls = []
+    tui_runtime.kungfu.__binding__ = types.SimpleNamespace(
+        libnode=types.SimpleNamespace(run=lambda *argv: calls.append(argv) or 17)
+    )
+    monkeypatch.delenv("KUNGFU_CONTROLLER_ENTRYPOINT", raising=False)
+    entry = str(tmp_path / "tui.mjs")
+
+    status = tui_runtime._run_tui_entry(entry, ("--agent-work-lab-autoplay",))
+
+    assert status == 17
+    assert calls == [(sys.argv[0], entry, "--agent-work-lab-autoplay")]

--- a/framework/core/tests/python/test_work_authority_surface.py
+++ b/framework/core/tests/python/test_work_authority_surface.py
@@ -1178,6 +1178,44 @@ def test_fresh_recovery_apply_preserves_complete_lifecycle_state():
     assert [event[0] for event in events] == ["profile", "bind"]
 
 
+def test_fresh_recovery_ignores_profile_reader_work_semantics_projection():
+    status, binding, plan = _fresh_recovery_fixture()
+    projected = json.loads(json.dumps(status))
+    projected["work_semantics"] = {
+        "schema": "kungfu.work-semantics.status/v1",
+        "phase": "completion-claimed",
+        "next_actions": [{"action": "record-input-snapshot"}],
+    }
+    observations = iter(
+        [
+            projected,
+            json.loads(json.dumps(status)),
+            json.loads(json.dumps(status)),
+        ]
+    )
+
+    receipt = assignment_fresh_recovery.apply_plan(
+        plan,
+        expected_plan_root=plan["planRoot"],
+        authorized_by="maintainer:test",
+        status_reader=lambda: next(observations),
+        session_reader=lambda: dict(binding["session"]),
+        prepare_profile=lambda _actor: {},
+        bind_work=lambda expected: {
+            "workRef": dict(expected["workRef"]),
+            "receipt": {"receiptRoot": f"sha256:{'8' * 64}"},
+        },
+        now="2026-08-25T09:01:00Z",
+    )
+
+    assert receipt["ok"] is True
+    assert receipt["assignmentWrites"] == []
+    assert (
+        receipt["preservation"]["lifecycleStateRoot"]
+        == plan["work"]["lifecycleStateRoot"]
+    )
+
+
 def test_fresh_recovery_fails_closed_on_attempt_plan_or_state_drift():
     status, binding, plan = _fresh_recovery_fixture()
     with __import__("pytest").raises(ValueError, match="new SessionAttempt"):

--- a/framework/release/kfd-candidate-evidence.mjs
+++ b/framework/release/kfd-candidate-evidence.mjs
@@ -88,28 +88,6 @@ const GENERATOR_OWNED_PATHS = [
   'developer/sdk/kfd',
 ];
 
-const GITHUB_RUNNER_PLATFORMS = new Map([
-  ['Linux:X64', 'linux-x64'],
-  ['Linux:ARM64', 'linux-arm64'],
-  ['macOS:ARM64', 'macos-arm64'],
-  ['Windows:X64', 'windows-x64'],
-]);
-
-export function resolveKfdSourcePlatform(env = process.env) {
-  const explicit = env.BUILDCHAIN_PLATFORM_ID || env['INPUT_PLATFORM-ID'];
-  if (explicit) return explicit;
-  const runnerOs = env.RUNNER_OS || '';
-  const runnerArch = env.RUNNER_ARCH || '';
-  if (!runnerOs && !runnerArch) return '';
-  const platform = GITHUB_RUNNER_PLATFORMS.get(`${runnerOs}:${runnerArch}`);
-  if (!platform) {
-    throw new Error(
-      `unsupported KFD source runner platform: ${runnerOs || '<empty>'}/${runnerArch || '<empty>'}`,
-    );
-  }
-  return platform;
-}
-
 function canonicalJson(value) {
   if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
   if (value && typeof value === 'object') {
@@ -137,6 +115,21 @@ export function kfdEvidenceRoot(value) {
   return rooted(value);
 }
 
+export function kfdPlatformId(
+  hostPlatform = process.platform,
+  hostArch = process.arch,
+) {
+  const platform =
+    hostPlatform === 'darwin'
+      ? 'macos'
+      : hostPlatform === 'win32'
+        ? 'windows'
+        : hostPlatform;
+  const arch = hostArch === 'x64' ? 'x64' : hostArch;
+  const candidate = `${platform}-${arch}`;
+  return SUPPORTED_KFD_PLATFORMS.includes(candidate) ? candidate : '';
+}
+
 function toPosix(value) {
   return value.split(path.sep).join('/');
 }
@@ -160,15 +153,16 @@ function gitValue(root, args) {
   return result.stdout.trim();
 }
 
-function resolveIdentity(root, sourceSha = '', sourceTree = '') {
-  const head = gitValue(root, ['rev-parse', 'HEAD']);
-  const tree = gitValue(root, ['rev-parse', 'HEAD^{tree}']);
-  const resolvedSha = sourceSha || process.env.BUILDCHAIN_SOURCE_SHA || head;
-  const resolvedTree =
-    sourceTree || process.env.BUILDCHAIN_SOURCE_TREE_SHA || tree;
-  if (resolvedSha !== head) {
+function assertCheckoutIdentity({
+  resolvedSha,
+  resolvedTree,
+  declaredTree,
+  head,
+  tree,
+}) {
+  if (resolvedSha !== head && !declaredTree) {
     throw new Error(
-      `candidate source root mismatch: expected ${resolvedSha}, checkout is ${head}`,
+      `candidate source commit mismatch without an exact tree binding: expected ${resolvedSha}, checkout is ${head}`,
     );
   }
   if (resolvedTree !== tree) {
@@ -176,7 +170,31 @@ function resolveIdentity(root, sourceSha = '', sourceTree = '') {
       `candidate source tree mismatch: expected ${resolvedTree}, checkout is ${tree}`,
     );
   }
-  return { sourceSha: resolvedSha, sourceTree: resolvedTree };
+}
+
+function sourceIdentity(resolvedSha, resolvedTree, head) {
+  return {
+    sourceSha: resolvedSha,
+    sourceTree: resolvedTree,
+    checkoutSha: head,
+    checkoutBinding: 'checkout-tree-verified',
+  };
+}
+
+function resolveIdentity(root, sourceSha = '', sourceTree = '') {
+  const head = gitValue(root, ['rev-parse', 'HEAD']);
+  const tree = gitValue(root, ['rev-parse', 'HEAD^{tree}']);
+  const resolvedSha = sourceSha || process.env.BUILDCHAIN_SOURCE_SHA || head;
+  const declaredTree = sourceTree || process.env.BUILDCHAIN_SOURCE_TREE_SHA;
+  const resolvedTree = declaredTree || tree;
+  assertCheckoutIdentity({
+    resolvedSha,
+    resolvedTree,
+    declaredTree,
+    head,
+    tree,
+  });
+  return sourceIdentity(resolvedSha, resolvedTree, head);
 }
 
 function fileRows(root, relativePaths) {
@@ -261,7 +279,9 @@ export function sealKfdSourceEvidence({
   expectedInputRoot = '',
   sourceSha = '',
   sourceTree = '',
-  platform = resolveKfdSourcePlatform(),
+  platform = process.env.BUILDCHAIN_PLATFORM_ID ||
+    process.env['INPUT_PLATFORM-ID'] ||
+    kfdPlatformId(),
 } = {}) {
   if (platform) assertPlatform(platform);
   const prebuild = createKfdPrebuildGate({ root, sourceSha, sourceTree });
@@ -391,9 +411,15 @@ export function prepareKfdArtifactWitness({
   if (!fs.existsSync(sourceGatePath))
     throw new Error('missing sealed KFD source gate');
   const sourceGate = readJson(sourceGatePath);
+  if (sourceGate.status !== 'passed') {
+    throw new Error('KFD source gate is not passed');
+  }
+  if (sourceGate.platform !== platform) {
+    throw new Error(
+      `KFD source gate platform mismatch: expected ${platform}, got ${sourceGate.platform || '<empty>'}`,
+    );
+  }
   if (
-    sourceGate.status !== 'passed' ||
-    sourceGate.platform !== platform ||
     sourceGate.candidate?.sourceSha !== identity.sourceSha ||
     sourceGate.candidate?.sourceTree !== identity.sourceTree
   ) {
@@ -434,7 +460,7 @@ export function prepareKfdArtifactWitness({
   return witness;
 }
 
-function loadKfdArtifactWitness({
+export function finalizeKfdCandidateEvidence({
   root = process.cwd(),
   platform = process.env.BUILDCHAIN_PLATFORM_ID || '',
   sourceSha = '',
@@ -448,8 +474,12 @@ function loadKfdArtifactWitness({
   if (!fs.existsSync(witnessPath))
     throw new Error(`missing KFD artifact witness: ${platform}`);
   const witness = readJson(witnessPath);
-  const { bindingRoot, ...bindingBodyBeforeFinalize } =
-    witness.candidateBinding || {};
+  const artifact = releaseArtifactRoot(root);
+  if (witness.candidateBinding?.artifactRoot !== artifact.root) {
+    throw new Error(
+      `KFD artifact digest mismatch: expected ${witness.candidateBinding?.artifactRoot || '<empty>'}, got ${artifact.root}`,
+    );
+  }
   if (
     witness.candidateBinding?.candidate?.sourceSha !== identity.sourceSha ||
     witness.candidateBinding?.candidate?.sourceTree !== identity.sourceTree ||
@@ -457,44 +487,6 @@ function loadKfdArtifactWitness({
   ) {
     throw new Error('KFD artifact witness candidate/source root mismatch');
   }
-  if (bindingRoot !== rooted(bindingBodyBeforeFinalize)) {
-    throw new Error('KFD artifact witness binding digest mismatch');
-  }
-  return { identity, output, sourceGate, witness, witnessPath };
-}
-
-function bindVerifiedArtifactTransition(args = {}) {
-  const { identity, sourceGate, witness, witnessPath } =
-    loadKfdArtifactWitness(args);
-  const artifact = releaseArtifactRoot(args.root || process.cwd());
-  if (witness.candidateBinding?.artifactRoot !== artifact.root) {
-    const bindingBody = {
-      contract: KFD_ARTIFACT_WITNESS_CONTRACT,
-      platform: witness.candidateBinding.platform,
-      candidate: identity,
-      sourceGateRoot: sourceGate.gateRoot,
-      preVerifyArtifactRoot: witness.candidateBinding.artifactRoot,
-      artifactRoot: artifact.root,
-      transition: 'verified-qualification',
-    };
-    witness.candidateBinding = {
-      ...bindingBody,
-      bindingRoot: rooted(bindingBody),
-    };
-    writeJson(witnessPath, witness);
-  }
-}
-
-export function finalizeKfdCandidateEvidence(args = {}) {
-  const { identity, output, sourceGate, witness } =
-    loadKfdArtifactWitness(args);
-  const artifact = releaseArtifactRoot(args.root || process.cwd());
-  if (witness.candidateBinding?.artifactRoot !== artifact.root) {
-    throw new Error(
-      `KFD artifact digest mismatch: expected ${witness.candidateBinding?.artifactRoot || '<empty>'}, got ${artifact.root}`,
-    );
-  }
-  const platform = args.platform || process.env.BUILDCHAIN_PLATFORM_ID || '';
   const evidenceFiles = listFiles(output, output).filter(
     (row) => row.path !== 'candidate-evidence.json',
   );
@@ -651,39 +643,19 @@ export function runVerifiedQualification({
   sourceTree,
   buildArtifactWitness,
 }) {
+  const result = spawnSync(command[0], command.slice(1), {
+    cwd: root,
+    env: process.env,
+    stdio: 'inherit',
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) return result.status || 1;
   prepareKfdArtifactWitness({
     root,
     platform,
     sourceSha,
     sourceTree,
     buildArtifactWitness,
-  });
-  const output = path.join(root, 'product', 'release', 'qualification', 'kfd');
-  const sealed = path.join(
-    root,
-    '.buildchain',
-    'runtime',
-    'kfd-candidate-evidence',
-    'artifact-before-verify',
-  );
-  fs.rmSync(sealed, { recursive: true, force: true });
-  fs.mkdirSync(path.dirname(sealed), { recursive: true });
-  fs.renameSync(output, sealed);
-  const result = spawnSync(command[0], command.slice(1), {
-    cwd: root,
-    env: process.env,
-    stdio: 'inherit',
-  });
-  fs.rmSync(output, { recursive: true, force: true });
-  fs.mkdirSync(path.dirname(output), { recursive: true });
-  fs.renameSync(sealed, output);
-  if (result.error) throw result.error;
-  if (result.status !== 0) return result.status || 1;
-  bindVerifiedArtifactTransition({
-    root,
-    platform,
-    sourceSha,
-    sourceTree,
   });
   finalizeKfdCandidateEvidence({ root, platform, sourceSha, sourceTree });
   return 0;

--- a/framework/release/kfd-candidate-evidence.mjs
+++ b/framework/release/kfd-candidate-evidence.mjs
@@ -391,6 +391,54 @@ function assertPlatform(platform) {
   }
 }
 
+function validateSealedSourceGate({
+  sourceGate,
+  sourceDir,
+  platform,
+  identity,
+}) {
+  const { gateRoot, ...gateBody } = sourceGate;
+  if (gateRoot !== rooted(gateBody)) {
+    throw new Error('KFD source gate digest mismatch');
+  }
+  if (sourceGate.status !== 'passed') {
+    throw new Error('KFD source gate is not passed');
+  }
+  if (sourceGate.platform !== platform) {
+    throw new Error(
+      `KFD source gate platform mismatch: expected ${platform}, got ${sourceGate.platform || '<empty>'}`,
+    );
+  }
+  if (
+    sourceGate.candidate?.sourceSha !== identity.sourceSha ||
+    sourceGate.candidate?.sourceTree !== identity.sourceTree
+  ) {
+    throw new Error('KFD source gate candidate/source root mismatch');
+  }
+  if (sourceGate.evidenceRoot !== rooted(sourceGate.generatedEvidence || [])) {
+    throw new Error('KFD source evidence root mismatch');
+  }
+  const sourceRoot = path.resolve(sourceDir);
+  for (const row of sourceGate.generatedEvidence || []) {
+    const evidencePath = path.resolve(sourceRoot, String(row.path || ''));
+    if (
+      evidencePath === sourceRoot ||
+      !evidencePath.startsWith(`${sourceRoot}${path.sep}`) ||
+      !fs.existsSync(evidencePath)
+    ) {
+      throw new Error(
+        `missing sealed KFD source evidence: ${row.path || '<empty>'}`,
+      );
+    }
+    if (
+      fs.statSync(evidencePath).size !== row.bytes ||
+      `sha256:${sha256File(evidencePath)}` !== row.sha256
+    ) {
+      throw new Error(`tampered sealed KFD source evidence: ${row.path}`);
+    }
+  }
+}
+
 export function prepareKfdArtifactWitness({
   root = process.cwd(),
   platform = process.env.BUILDCHAIN_PLATFORM_ID || '',
@@ -411,20 +459,12 @@ export function prepareKfdArtifactWitness({
   if (!fs.existsSync(sourceGatePath))
     throw new Error('missing sealed KFD source gate');
   const sourceGate = readJson(sourceGatePath);
-  if (sourceGate.status !== 'passed') {
-    throw new Error('KFD source gate is not passed');
-  }
-  if (sourceGate.platform !== platform) {
-    throw new Error(
-      `KFD source gate platform mismatch: expected ${platform}, got ${sourceGate.platform || '<empty>'}`,
-    );
-  }
-  if (
-    sourceGate.candidate?.sourceSha !== identity.sourceSha ||
-    sourceGate.candidate?.sourceTree !== identity.sourceTree
-  ) {
-    throw new Error('KFD source gate candidate/source root mismatch');
-  }
+  validateSealedSourceGate({
+    sourceGate,
+    sourceDir: path.join(runtimeDir, 'source'),
+    platform,
+    identity,
+  });
   const artifact = releaseArtifactRoot(root);
   const baseWitness = buildArtifactWitness();
   const platformPrebuildPath = path.join(
@@ -474,6 +514,16 @@ export function finalizeKfdCandidateEvidence({
   if (!fs.existsSync(witnessPath))
     throw new Error(`missing KFD artifact witness: ${platform}`);
   const witness = readJson(witnessPath);
+  validateSealedSourceGate({
+    sourceGate,
+    sourceDir: path.join(output, 'source'),
+    platform,
+    identity,
+  });
+  const { bindingRoot, ...bindingBody } = witness.candidateBinding || {};
+  if (bindingRoot !== rooted(bindingBody)) {
+    throw new Error('KFD artifact witness binding digest mismatch');
+  }
   const artifact = releaseArtifactRoot(root);
   if (witness.candidateBinding?.artifactRoot !== artifact.root) {
     throw new Error(

--- a/framework/tui/src/main.tsx
+++ b/framework/tui/src/main.tsx
@@ -134,6 +134,7 @@ import {
   resolveTuiCliRuntime,
   resolveTuiProductPaths,
   resolveTuiRuntimeDir,
+  tuiAttachedAgentSessionEnvironment,
 } from './terminal-lifecycle.js';
 import {
   globalWorkContribution,
@@ -170,7 +171,10 @@ function tuiAgentSessionEnvironment(
     KUNGFU_PROJECT_WORK_AGENT_SESSION: '1',
   };
 }
-function ensureTuiAgentSession(runtimeDir: string): Promise<string> {
+function ensureTuiAgentSession(
+  runtimeDir: string,
+  attached = false,
+): Promise<string> {
   const resolvedRuntimeDir = path.resolve(runtimeDir);
   if (
     tuiAgentSessionReady &&
@@ -204,12 +208,16 @@ function ensureTuiAgentSession(runtimeDir: string): Promise<string> {
   process.env.KUNGFU_PROJECT_WORK_AGENT_SESSION = '1';
   const paths = runtimePaths();
   const mockScenario = process.env.KUNGFU_MOCK_AGENT_SCENARIO;
-  const deterministicMock = Boolean(mockScenario?.trim());
+  const deterministicMock = attached || Boolean(mockScenario?.trim());
   const host = deterministicMock
     ? createAttachedAgentSessionHost({
         runtimeDir: resolvedRuntimeDir,
         ptyModule: process.env.KUNGFU_AGENT_SESSION_NODE_PTY_MODULE,
-        env: process.env,
+        env: tuiAttachedAgentSessionEnvironment({
+          env: process.env,
+          packagedBin: paths.packagedBin,
+          mockPath,
+        }),
       })
     : createDetachedAgentSessionHost({
         runtimeDir: resolvedRuntimeDir,
@@ -389,7 +397,7 @@ async function openTuiAgentWorkLab(projectTour = false): Promise<AgentWorkLab> {
   const cli = tuiCliInvocation(paths);
   bindMockAgentEnvironment(cli, paths);
   if (projectTour) {
-    const endpoint = await ensureTuiAgentSession(paths.runtimeDir);
+    const endpoint = await ensureTuiAgentSession(paths.runtimeDir, true);
     cli.env.KUNGFU_AGENT_SESSION_ENDPOINT = endpoint;
     cli.env.KUNGFU_ASSIGNMENT_ADMIT_ALLOW_FOREIGN_BINDING = '1';
   }

--- a/framework/tui/src/project-tour-view.test.ts
+++ b/framework/tui/src/project-tour-view.test.ts
@@ -53,17 +53,16 @@ test('Project Work awaits the shared Agent Session before rendering', () => {
   );
   assert.match(
     lab,
-    /const endpoint = await ensureTuiAgentSession\(paths\.runtimeDir\)/u,
+    /const endpoint = await ensureTuiAgentSession\(paths\.runtimeDir, true\)/u,
   );
   assert.match(lab, /cli\.env\.KUNGFU_AGENT_SESSION_ENDPOINT = endpoint/u);
   assert.match(
     lab,
     /execFileEvents: async[\s\S]*?await ensureTuiAgentSession\(tuiAgentSessionRuntimeDir\)/u,
   );
-  assert.match(lab, /bindTuiMockAgentEnvironment\(\{/u);
+  assert.match(lab, /bindMockAgentEnvironment\(cli, paths\)/u);
   assert.ok(
-    lab.indexOf('bindTuiMockAgentEnvironment') <
-      lab.indexOf('if (projectTour)'),
+    lab.indexOf('bindMockAgentEnvironment') < lab.indexOf('if (projectTour)'),
     'installed Mock Agent paths must be bound outside Project Tour mode',
   );
   assert.doesNotMatch(

--- a/framework/tui/src/projects-view.test.ts
+++ b/framework/tui/src/projects-view.test.ts
@@ -318,11 +318,15 @@ test('Project Session discovery follows the current runtime host after Project r
   const source = readFileSync(new URL('./main.tsx', import.meta.url), 'utf8');
   const invokeCurrent = source.slice(
     source.indexOf('async function invokeTuiAgentSession'),
-    source.indexOf('function cliEnvironment'),
+    source.indexOf('function runtimePaths'),
   );
   const openProjects = source.slice(
     source.indexOf('function openTuiProjects'),
     source.indexOf('function ProjectFileTreeNavigation'),
+  );
+  const bindMockEnvironment = source.slice(
+    source.indexOf('function bindMockAgentEnvironment'),
+    source.indexOf('function streamCliEvents'),
   );
 
   assert.match(invokeCurrent, /const ready = tuiAgentSessionReady/);
@@ -340,11 +344,12 @@ test('Project Session discovery follows the current runtime host after Project r
     openProjects,
     /ensureTuiAgentSession\(paths\.runtimeDir\)/,
   );
-  assert.match(openProjects, /bindTuiMockAgentEnvironment\(\{/);
+  assert.match(bindMockEnvironment, /bindTuiMockAgentEnvironment\(\{/);
+  assert.match(openProjects, /bindMockAgentEnvironment\(cli, paths\)/);
   assert.ok(
-    openProjects.indexOf('bindTuiMockAgentEnvironment') <
+    openProjects.indexOf('bindMockAgentEnvironment') <
       openProjects.indexOf('if (!useAgentSession)'),
     'installed Mock Agent paths must be bound for normal Project Agent Session use',
   );
-  assert.match(source, /return tuiChildCliEnvironment\(process\.env\)/);
+  assert.match(source, /return resolveTuiCliInvocation\(paths, process\.env\)/);
 });

--- a/framework/tui/src/terminal-lifecycle.test.ts
+++ b/framework/tui/src/terminal-lifecycle.test.ts
@@ -25,6 +25,7 @@ import {
   resolveTuiCliProcess,
   resolveTuiCoreDir,
   resolveTuiProductPaths,
+  tuiAttachedAgentSessionEnvironment,
   tuiChildCliEnvironment,
 } from './terminal-lifecycle.js';
 
@@ -124,7 +125,7 @@ test('cached Agent Session readiness is revalidated before reuse', () => {
   );
 });
 
-test('deterministic Mock onboarding owns an attached Session host', () => {
+test('deterministic Project Tour and Mock onboarding own an attached Session host', () => {
   const source = fs.readFileSync(
     new URL('./main.tsx', import.meta.url),
     'utf8',
@@ -138,8 +139,31 @@ test('deterministic Mock onboarding owns an attached Session host', () => {
     ensureSession,
     /KUNGFU_MOCK_AGENT_SCENARIO[\s\S]*createAttachedAgentSessionHost/u,
   );
+  assert.match(source, /ensureTuiAgentSession\(paths\.runtimeDir, true\)/u);
   assert.match(ensureSession, /async function closeTuiAgentSession/u);
   assert.match(source, /finally \{\s*await closeTuiAgentSession\(\);\s*\}/u);
+});
+
+test('attached Agent Session launches Mock Agent outside the active TUI entry', () => {
+  const parent = {
+    KUNGFU_AS_VARIANT: 'node',
+    KUNGFU_NODE_VARIANT_ENTRY: '/product/tui/tui.mjs',
+    KUNGFU_INSTALL_SOURCE: 'archive',
+  };
+
+  const child = tuiAttachedAgentSessionEnvironment({
+    env: parent,
+    packagedBin: '/product/runtime/kungfu',
+    mockPath: '/product/tui/mock-agent.mjs',
+  });
+
+  assert.equal(child.KUNGFU_AS_VARIANT, 'node');
+  assert.equal(child.KUNGFU_NODE_VARIANT_ENTRY, undefined);
+  assert.equal(child.KUNGFU_INSTALL_SOURCE, 'archive');
+  assert.equal(child.KUNGFU_MOCK_AGENT_EXECUTABLE, '/product/runtime/kungfu');
+  assert.equal(child.KUNGFU_MOCK_AGENT_SCRIPT, '/product/tui/mock-agent.mjs');
+  assert.equal(parent.KUNGFU_AS_VARIANT, 'node');
+  assert.equal(parent.KUNGFU_NODE_VARIANT_ENTRY, '/product/tui/tui.mjs');
 });
 
 test('child CLI retains installed authority without recursive libnode selection', () => {

--- a/framework/tui/src/terminal-lifecycle.ts
+++ b/framework/tui/src/terminal-lifecycle.ts
@@ -194,6 +194,28 @@ export function bindTuiMockAgentEnvironment({
   };
 }
 
+export function tuiAttachedAgentSessionEnvironment({
+  env,
+  packagedBin,
+  mockPath,
+}: {
+  env: NodeJS.ProcessEnv;
+  packagedBin: string;
+  mockPath: string;
+}): NodeJS.ProcessEnv {
+  const child = bindTuiMockAgentEnvironment({
+    env: tuiChildCliEnvironment(env),
+    packagedBin,
+    mockPath,
+  });
+  // The attached host executes the deterministic Mock Agent script through
+  // the installed Kungfu front door. Select its embedded Node variant after
+  // removing the parent TUI entry pin; otherwise the front door interprets
+  // mock-agent.mjs as a Python CLI command and exits 127.
+  child.KUNGFU_AS_VARIANT = 'node';
+  return child;
+}
+
 export function resolveTuiAgentSessionExecutable({
   env,
   cliBin,

--- a/scripts/kfd-candidate-evidence.test.mjs
+++ b/scripts/kfd-candidate-evidence.test.mjs
@@ -111,21 +111,29 @@ function artifactFixture(platform = 'linux-x64') {
     'runtime',
     'kfd-candidate-evidence',
   );
-  writeJson(path.join(runtime, 'source-gate.json'), {
+  const prebuildRelative = `kfd-3/collaboration-interface.${platform}.prebuild.json`;
+  const prebuildPath = path.join(runtime, 'source', prebuildRelative);
+  writeJson(prebuildPath, { id: `kungfu-collaboration-interface-${platform}` });
+  const generatedEvidence = [
+    {
+      path: prebuildRelative,
+      bytes: fs.statSync(prebuildPath).size,
+      sha256: `sha256:${awaitHash(prebuildPath)}`,
+    },
+  ];
+  const gateBody = {
+    schema: 'kungfu.kfd-candidate-source-gate/v1',
     status: 'passed',
+    phase: 'source-sealed',
     platform,
     candidate: { sourceSha, sourceTree },
-    gateRoot: 'sha256:source-gate',
+    generatedEvidence,
+    evidenceRoot: kfdEvidenceRoot(generatedEvidence),
+  };
+  writeJson(path.join(runtime, 'source-gate.json'), {
+    ...gateBody,
+    gateRoot: kfdEvidenceRoot(gateBody),
   });
-  writeJson(
-    path.join(
-      runtime,
-      'source',
-      'kfd-3',
-      `collaboration-interface.${platform}.prebuild.json`,
-    ),
-    { id: `kungfu-collaboration-interface-${platform}` },
-  );
   fs.mkdirSync(path.join(root, 'product', 'release'), { recursive: true });
   fs.writeFileSync(
     path.join(root, 'product', 'release', 'artifact.bin'),
@@ -320,10 +328,79 @@ test('rejects a source gate sealed for another platform', () => {
   );
   const gate = JSON.parse(fs.readFileSync(sourceGate, 'utf8'));
   gate.platform = 'linux-arm64';
+  const gateBody = Object.fromEntries(
+    Object.entries(gate).filter(([key]) => key !== 'gateRoot'),
+  );
+  gate.gateRoot = kfdEvidenceRoot(gateBody);
   writeJson(sourceGate, gate);
   assert.throws(
     () => prepareKfdArtifactWitness(fixture),
     /KFD source gate platform mismatch: expected linux-x64, got linux-arm64/u,
+  );
+});
+
+test('rejects source evidence tampered after the prebuild gate', () => {
+  const fixture = artifactFixture();
+  const sourceEvidence = path.join(
+    fixture.root,
+    '.buildchain',
+    'runtime',
+    'kfd-candidate-evidence',
+    'source',
+    'kfd-3',
+    `collaboration-interface.${fixture.platform}.prebuild.json`,
+  );
+  fs.appendFileSync(sourceEvidence, 'tampered\n');
+  assert.throws(
+    () => prepareKfdArtifactWitness(fixture),
+    /tampered sealed KFD source evidence/u,
+  );
+});
+
+test('rejects a source gate whose sealed digest no longer matches', () => {
+  const fixture = artifactFixture();
+  const sourceGate = path.join(
+    fixture.root,
+    '.buildchain',
+    'runtime',
+    'kfd-candidate-evidence',
+    'source-gate.json',
+  );
+  const gate = JSON.parse(fs.readFileSync(sourceGate, 'utf8'));
+  gate.phase = 'tampered-after-prebuild';
+  writeJson(sourceGate, gate);
+  assert.throws(
+    () => prepareKfdArtifactWitness(fixture),
+    /KFD source gate digest mismatch/u,
+  );
+});
+
+test('rejects an artifact witness binding tampered before final sealing', () => {
+  const fixture = artifactFixture();
+  prepareKfdArtifactWitness({
+    ...fixture,
+    buildArtifactWitness: () => ({
+      id: 'kungfu-collaboration-interface',
+      standard: 'kfd-3',
+      witnessKind: 'artifact',
+      exposedSurfaces: [],
+    }),
+  });
+  const witnessPath = path.join(
+    fixture.root,
+    'product',
+    'release',
+    'qualification',
+    'kfd',
+    'artifacts',
+    `${fixture.platform}.json`,
+  );
+  const witness = JSON.parse(fs.readFileSync(witnessPath, 'utf8'));
+  witness.candidateBinding.sourceGateRoot = `sha256:${'f'.repeat(64)}`;
+  writeJson(witnessPath, witness);
+  assert.throws(
+    () => finalizeKfdCandidateEvidence(fixture),
+    /KFD artifact witness (binding digest|candidate\/source root) mismatch/u,
   );
 });
 

--- a/scripts/kfd-candidate-evidence.test.mjs
+++ b/scripts/kfd-candidate-evidence.test.mjs
@@ -9,10 +9,12 @@ import test from 'node:test';
 import {
   KFD_CANDIDATE_EVIDENCE_CONTRACT,
   SUPPORTED_KFD_PLATFORMS,
+  createKfdPrebuildGate,
   finalizeKfdCandidateEvidence,
   kfdEvidenceRoot,
+  kfdPlatformId,
   prepareKfdArtifactWitness,
-  resolveKfdSourcePlatform,
+  releaseArtifactRoot,
   runVerifiedQualification,
   verifyKfdCandidatePayloadSet,
   verifyKfdManifestSet,
@@ -20,6 +22,17 @@ import {
 
 const SOURCE_SHA = 'a'.repeat(40);
 const SOURCE_TREE = 'b'.repeat(40);
+
+const SOURCE_GATE_INPUTS = [
+  '.buildchain/kfd/kfd-1/contract-world.witness.json',
+  '.buildchain/kfd/kfd-1/documentation-pack.witness.json',
+  '.buildchain/kfd/kfd-2/claims/agent-onboarding-pack.json',
+  '.buildchain/kfd/kfd-2/claims/remote-fact-boundary.json',
+  '.buildchain/kfd/kfd-2/claims/agent-work-state-contract.json',
+  '.buildchain/kfd/kfd-2/claims/cross-language-authority-membrane.json',
+  '.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json',
+  '.buildchain/kfd/support-matrix.json',
+];
 
 function writeJson(filePath, value) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -121,28 +134,55 @@ function artifactFixture(platform = 'linux-x64') {
   return { root, platform, sourceSha, sourceTree };
 }
 
-test('binds source evidence to the exact native GitHub runner platform', () => {
-  assert.equal(
-    resolveKfdSourcePlatform({ RUNNER_OS: 'Linux', RUNNER_ARCH: 'X64' }),
-    'linux-x64',
+function rematerializedSourceFixture() {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-kfd-rematerialized-source-test-'),
   );
-  assert.equal(
-    resolveKfdSourcePlatform({ RUNNER_OS: 'Linux', RUNNER_ARCH: 'ARM64' }),
-    'linux-arm64',
-  );
-  assert.equal(
-    resolveKfdSourcePlatform({ RUNNER_OS: 'macOS', RUNNER_ARCH: 'ARM64' }),
-    'macos-arm64',
-  );
-  assert.equal(
-    resolveKfdSourcePlatform({ RUNNER_OS: 'Windows', RUNNER_ARCH: 'X64' }),
-    'windows-x64',
-  );
-  assert.equal(resolveKfdSourcePlatform({}), '');
+  const git = (args) => {
+    const result = spawnSync('git', args, { cwd: root, encoding: 'utf8' });
+    assert.equal(result.status, 0, result.stderr);
+    return result.stdout.trim();
+  };
+  git(['init', '-q']);
+  git(['config', 'user.name', 'KFD Test']);
+  git(['config', 'user.email', 'kfd-test@example.invalid']);
+  for (const filePath of SOURCE_GATE_INPUTS)
+    writeJson(path.join(root, filePath), {});
+  git(['add', '.']);
+  git(['commit', '-q', '-m', 'source identity']);
+  const sourceSha = git(['rev-parse', 'HEAD']);
+  const sourceTree = git(['rev-parse', 'HEAD^{tree}']);
+  git(['commit', '-q', '--allow-empty', '-m', 'rematerialized identity']);
+  const checkoutSha = git(['rev-parse', 'HEAD']);
+  assert.notEqual(checkoutSha, sourceSha);
+  assert.equal(git(['rev-parse', 'HEAD^{tree}']), sourceTree);
+  return { root, sourceSha, sourceTree, checkoutSha };
+}
+
+test('derives every supported Buildchain platform from the native host tuple', () => {
+  assert.equal(kfdPlatformId('linux', 'x64'), 'linux-x64');
+  assert.equal(kfdPlatformId('linux', 'arm64'), 'linux-arm64');
+  assert.equal(kfdPlatformId('darwin', 'arm64'), 'macos-arm64');
+  assert.equal(kfdPlatformId('win32', 'x64'), 'windows-x64');
+  assert.equal(kfdPlatformId('darwin', 'x64'), '');
+});
+
+test('binds a rematerialized checkout only through the exact declared source tree', () => {
+  const fixture = rematerializedSourceFixture();
+  const gate = createKfdPrebuildGate(fixture);
+  assert.deepEqual(gate.candidate, {
+    sourceSha: fixture.sourceSha,
+    sourceTree: fixture.sourceTree,
+    checkoutSha: fixture.checkoutSha,
+    checkoutBinding: 'checkout-tree-verified',
+  });
   assert.throws(
     () =>
-      resolveKfdSourcePlatform({ RUNNER_OS: 'Linux', RUNNER_ARCH: 'RISCV64' }),
-    /unsupported KFD source runner platform/u,
+      createKfdPrebuildGate({
+        ...fixture,
+        sourceTree: 'f'.repeat(40),
+      }),
+    /candidate source tree mismatch/u,
   );
 });
 
@@ -158,7 +198,7 @@ test('accepts a complete sealed four-platform KFD payload set', () => {
   );
 });
 
-test('seals the artifact witness before qualification and the capsule after it', () => {
+test('seals an artifact witness and candidate capsule in two phases', () => {
   const fixture = artifactFixture();
   const witness = prepareKfdArtifactWitness({
     ...fixture,
@@ -193,7 +233,7 @@ test('seals the artifact witness before qualification and the capsule after it',
   assert.equal(capsule.platform, fixture.platform);
 });
 
-test('the Verify wrapper restores pre-qualification evidence after qualification cleanup', () => {
+test('the Verify wrapper seals final artifacts after qualification cleanup', () => {
   const fixture = artifactFixture();
   const qualification = path.join(
     fixture.root,
@@ -201,21 +241,30 @@ test('the Verify wrapper restores pre-qualification evidence after qualification
     'release',
     'qualification',
   );
+  const finalArtifact = path.join(
+    fixture.root,
+    'product',
+    'release',
+    'artifact-after-qualification.bin',
+  );
   const command = [
     process.execPath,
     '-e',
-    `const fs=require('node:fs');fs.rmSync(${JSON.stringify(qualification)},{recursive:true,force:true});fs.mkdirSync(${JSON.stringify(qualification)},{recursive:true});fs.writeFileSync(${JSON.stringify(path.join(qualification, 'qualification-passed.json'))},'{}\\n')`,
+    `const fs=require('node:fs');fs.rmSync(${JSON.stringify(qualification)},{recursive:true,force:true});fs.mkdirSync(${JSON.stringify(qualification)},{recursive:true});fs.writeFileSync(${JSON.stringify(path.join(qualification, 'qualification-passed.json'))},'{}\\n');fs.writeFileSync(${JSON.stringify(finalArtifact)},'final artifact\\n')`,
   ];
   assert.equal(
     runVerifiedQualification({
       ...fixture,
       command,
-      buildArtifactWitness: () => ({
-        id: 'kungfu-collaboration-interface',
-        standard: 'kfd-3',
-        witnessKind: 'artifact',
-        exposedSurfaces: [],
-      }),
+      buildArtifactWitness: () => {
+        assert.equal(fs.existsSync(finalArtifact), true);
+        return {
+          id: 'kungfu-collaboration-interface',
+          standard: 'kfd-3',
+          witnessKind: 'artifact',
+          exposedSurfaces: [],
+        };
+      },
     }),
     0,
   );
@@ -227,108 +276,15 @@ test('the Verify wrapper restores pre-qualification evidence after qualification
     fs.existsSync(path.join(qualification, 'kfd', 'candidate-evidence.json')),
     true,
   );
-});
-
-test('the Verify wrapper binds a successful qualification artifact transition', () => {
-  const fixture = artifactFixture();
-  const artifactPath = path.join(
-    fixture.root,
-    'product',
-    'release',
-    'artifact.bin',
-  );
-  const beforeRoot = kfdEvidenceRoot([
-    {
-      path: 'artifact.bin',
-      bytes: fs.statSync(artifactPath).size,
-      sha256: `sha256:${awaitHash(artifactPath)}`,
-    },
-  ]);
-  const command = [
-    process.execPath,
-    '-e',
-    `require('node:fs').writeFileSync(${JSON.stringify(artifactPath)},'verified artifact\\n')`,
-  ];
-  assert.equal(
-    runVerifiedQualification({
-      ...fixture,
-      command,
-      buildArtifactWitness: () => ({
-        id: 'kungfu-collaboration-interface',
-        standard: 'kfd-3',
-        witnessKind: 'artifact',
-        exposedSurfaces: [],
-      }),
-    }),
-    0,
-  );
   const witness = JSON.parse(
     fs.readFileSync(
-      path.join(
-        fixture.root,
-        'product',
-        'release',
-        'qualification',
-        'kfd',
-        'artifacts',
-        `${fixture.platform}.json`,
-      ),
+      path.join(qualification, 'kfd', 'artifacts', `${fixture.platform}.json`),
       'utf8',
     ),
   );
-  assert.equal(witness.candidateBinding.preVerifyArtifactRoot, beforeRoot);
-  assert.notEqual(witness.candidateBinding.artifactRoot, beforeRoot);
-  assert.equal(witness.candidateBinding.transition, 'verified-qualification');
-  assert.doesNotThrow(() => finalizeKfdCandidateEvidence(fixture));
-  fs.appendFileSync(artifactPath, 'tampered after verification\n');
-  assert.throws(
-    () => finalizeKfdCandidateEvidence(fixture),
-    /KFD artifact digest mismatch/u,
-  );
-});
-
-test('the Verify wrapper never authorizes a failed qualification artifact transition', () => {
-  const fixture = artifactFixture();
-  const artifactPath = path.join(
-    fixture.root,
-    'product',
-    'release',
-    'artifact.bin',
-  );
-  const command = [
-    process.execPath,
-    '-e',
-    `require('node:fs').writeFileSync(${JSON.stringify(artifactPath)},'failed artifact\\n');process.exit(7)`,
-  ];
   assert.equal(
-    runVerifiedQualification({
-      ...fixture,
-      command,
-      buildArtifactWitness: () => ({
-        id: 'kungfu-collaboration-interface',
-        standard: 'kfd-3',
-        witnessKind: 'artifact',
-        exposedSurfaces: [],
-      }),
-    }),
-    7,
-  );
-  assert.equal(
-    fs.existsSync(
-      path.join(
-        fixture.root,
-        'product',
-        'release',
-        'qualification',
-        'kfd',
-        'candidate-evidence.json',
-      ),
-    ),
-    false,
-  );
-  assert.throws(
-    () => finalizeKfdCandidateEvidence(fixture),
-    /KFD artifact digest mismatch/u,
+    witness.candidateBinding.artifactRoot,
+    releaseArtifactRoot(fixture.root).root,
   );
 });
 
@@ -348,50 +304,26 @@ test('fails before Verify completion when artifact bytes change after witnessing
     'tampered\n',
   );
   assert.throws(
-    () =>
-      finalizeKfdCandidateEvidence({
-        ...fixture,
-        allowVerifiedArtifactTransition: true,
-      }),
+    () => finalizeKfdCandidateEvidence(fixture),
     /KFD artifact digest mismatch/u,
   );
 });
 
-test('rejects a tampered witness instead of laundering it through a verified transition', () => {
+test('rejects a source gate sealed for another platform', () => {
   const fixture = artifactFixture();
-  const witnessPath = path.join(
+  const sourceGate = path.join(
     fixture.root,
     '.buildchain',
     'runtime',
     'kfd-candidate-evidence',
-    'artifact-before-verify',
-    'artifacts',
-    `${fixture.platform}.json`,
+    'source-gate.json',
   );
-  const artifactPath = path.join(
-    fixture.root,
-    'product',
-    'release',
-    'artifact.bin',
-  );
-  const command = [
-    process.execPath,
-    '-e',
-    `const fs=require('node:fs');const p=${JSON.stringify(witnessPath)};const w=JSON.parse(fs.readFileSync(p,'utf8'));w.candidateBinding.candidate.sourceSha='${'f'.repeat(40)}';fs.writeFileSync(p,JSON.stringify(w,null,2)+'\\n');fs.appendFileSync(${JSON.stringify(artifactPath)},'verified artifact change\\n')`,
-  ];
+  const gate = JSON.parse(fs.readFileSync(sourceGate, 'utf8'));
+  gate.platform = 'linux-arm64';
+  writeJson(sourceGate, gate);
   assert.throws(
-    () =>
-      runVerifiedQualification({
-        ...fixture,
-        command,
-        buildArtifactWitness: () => ({
-          id: 'kungfu-collaboration-interface',
-          standard: 'kfd-3',
-          witnessKind: 'artifact',
-          exposedSurfaces: [],
-        }),
-      }),
-    /KFD artifact witness candidate\/source root mismatch/u,
+    () => prepareKfdArtifactWitness(fixture),
+    /KFD source gate platform mismatch: expected linux-x64, got linux-arm64/u,
   );
 });
 


### PR DESCRIPTION
## Summary

- replay the reviewed R5 Alpha candidate as a linear, rebase-compatible successor
- preserve the R5 product tree and rebind sealed KFD evidence to source commit `ab35fdf82db27a85ed7ca03d766fc519a85ed688`
- keep KFD source/prebuild witnesses before long builds and artifact witnesses before Verify, with missing/tampered/platform-incomplete/root-mismatch rejection
- keep Promote/Release declarative through `release-passport-kfd-*-jsons`; no KFD witness regeneration or legacy artifact-verify tail command

## Validation

- exact R6 tree equals reviewed R5 tree before the evidence rebind
- zero merge commits relative to `alpha/v4/v4.0`
- `./shifu kfd:buildchain`
- `./shifu kfd:support-matrix`
- `./shifu check:staged` (149/149 promotion rehearsal plus all KFD negative fixtures)
- exact-source Alpha preflight run 33156037811 passed all four platforms and aggregate verification

## Evolution Map impact

Evolution impact: this linear successor preserves the already reviewed R5 candidate projection and adds no accepted ADR record changes.

## Governance risk check

- [x] Official branding, package names, release identity, or domains are affected by the Alpha publication path.
- [x] Release evidence, artifacts, and installer channel authority require protected review.

## Checklist

- [x] Commits are signed off.
- [x] Alpha-first lineage preserves the retained channel base.
- [x] Protected merge is required before release.
- [x] Promote/Release only consumes sealed declarative KFD JSON inputs; KFD witness regeneration is absent from the tail.
- [x] Buildchain remains unmodified.

## Delivery boundary

This PR targets the protected Alpha branch. No public tag or release is created manually. Hosted Build, Auditable Demo, Linux ARM64 qualification, exact-head independent review, and governed Alpha publication remain required before closeout.

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "alpha-settlement",
  "no_adr_progress_reason": "The linear R6 successor preserves the reviewed R5 candidate projection and contains no accepted ADR record changes"
}
-->