### PR TITLE
refactor(product): decompose complex system views

### DIFF
--- a/extensions/system/kfx-manager/src/view/index.tsx
+++ b/extensions/system/kfx-manager/src/view/index.tsx
@@ -222,7 +222,7 @@ function ProfileCard({
   );
 }
 
-function KfxManagerView({ caps, shell }: KfxViewProps) {
+function useManagerProjection({ caps, shell }: KfxViewProps) {
   const [manager, setManager] = React.useState<ProfileManagerProjection | null>(
     null,
   );
@@ -235,32 +235,8 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
   >({});
   const [loading, setLoading] = React.useState(true);
   const initialLoad = React.useRef(true);
-  const [pending, setPending] = React.useState<{
-    plan: ProfileLifecyclePlan;
-    action: 'qualify' | 'activate' | 'upgrade';
-    source: string;
-  } | null>(null);
-  const [planning, setPlanning] = React.useState(false);
-  const [pendingIntent, setPendingIntent] = React.useState<{
-    plan: ProfileIntentPlan;
-    source: string;
-    intentId: string;
-  } | null>(null);
-  const [pendingKfd3, setPendingKfd3] = React.useState<{
-    plan: ProfileKfd3QualificationPlan;
-    source: string;
-  } | null>(null);
-  const [authorizedBy, setAuthorizedBy] = React.useState('');
   const [controlStatus, setControlStatus] =
     React.useState<KfxControlStatus | null>(null);
-  const [pendingControl, setPendingControl] = React.useState<{
-    plan: KfxControlPlan;
-    operation: 'install' | 'update';
-    path: string;
-  } | null>(null);
-  const profile =
-    shell.profiles.find((p) => p.id === shell.state.profileId) ??
-    shell.profiles[0];
   const onRefresh = shell.onRefresh;
 
   const refresh = React.useCallback(async () => {
@@ -319,6 +295,36 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
     return onRefresh(() => void refresh());
   }, [onRefresh, refresh]);
 
+  return {
+    applicationErrors,
+    applications,
+    controlStatus,
+    error,
+    loading,
+    manager,
+    refresh,
+    setControlStatus,
+    setError,
+  };
+}
+
+type PlanningContext = {
+  authorizedBy: string;
+  caps: KfxViewProps['caps'];
+  refresh: () => Promise<void>;
+  setError: React.Dispatch<React.SetStateAction<string>>;
+  setPlanning: React.Dispatch<React.SetStateAction<boolean>>;
+  shell: KfxViewProps['shell'];
+};
+
+function useLifecyclePlanning(context: PlanningContext) {
+  const { authorizedBy, caps, refresh, setError, setPlanning, shell } = context;
+  const [pending, setPending] = React.useState<{
+    plan: ProfileLifecyclePlan;
+    action: 'qualify' | 'activate' | 'upgrade';
+    source: string;
+  } | null>(null);
+
   const previewPlan = async (
     action: 'qualify' | 'activate' | 'upgrade',
     source: string,
@@ -339,6 +345,41 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
     }
   };
 
+  const approveAndApply = async () => {
+    if (!caps.profile || !pending || !authorizedBy.trim()) return;
+    setPlanning(true);
+    try {
+      await caps.profile.authorizeLifecycleAsync(
+        pending.action,
+        pending.source,
+        String(pending.plan.corePlan.plan_id ?? ''),
+        'approve',
+        authorizedBy.trim(),
+      );
+      setPending(null);
+      await refresh();
+      shell.notify({
+        level: 'success',
+        title: `Profile ${pending.action} applied`,
+      });
+    } catch (reason) {
+      setError((reason as Error).message);
+    } finally {
+      setPlanning(false);
+    }
+  };
+
+  return { approveAndApply, pending, previewPlan, setPending };
+}
+
+function useIntentPlanning(context: PlanningContext) {
+  const { authorizedBy, caps, refresh, setError, setPlanning, shell } = context;
+  const [pendingIntent, setPendingIntent] = React.useState<{
+    plan: ProfileIntentPlan;
+    source: string;
+    intentId: string;
+  } | null>(null);
+
   const previewIntent = async (source: string, intentId: string) => {
     if (!caps.profile) return;
     setPlanning(true);
@@ -355,6 +396,42 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
       setPlanning(false);
     }
   };
+
+  const approveIntent = async () => {
+    if (!caps.profile || !pendingIntent || !authorizedBy.trim()) return;
+    setPlanning(true);
+    try {
+      const receipt = await caps.profile.authorizeIntentAsync(
+        pendingIntent.source,
+        pendingIntent.intentId,
+        pendingIntent.plan.planId,
+        'approve',
+        authorizedBy.trim(),
+      );
+      setPendingIntent(null);
+      await refresh();
+      shell.notify({
+        level: receipt.verification?.verified ? 'success' : 'warning',
+        title: receipt.verification?.verified
+          ? 'Intent receipt verified'
+          : 'Intent executed; verification incomplete',
+      });
+    } catch (reason) {
+      setError((reason as Error).message);
+    } finally {
+      setPlanning(false);
+    }
+  };
+
+  return { approveIntent, pendingIntent, previewIntent, setPendingIntent };
+}
+
+function useKfd3Planning(context: PlanningContext) {
+  const { authorizedBy, caps, refresh, setError, setPlanning, shell } = context;
+  const [pendingKfd3, setPendingKfd3] = React.useState<{
+    plan: ProfileKfd3QualificationPlan;
+    source: string;
+  } | null>(null);
 
   const previewKfd3 = async (source: string) => {
     if (!caps.profile) return;
@@ -392,55 +469,23 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
     }
   };
 
-  const approveIntent = async () => {
-    if (!caps.profile || !pendingIntent || !authorizedBy.trim()) return;
-    setPlanning(true);
-    try {
-      const receipt = await caps.profile.authorizeIntentAsync(
-        pendingIntent.source,
-        pendingIntent.intentId,
-        pendingIntent.plan.planId,
-        'approve',
-        authorizedBy.trim(),
-      );
-      setPendingIntent(null);
-      await refresh();
-      shell.notify({
-        level: receipt.verification?.verified ? 'success' : 'warning',
-        title: receipt.verification?.verified
-          ? 'Intent receipt verified'
-          : 'Intent executed; verification incomplete',
-      });
-    } catch (reason) {
-      setError((reason as Error).message);
-    } finally {
-      setPlanning(false);
-    }
-  };
+  return { approveKfd3, pendingKfd3, previewKfd3, setPendingKfd3 };
+}
 
-  const approveAndApply = async () => {
-    if (!caps.profile || !pending || !authorizedBy.trim()) return;
-    setPlanning(true);
-    try {
-      await caps.profile.authorizeLifecycleAsync(
-        pending.action,
-        pending.source,
-        String(pending.plan.corePlan.plan_id ?? ''),
-        'approve',
-        authorizedBy.trim(),
-      );
-      setPending(null);
-      await refresh();
-      shell.notify({
-        level: 'success',
-        title: `Profile ${pending.action} applied`,
-      });
-    } catch (reason) {
-      setError((reason as Error).message);
-    } finally {
-      setPlanning(false);
-    }
-  };
+type ControlPlanningArgs = {
+  context: PlanningContext;
+  projection: ReturnType<typeof useManagerProjection>;
+};
+
+function useControlPlanning(args: ControlPlanningArgs) {
+  const { context, projection } = args;
+  const { authorizedBy, caps, refresh, setError, setPlanning, shell } = context;
+  const { setControlStatus } = projection;
+  const [pendingControl, setPendingControl] = React.useState<{
+    plan: KfxControlPlan;
+    operation: 'install' | 'update';
+    path: string;
+  } | null>(null);
 
   const previewControl = (operation: 'install' | 'update', path: string) => {
     if (!caps.kfxControl) return;
@@ -483,6 +528,29 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
     }
   };
 
+  return { approveControl, pendingControl, previewControl, setPendingControl };
+}
+
+function useKfxManagerController({ caps, shell }: KfxViewProps) {
+  const projection = useManagerProjection({ caps, shell });
+  const [planning, setPlanning] = React.useState(false);
+  const [authorizedBy, setAuthorizedBy] = React.useState('');
+  const context = {
+    authorizedBy,
+    caps,
+    refresh: projection.refresh,
+    setError: projection.setError,
+    setPlanning,
+    shell,
+  };
+  const lifecycle = useLifecyclePlanning(context);
+  const intent = useIntentPlanning(context);
+  const kfd3 = useKfd3Planning(context);
+  const control = useControlPlanning({ context, projection });
+  const profile =
+    shell.profiles.find((item) => item.id === shell.state.profileId) ??
+    shell.profiles[0];
+
   const toggleKfx = (id: string, disabled: boolean) => {
     shell.updateState({
       disabledKfx: disabled
@@ -499,17 +567,48 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
     });
   };
 
-  const cell: React.CSSProperties = { padding: '2px 12px 2px 0' };
+  return {
+    ...projection,
+    ...lifecycle,
+    ...intent,
+    ...kfd3,
+    ...control,
+    authorizedBy,
+    planning,
+    profile,
+    setAuthorizedBy,
+    toggleKfx,
+    toggleSuite,
+  };
+}
 
+type KfxManagerContentProps = {
+  controller: ReturnType<typeof useKfxManagerController>;
+  shell: KfxViewProps['shell'];
+};
+
+function KfxControlSection(props: KfxManagerContentProps) {
+  const { controller, shell } = props;
+  const {
+    approveControl,
+    authorizedBy,
+    controlStatus,
+    pendingControl,
+    planning,
+    previewControl,
+    setAuthorizedBy,
+    setPendingControl,
+  } = controller;
+  const managerDir = shell.registry.find(
+    (entry) => entry.id === 'kfx-manager',
+  )?.dir;
   return (
-    <section style={panelStyle}>
+    <>
       <h2 style={headingStyle}>KFX Control Suite</h2>
       <div
         style={{
           ...mono,
-          border: `1px solid ${
-            controlStatus?.mode === 'active' ? '#4ec9b0' : '#f48771'
-          }`,
+          border: `1px solid ${controlStatus?.mode === 'active' ? '#4ec9b0' : '#f48771'}`,
           padding: 10,
           marginBottom: 12,
         }}
@@ -527,15 +626,14 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
           Core independently verifies the embedded bootstrap ceiling; every
           mutation settles through the public KFX Fact/Work named-Cut CAS.
         </div>
-        {shell.registry.find((entry) => entry.id === 'kfx-manager')?.dir ? (
+        {managerDir ? (
           <button
             type="button"
             disabled={planning}
             onClick={() =>
               previewControl(
                 controlStatus?.active ? 'update' : 'install',
-                shell.registry.find((entry) => entry.id === 'kfx-manager')
-                  ?.dir as string,
+                managerDir,
               )
             }
             style={{ ...mono, marginTop: 8, marginRight: 8 }}
@@ -603,6 +701,26 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
           </button>
         </div>
       ) : null}
+    </>
+  );
+}
+
+function ProfileOverviewSection(props: KfxManagerContentProps) {
+  const { controller } = props;
+  const {
+    applicationErrors,
+    applications,
+    error,
+    loading,
+    manager,
+    planning,
+    previewIntent,
+    previewKfd3,
+    previewPlan,
+    profile,
+  } = controller;
+  return (
+    <>
       <h2 style={headingStyle}>Profiles · {manager?.count ?? 0}</h2>
       <div style={{ ...mono, color: '#858585', marginBottom: 10 }}>
         Runtime activation controls composition authority. GUI focus is “
@@ -644,61 +762,121 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
           </div>
         ) : null}
       </div>
+    </>
+  );
+}
+
+type DecisionPanelProps = {
+  approve: () => void;
+  approveLabel: string;
+  authorizedBy: string;
+  children: React.ReactNode;
+  dismiss: () => void;
+  planning: boolean;
+  placeholder: string;
+  setAuthorizedBy: React.Dispatch<React.SetStateAction<string>>;
+  title: string;
+};
+
+function DecisionPanel(props: DecisionPanelProps) {
+  const {
+    approve,
+    approveLabel,
+    authorizedBy,
+    children,
+    dismiss,
+    planning,
+    placeholder,
+    setAuthorizedBy,
+    title,
+  } = props;
+  return (
+    <div
+      style={{
+        ...mono,
+        border: '1px solid #dcdcaa',
+        padding: 10,
+        marginBottom: 12,
+      }}
+    >
+      <strong style={{ color: '#dcdcaa' }}>{title}</strong>
+      {children}
+      <label style={{ display: 'block', marginTop: 8 }}>
+        authorized by{' '}
+        <input
+          value={authorizedBy}
+          onChange={(event) => setAuthorizedBy(event.target.value)}
+          placeholder={placeholder}
+          style={{ ...mono, minWidth: 220 }}
+        />
+      </label>
+      <button
+        type="button"
+        disabled={planning || !authorizedBy.trim()}
+        onClick={approve}
+        style={{ ...mono, marginTop: 8, marginRight: 8 }}
+      >
+        {approveLabel}
+      </button>
+      <button
+        type="button"
+        disabled={planning}
+        onClick={dismiss}
+        style={{ ...mono, marginTop: 8 }}
+      >
+        Dismiss
+      </button>
+    </div>
+  );
+}
+
+function ProfileDecisionSections(props: KfxManagerContentProps) {
+  const {
+    approveAndApply,
+    approveIntent,
+    approveKfd3,
+    authorizedBy,
+    pending,
+    pendingIntent,
+    pendingKfd3,
+    planning,
+    setAuthorizedBy,
+    setPending,
+    setPendingIntent,
+    setPendingKfd3,
+  } = props.controller;
+  return (
+    <>
       {pendingKfd3 ? (
-        <div
-          style={{
-            ...mono,
-            border: '1px solid #dcdcaa',
-            padding: 10,
-            marginBottom: 12,
-          }}
+        <DecisionPanel
+          approve={() => void approveKfd3()}
+          approveLabel="Run exact test plan"
+          authorizedBy={authorizedBy}
+          dismiss={() => setPendingKfd3(null)}
+          planning={planning}
+          placeholder="workspace profile operator"
+          setAuthorizedBy={setAuthorizedBy}
+          title="◇ KFD-3 test plan"
         >
-          <strong style={{ color: '#dcdcaa' }}>◇ KFD-3 test plan</strong>
           <div>profile {shortRoot(pendingKfd3.plan.profileSuiteRoot)}</div>
           <div>runtime {shortRoot(pendingKfd3.plan.runtimeContractRoot)}</div>
           <div>plan {shortRoot(pendingKfd3.plan.planId)}</div>
           <div style={{ color: '#858585' }}>
             {pendingKfd3.plan.probes.join(' · ')}
           </div>
-          <label style={{ display: 'block', marginTop: 8 }}>
-            authorized by{' '}
-            <input
-              value={authorizedBy}
-              onChange={(event) => setAuthorizedBy(event.target.value)}
-              placeholder="workspace profile operator"
-              style={{ ...mono, minWidth: 220 }}
-            />
-          </label>
-          <button
-            type="button"
-            disabled={planning || !authorizedBy.trim()}
-            onClick={() => void approveKfd3()}
-            style={{ ...mono, marginTop: 8, marginRight: 8 }}
-          >
-            Run exact test plan
-          </button>
-          <button
-            type="button"
-            disabled={planning}
-            onClick={() => setPendingKfd3(null)}
-            style={{ ...mono, marginTop: 8 }}
-          >
-            Dismiss
-          </button>
-        </div>
+        </DecisionPanel>
       ) : null}
       {pending ? (
-        <div
-          style={{
-            ...mono,
-            border: '1px solid #dcdcaa',
-            padding: 10,
-            marginBottom: 12,
-          }}
+        <DecisionPanel
+          approve={() => void approveAndApply()}
+          approveLabel="Approve exact plan"
+          authorizedBy={authorizedBy}
+          dismiss={() => setPending(null)}
+          planning={planning}
+          placeholder="workspace owner identity"
+          setAuthorizedBy={setAuthorizedBy}
+          title="Decision required before mutation"
         >
-          <strong style={{ color: '#dcdcaa' }}>
-            Decision required before mutation
-          </strong>
           <div>plan {String(pending.plan.corePlan.plan_id ?? '—')}</div>
           <div>
             {String(
@@ -710,175 +888,193 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
             GUI and Agent use the same installed decision-card contract. The
             runtime re-plans and rejects drift before apply.
           </div>
-          <label style={{ display: 'block', marginTop: 8 }}>
-            authorized by{' '}
-            <input
-              value={authorizedBy}
-              onChange={(event) => setAuthorizedBy(event.target.value)}
-              placeholder="workspace owner identity"
-              style={{ ...mono, minWidth: 220 }}
-            />
-          </label>
-          <button
-            type="button"
-            disabled={planning || !authorizedBy.trim()}
-            onClick={() => void approveAndApply()}
-            style={{ ...mono, marginTop: 8, marginRight: 8 }}
-          >
-            Approve exact plan
-          </button>
-          <button
-            type="button"
-            disabled={planning}
-            onClick={() => setPending(null)}
-            style={{ ...mono, marginTop: 8 }}
-          >
-            Dismiss
-          </button>
-        </div>
+        </DecisionPanel>
       ) : null}
       {pendingIntent ? (
-        <div
-          style={{
-            ...mono,
-            border: '1px solid #dcdcaa',
-            padding: 10,
-            marginBottom: 12,
-          }}
+        <DecisionPanel
+          approve={() => void approveIntent()}
+          approveLabel="Approve exact intent"
+          authorizedBy={authorizedBy}
+          dismiss={() => setPendingIntent(null)}
+          planning={planning}
+          placeholder="declared authority identity"
+          setAuthorizedBy={setAuthorizedBy}
+          title="Intent decision required"
         >
-          <strong style={{ color: '#dcdcaa' }}>Intent decision required</strong>
           <div>intent {pendingIntent.intentId}</div>
           <div>plan {pendingIntent.plan.planId}</div>
           <div style={{ color: '#858585' }}>
             This exact plan is shared with the Agent CLI. Apply re-plans, emits
             a receipt, and verifies the same Profile and collaboration roots.
           </div>
-          <label style={{ display: 'block', marginTop: 8 }}>
-            authorized by{' '}
-            <input
-              value={authorizedBy}
-              onChange={(event) => setAuthorizedBy(event.target.value)}
-              placeholder="declared authority identity"
-              style={{ ...mono, minWidth: 220 }}
-            />
-          </label>
-          <button
-            type="button"
-            disabled={planning || !authorizedBy.trim()}
-            onClick={() => void approveIntent()}
-            style={{ ...mono, marginTop: 8, marginRight: 8 }}
-          >
-            Approve exact intent
-          </button>
-          <button
-            type="button"
-            disabled={planning}
-            onClick={() => setPendingIntent(null)}
-            style={{ ...mono, marginTop: 8 }}
-          >
-            Dismiss
-          </button>
-        </div>
+        </DecisionPanel>
       ) : null}
+    </>
+  );
+}
+
+const tableCell: React.CSSProperties = { padding: '2px 12px 2px 0' };
+
+type RuntimeRowProps = {
+  disabled: boolean;
+  entry: KfxViewProps['shell']['registry'][number];
+  inProfile: boolean;
+  toggleKfx: (id: string, disabled: boolean) => void;
+};
+
+function KfxRuntimeRow(props: RuntimeRowProps) {
+  const { disabled, entry, inProfile, toggleKfx } = props;
+  return (
+    <tr>
+      <td style={{ ...tableCell, color: '#9cdcfe' }}>{entry.id}</td>
+      <td style={tableCell}>{entry.title}</td>
+      <td style={{ ...tableCell, color: '#858585' }}>{entry.suite ?? '—'}</td>
+      <td style={{ ...tableCell, color: '#ce9178' }}>
+        {entry.capabilities.join(', ') || '—'}
+      </td>
+      <td style={{ ...tableCell, color: '#858585' }}>
+        {entry.packageName
+          ? `${entry.packageName}@${entry.version ?? '?'}`
+          : '—'}
+      </td>
+      <td style={{ ...tableCell, color: '#6a6a6a' }}>{entry.source}</td>
+      <td style={tableCell}>
+        {entry.system ? (
+          <span style={{ color: '#6a6a6a' }}>system · always on</span>
+        ) : !inProfile ? (
+          <span style={{ color: '#6a6a6a' }}>not in profile</span>
+        ) : (
+          <button
+            type="button"
+            onClick={() => toggleKfx(entry.id, disabled)}
+            style={{
+              ...mono,
+              padding: '1px 8px',
+              border: '1px solid #3c3c3c',
+              borderRadius: 4,
+              cursor: 'pointer',
+              background: 'transparent',
+              color: disabled ? '#f48771' : '#4ec9b0',
+            }}
+          >
+            {disabled ? 'disabled — enable' : 'enabled — disable'}
+          </button>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+type SuiteRowProps = {
+  disabled: boolean;
+  isSystem: boolean;
+  name: string;
+  suite: KfxViewProps['shell']['suites'][string];
+  toggleSuite: (key: string, disabled: boolean) => void;
+};
+
+function KfxSuiteRow(props: SuiteRowProps) {
+  const { disabled, isSystem, name, suite, toggleSuite } = props;
+  return (
+    <div style={{ ...mono, padding: '2px 0' }}>
+      <span style={{ color: '#9cdcfe' }}>{name}</span> · {suite.title} ·
+      members: {suite.members.join(', ')}{' '}
+      {isSystem ? (
+        <span style={{ color: '#6a6a6a' }}>system · always on</span>
+      ) : (
+        <button
+          type="button"
+          onClick={() => toggleSuite(name, disabled)}
+          style={{
+            ...mono,
+            padding: '1px 8px',
+            border: '1px solid #3c3c3c',
+            borderRadius: 4,
+            cursor: 'pointer',
+            background: 'transparent',
+            color: disabled ? '#f48771' : '#4ec9b0',
+          }}
+        >
+          {disabled ? 'suite disabled — enable' : 'suite enabled — disable'}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function KfxRegistrySection(props: KfxManagerContentProps) {
+  const { controller, shell } = props;
+  const { profile, toggleKfx, toggleSuite } = controller;
+  return (
+    <>
       <h2 style={headingStyle}>KFX runtime · {shell.registry.length} loaded</h2>
       <table style={{ ...mono, borderCollapse: 'collapse' }}>
         <thead>
           <tr style={{ color: '#858585', textAlign: 'left' }}>
-            <th style={cell}>id</th>
-            <th style={cell}>title</th>
-            <th style={cell}>suite</th>
-            <th style={cell}>capabilities</th>
-            <th style={cell}>package</th>
-            <th style={cell}>source</th>
-            <th style={cell}>state</th>
+            {[
+              'id',
+              'title',
+              'suite',
+              'capabilities',
+              'package',
+              'source',
+              'state',
+            ].map((label) => (
+              <th key={label} style={tableCell}>
+                {label}
+              </th>
+            ))}
           </tr>
         </thead>
         <tbody>
-          {shell.registry.map((entry) => {
-            const inProfile =
-              entry.system || (profile?.kfx.includes(entry.id) ?? false);
-            const disabled = shell.state.disabledKfx.includes(entry.id);
-            return (
-              <tr key={entry.id}>
-                <td style={{ ...cell, color: '#9cdcfe' }}>{entry.id}</td>
-                <td style={cell}>{entry.title}</td>
-                <td style={{ ...cell, color: '#858585' }}>
-                  {entry.suite ?? '—'}
-                </td>
-                <td style={{ ...cell, color: '#ce9178' }}>
-                  {entry.capabilities.join(', ') || '—'}
-                </td>
-                <td style={{ ...cell, color: '#858585' }}>
-                  {entry.packageName
-                    ? `${entry.packageName}@${entry.version ?? '?'}`
-                    : '—'}
-                </td>
-                <td style={{ ...cell, color: '#6a6a6a' }}>{entry.source}</td>
-                <td style={cell}>
-                  {entry.system ? (
-                    <span style={{ color: '#6a6a6a' }}>system · always on</span>
-                  ) : !inProfile ? (
-                    <span style={{ color: '#6a6a6a' }}>not in profile</span>
-                  ) : (
-                    <button
-                      type="button"
-                      onClick={() => toggleKfx(entry.id, disabled)}
-                      style={{
-                        ...mono,
-                        padding: '1px 8px',
-                        border: '1px solid #3c3c3c',
-                        borderRadius: 4,
-                        cursor: 'pointer',
-                        background: 'transparent',
-                        color: disabled ? '#f48771' : '#4ec9b0',
-                      }}
-                    >
-                      {disabled ? 'disabled — enable' : 'enabled — disable'}
-                    </button>
-                  )}
-                </td>
-              </tr>
-            );
-          })}
+          {shell.registry.map((entry) => (
+            <KfxRuntimeRow
+              key={entry.id}
+              entry={entry}
+              disabled={shell.state.disabledKfx.includes(entry.id)}
+              inProfile={
+                entry.system || (profile?.kfx.includes(entry.id) ?? false)
+              }
+              toggleKfx={toggleKfx}
+            />
+          ))}
         </tbody>
       </table>
       <h2 style={{ ...headingStyle, marginTop: 12 }}>
         Suites · {Object.keys(shell.suites).length}
       </h2>
-      {Object.entries(shell.suites).map(([key, suite]) => {
-        const disabled = shell.state.disabledSuites.includes(key);
-        const isSystem = shell.registry.some(
-          (entry) => entry.suite === key && entry.system,
-        );
-        return (
-          <div key={key} style={{ ...mono, padding: '2px 0' }}>
-            <span style={{ color: '#9cdcfe' }}>{key}</span> · {suite.title} ·
-            members: {suite.members.join(', ')}{' '}
-            {isSystem ? (
-              <span style={{ color: '#6a6a6a' }}>system · always on</span>
-            ) : (
-              <button
-                type="button"
-                onClick={() => toggleSuite(key, disabled)}
-                style={{
-                  ...mono,
-                  padding: '1px 8px',
-                  border: '1px solid #3c3c3c',
-                  borderRadius: 4,
-                  cursor: 'pointer',
-                  background: 'transparent',
-                  color: disabled ? '#f48771' : '#4ec9b0',
-                }}
-              >
-                {disabled
-                  ? 'suite disabled — enable'
-                  : 'suite enabled — disable'}
-              </button>
-            )}
-          </div>
-        );
-      })}
+      {Object.entries(shell.suites).map(([name, suite]) => (
+        <KfxSuiteRow
+          key={name}
+          name={name}
+          suite={suite}
+          disabled={shell.state.disabledSuites.includes(name)}
+          isSystem={shell.registry.some(
+            (entry) => entry.suite === name && entry.system,
+          )}
+          toggleSuite={toggleSuite}
+        />
+      ))}
+    </>
+  );
+}
+
+function KfxManagerContent(props: KfxManagerContentProps) {
+  return (
+    <section style={panelStyle}>
+      <KfxControlSection {...props} />
+      <ProfileOverviewSection {...props} />
+      <ProfileDecisionSections {...props} />
+      <KfxRegistrySection {...props} />
     </section>
+  );
+}
+function KfxManagerView(props: KfxViewProps) {
+  return (
+    <KfxManagerContent
+      controller={useKfxManagerController(props)}
+      shell={props.shell}
+    />
   );
 }
 

--- a/extensions/system/settings/src/view/index.tsx
+++ b/extensions/system/settings/src/view/index.tsx
@@ -85,107 +85,27 @@ const emptyAgentDraft: AgentRuntimeProfileInput = {
   envelope: 'required',
 };
 
-function SettingsView({ shell, caps }: KfxViewProps) {
-  const [drafts, setDrafts] = React.useState<Record<string, string>>({});
-  const [activeTab, setActiveTab] = React.useState<SettingsTab>('appearance');
-  const ui = shell.config?.config.ui ?? {
-    fontFamily: 'system',
-    fontSize: 14,
-    scale: 1,
-  };
-  const [uiDraft, setUiDraft] = React.useState({
-    fontFamily: ui.fontFamily,
-    fontSize: String(ui.fontSize),
-    scale: String(ui.scale),
-  });
-  const [uiError, setUiError] = React.useState('');
-  const [agentCatalog, setAgentCatalog] =
-    React.useState<AgentRuntimeCatalog | null>(null);
-  const [agentDraft, setAgentDraft] =
-    React.useState<AgentRuntimeProfileInput>(emptyAgentDraft);
-  const [agentArgv, setAgentArgv] = React.useState('');
-  const [agentMessage, setAgentMessage] = React.useState('');
-  const [agentBusy, setAgentBusy] = React.useState(false);
+type UiDraft = { fontFamily: string; fontSize: string; scale: string };
 
-  const reloadAgents = React.useCallback(async () => {
-    if (!caps.agentRuntime) return;
-    setAgentBusy(true);
-    try {
-      setAgentCatalog(await caps.agentRuntime.list());
-      setAgentMessage('');
-    } catch (error) {
-      setAgentMessage((error as Error).message);
-    } finally {
-      setAgentBusy(false);
-    }
-  }, [caps.agentRuntime]);
+type AppearanceSettingsProps = {
+  shell: KfxViewProps['shell'];
+  uiDraft: UiDraft;
+  setUiDraft: React.Dispatch<React.SetStateAction<UiDraft>>;
+  uiError: string;
+  saveAppearance: () => void;
+  resetAppearance: () => void;
+};
 
-  React.useEffect(() => {
-    if (activeTab === 'agents') void reloadAgents();
-  }, [activeTab, reloadAgents]);
-
-  React.useEffect(() => {
-    setUiDraft({
-      fontFamily: ui.fontFamily,
-      fontSize: String(ui.fontSize),
-      scale: String(ui.scale),
-    });
-  }, [ui.fontFamily, ui.fontSize, ui.scale]);
-
-  const declared = shell.registry.flatMap((entry) =>
-    entry.settings.map((decl) => ({ owner: entry.title, decl })),
-  );
-
-  const commit = (key: string) => {
-    const value = drafts[key];
-    if (value === undefined) return;
-    shell.updateState({ settings: { ...shell.state.settings, [key]: value } });
-    setDrafts((current) => {
-      const next = { ...current };
-      delete next[key];
-      return next;
-    });
-  };
-
-  const profile =
-    shell.profiles.find((p) => p.id === shell.state.profileId) ??
-    shell.profiles[0];
-
-  const saveAppearance = () => {
-    const fontSize = Number(uiDraft.fontSize);
-    const scale = Number(uiDraft.scale);
-    if (!Number.isFinite(fontSize) || fontSize < 8 || fontSize > 48) {
-      setUiError('font size must be between 8 and 48');
-      return;
-    }
-    if (!Number.isFinite(scale) || scale < 0.5 || scale > 3) {
-      setUiError('zoom must be between 50% and 300%');
-      return;
-    }
-    const fontFamily = uiDraft.fontFamily.trim() || 'system';
-    try {
-      shell.setConfigValue('ui.fontFamily', fontFamily);
-      shell.setConfigValue('ui.fontSize', fontSize);
-      shell.setConfigValue('ui.scale', scale);
-      setUiError('');
-    } catch (e) {
-      setUiError((e as Error).message);
-    }
-  };
-
-  const resetAppearance = () => {
-    try {
-      shell.unsetConfigValue('ui.fontFamily');
-      shell.unsetConfigValue('ui.fontSize');
-      shell.unsetConfigValue('ui.scale');
-      shell.reloadConfig();
-      setUiError('');
-    } catch (e) {
-      setUiError((e as Error).message);
-    }
-  };
-
-  const renderAppearance = () => (
+function AppearanceSettings(props: AppearanceSettingsProps) {
+  const {
+    resetAppearance,
+    saveAppearance,
+    setUiDraft,
+    shell,
+    uiDraft,
+    uiError,
+  } = props;
+  return (
     <section style={sectionStyle}>
       <h2 style={headingStyle}>Global appearance</h2>
       {shell.configError && (
@@ -307,8 +227,16 @@ function SettingsView({ shell, caps }: KfxViewProps) {
       </div>
     </section>
   );
+}
 
-  const renderProfile = () => (
+type ProfileSettingsProps = {
+  shell: KfxViewProps['shell'];
+  profile: KfxViewProps['shell']['profiles'][number];
+};
+
+function ProfileSettings(props: ProfileSettingsProps) {
+  const { profile, shell } = props;
+  return (
     <section style={sectionStyle}>
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
         <div>
@@ -345,6 +273,628 @@ function SettingsView({ shell, caps }: KfxViewProps) {
         </div>
       </div>
     </section>
+  );
+}
+
+type DeclaredSetting = {
+  owner: string;
+  decl: KfxViewProps['shell']['registry'][number]['settings'][number];
+};
+
+type KfxSettingsProps = {
+  commit: (key: string) => void;
+  declared: DeclaredSetting[];
+  drafts: Record<string, string>;
+  setDrafts: React.Dispatch<React.SetStateAction<Record<string, string>>>;
+  shell: KfxViewProps['shell'];
+};
+
+function KfxSettings(props: KfxSettingsProps) {
+  const { commit, declared, drafts, setDrafts, shell } = props;
+  return (
+    <section style={sectionStyle}>
+      <h2 style={headingStyle}>KFX settings</h2>
+      {declared.length ? (
+        <div>
+          {declared.map(({ owner, decl }) => (
+            <div key={decl.key} style={rowStyle}>
+              <div style={{ color: '#858585' }}>
+                {owner}
+                <div style={{ color: '#6a6a6a' }}>{decl.key}</div>
+              </div>
+              <label style={{ display: 'block' }}>
+                <div style={{ marginBottom: 4 }}>{decl.label}</div>
+                <input
+                  style={{ ...inputStyle, width: 'min(360px, 100%)' }}
+                  value={drafts[decl.key] ?? shell.setting(decl.key)}
+                  onChange={(event) =>
+                    setDrafts((current) => ({
+                      ...current,
+                      [decl.key]: event.target.value,
+                    }))
+                  }
+                  onBlur={() => commit(decl.key)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') commit(decl.key);
+                  }}
+                />
+              </label>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div style={{ ...mono, color: '#6a6a6a' }}>
+          no kfx contributed settings
+        </div>
+      )}
+    </section>
+  );
+}
+
+function PathsSettings({ shell }: Pick<KfxViewProps, 'shell'>) {
+  return (
+    <section style={sectionStyle}>
+      <h2 style={headingStyle}>Runtime paths</h2>
+      {[
+        ['runtime home', shell.info.runtimeDir],
+        ['KF_HOME', shellEnv('KF_HOME')],
+        ['KF_CONFIG_HOME', shellEnv('KF_CONFIG_HOME')],
+        ['KF_EXTENSION_PATH', shellEnv('KF_EXTENSION_PATH')],
+        ['KF_BUNDLED_EXTENSION_ROOT', shellEnv('KF_BUNDLED_EXTENSION_ROOT')],
+      ].map(([label, value]) => (
+        <div key={label} style={rowStyle}>
+          <div style={{ color: '#858585' }}>{label}</div>
+          <div style={{ color: '#9cdcfe', overflowWrap: 'anywhere' }}>
+            {value}
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+function AdvancedSettings({ shell }: Pick<KfxViewProps, 'shell'>) {
+  return (
+    <section style={sectionStyle}>
+      <h2 style={headingStyle}>Shell state</h2>
+      <pre
+        style={{
+          ...mono,
+          margin: 0,
+          padding: 12,
+          overflow: 'auto',
+          border: '1px solid #3c3c3c',
+          borderRadius: 6,
+          background: '#1e1e1e',
+          color: '#cccccc',
+          maxHeight: 360,
+        }}
+      >
+        {JSON.stringify(shell.state, null, 2)}
+      </pre>
+    </section>
+  );
+}
+
+type SettingsTabsProps = {
+  activeTab: SettingsTab;
+  content: React.ReactNode;
+  setActiveTab: React.Dispatch<React.SetStateAction<SettingsTab>>;
+};
+
+function SettingsTabs(props: SettingsTabsProps) {
+  const { activeTab, content, setActiveTab } = props;
+  return (
+    <div>
+      <div
+        role="tablist"
+        aria-label="Settings sections"
+        style={{
+          display: 'flex',
+          gap: 6,
+          marginBottom: 12,
+          borderBottom: '1px solid #3c3c3c',
+          paddingBottom: 8,
+        }}
+      >
+        {tabs.map((tab) => (
+          <button
+            key={tab}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === tab}
+            onClick={() => setActiveTab(tab)}
+            style={{
+              ...mono,
+              padding: '6px 10px',
+              border: '1px solid #3c3c3c',
+              borderRadius: 6,
+              cursor: 'pointer',
+              background: activeTab === tab ? '#04395e' : '#1e1e1e',
+              color: activeTab === tab ? '#9cdcfe' : '#cccccc',
+            }}
+          >
+            {tabLabels[tab]}
+          </button>
+        ))}
+      </div>
+      {content}
+    </div>
+  );
+}
+
+type SettingsRenderers = Record<SettingsTab, () => React.ReactNode>;
+
+function activeSettingsContent(
+  activeTab: SettingsTab,
+  renderers: SettingsRenderers,
+) {
+  return renderers[activeTab]();
+}
+
+type ConfiguredAgent = AgentRuntimeCatalog['configured'][number];
+type DiscoveredAgent = AgentRuntimeCatalog['discovered'][number];
+
+type AgentSettingsModel = {
+  agentArgv: string;
+  agentBusy: boolean;
+  agentCatalog: AgentRuntimeCatalog | null;
+  agentDraft: AgentRuntimeProfileInput;
+  agentMessage: string;
+  configureDiscovered: (profile: DiscoveredAgent['profile']) => Promise<void>;
+  reloadAgents: () => Promise<void>;
+  removeAgent: (profileId: string) => Promise<void>;
+  saveAgentDraft: () => Promise<void>;
+  setAgentArgv: React.Dispatch<React.SetStateAction<string>>;
+  setAgentDraft: React.Dispatch<React.SetStateAction<AgentRuntimeProfileInput>>;
+  setDefaultAgent: (profileId: string) => Promise<void>;
+  verifyAgent: (profileId: string) => Promise<void>;
+};
+
+type ConfiguredAgentRowProps = {
+  model: AgentSettingsModel;
+  profile: ConfiguredAgent;
+};
+
+function ConfiguredAgentRow(props: ConfiguredAgentRowProps) {
+  const { model, profile } = props;
+  const editProfile = () => {
+    model.setAgentDraft({
+      id: profile.id,
+      label: profile.label,
+      provider: profile.provider,
+      executable: profile.launch.executable,
+      argv: profile.launch.argv,
+      shellMode: profile.launch.shellMode,
+      cwdPolicy: profile.cwdPolicy,
+      backend: profile.backendDefault,
+      envelope: profile.bootstrap.envelope,
+    });
+    model.setAgentArgv(profile.launch.argv.join('\n'));
+  };
+  return (
+    <div style={rowStyle}>
+      <div>
+        <div style={{ color: '#9cdcfe' }}>{profile.label}</div>
+        <div style={{ color: '#6a6a6a' }}>{profile.id}</div>
+      </div>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+        <code style={{ overflowWrap: 'anywhere' }}>
+          {profile.launch.executable}
+        </code>
+        <button
+          type="button"
+          disabled={model.agentBusy}
+          onClick={() => void model.setDefaultAgent(profile.id)}
+        >
+          {model.agentCatalog?.defaultProfileId === profile.id
+            ? 'Default ✓'
+            : 'Set default'}
+        </button>
+        <button
+          type="button"
+          disabled={model.agentBusy}
+          onClick={() => void model.verifyAgent(profile.id)}
+        >
+          Verify
+        </button>
+        <button type="button" disabled={model.agentBusy} onClick={editProfile}>
+          Edit
+        </button>
+        <button
+          type="button"
+          disabled={model.agentBusy}
+          onClick={() => void model.removeAgent(profile.id)}
+        >
+          Remove
+        </button>
+      </div>
+    </div>
+  );
+}
+
+type ConfiguredAgentsSectionProps = {
+  model: AgentSettingsModel;
+  shell: KfxViewProps['shell'];
+};
+
+function ConfiguredAgentsSection(props: ConfiguredAgentsSectionProps) {
+  const { model, shell } = props;
+  return (
+    <div>
+      <h3 style={{ ...headingStyle, fontSize: 13 }}>Configured</h3>
+      <div style={{ display: 'flex', gap: 12, marginBottom: 10 }}>
+        <label style={{ ...mono, display: 'flex', gap: 6 }}>
+          startup
+          <select
+            value={model.agentCatalog?.startupView ?? 'profile-home'}
+            onChange={(event) => {
+              shell.setConfigValue('agent.startupView', event.target.value);
+              void model.reloadAgents();
+            }}
+          >
+            <option value="profile-home">Work Control</option>
+            <option value="agent-console">Agent Console</option>
+          </select>
+        </label>
+        <label style={{ ...mono, display: 'flex', gap: 6 }}>
+          default backend
+          <select
+            value={model.agentCatalog?.backendDefault ?? 'tmux'}
+            onChange={(event) => {
+              shell.setConfigValue('agent.backendDefault', event.target.value);
+              void model.reloadAgents();
+            }}
+          >
+            <option value="tmux">Durable</option>
+            <option value="direct">Direct</option>
+          </select>
+        </label>
+      </div>
+      {(model.agentCatalog?.configured ?? []).map((profile) => (
+        <ConfiguredAgentRow key={profile.id} model={model} profile={profile} />
+      ))}
+      {(model.agentCatalog?.configured.length ?? 0) === 0 && (
+        <div style={{ ...mono, color: '#6a6a6a' }}>
+          No saved launch method yet.
+        </div>
+      )}
+    </div>
+  );
+}
+
+type DiscoveredAgentRowProps = {
+  model: AgentSettingsModel;
+  row: DiscoveredAgent;
+};
+
+function DiscoveredAgentRow(props: DiscoveredAgentRowProps) {
+  const { model, row } = props;
+  return (
+    <div style={rowStyle}>
+      <div>
+        <div style={{ color: '#9cdcfe' }}>{row.profile.label}</div>
+        <div style={{ color: '#6a6a6a' }}>
+          {row.version ?? 'version unknown'}
+        </div>
+      </div>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+        <code style={{ overflowWrap: 'anywhere' }}>
+          {row.profile.launch.executable}
+        </code>
+        <button
+          type="button"
+          disabled={model.agentBusy}
+          onClick={() => void model.configureDiscovered(row.profile)}
+        >
+          {model.agentCatalog?.defaultProfileId === row.profile.id
+            ? 'Default ✓'
+            : 'Use'}
+        </button>
+        <button
+          type="button"
+          disabled={model.agentBusy}
+          onClick={() => void model.verifyAgent(row.profile.id)}
+        >
+          Verify
+        </button>
+      </div>
+    </div>
+  );
+}
+
+type DiscoveredAgentsSectionProps = { model: AgentSettingsModel };
+
+function DiscoveredAgentsSection(props: DiscoveredAgentsSectionProps) {
+  const { model } = props;
+  return (
+    <div>
+      <h3 style={{ ...headingStyle, fontSize: 13 }}>Detected on this Mac</h3>
+      {(model.agentCatalog?.discovered ?? []).map((row) => (
+        <DiscoveredAgentRow key={row.profile.id} model={model} row={row} />
+      ))}
+      {(model.agentCatalog?.discovered.length ?? 0) === 0 && (
+        <div style={{ ...mono, color: '#6a6a6a' }}>
+          No Codex or Claude executable found. Add a custom method below.
+        </div>
+      )}
+    </div>
+  );
+}
+
+type AgentIdentityFieldsProps = { model: AgentSettingsModel };
+
+function AgentIdentityFields(props: AgentIdentityFieldsProps) {
+  const { model } = props;
+  const fields = [
+    ['id', 'stable id'],
+    ['label', 'label'],
+    ['executable', 'executable'],
+  ] as const;
+  return (
+    <>
+      <label style={rowStyle}>
+        <span>provider</span>
+        <select
+          value={model.agentDraft.provider}
+          onChange={(event) => {
+            const provider = event.target.value as 'codex' | 'claude';
+            model.setAgentDraft((current) => ({
+              ...current,
+              provider,
+              id: `${provider}.custom`,
+              label: `${provider === 'codex' ? 'Codex' : 'Claude'} · Custom`,
+              executable: provider,
+            }));
+          }}
+        >
+          <option value="codex">Codex</option>
+          <option value="claude">Claude</option>
+        </select>
+      </label>
+      {fields.map(([key, label]) => (
+        <label key={key} style={rowStyle}>
+          <span>{label}</span>
+          <input
+            style={inputStyle}
+            value={model.agentDraft[key]}
+            onChange={(event) =>
+              model.setAgentDraft((current) => ({
+                ...current,
+                [key]: event.target.value,
+              }))
+            }
+          />
+        </label>
+      ))}
+    </>
+  );
+}
+
+type CustomAgentSectionProps = { model: AgentSettingsModel };
+
+function CustomAgentSection(props: CustomAgentSectionProps) {
+  const { model } = props;
+  return (
+    <div>
+      <h3 style={{ ...headingStyle, fontSize: 13 }}>Custom method</h3>
+      <div style={{ display: 'grid', gap: 8, maxWidth: 720 }}>
+        <AgentIdentityFields model={model} />
+        <label style={rowStyle}>
+          <span>argv · one per line</span>
+          <textarea
+            rows={3}
+            style={{ ...inputStyle, resize: 'vertical' }}
+            value={model.agentArgv}
+            onChange={(event) => model.setAgentArgv(event.target.value)}
+            placeholder="Optional agentctl arguments"
+          />
+        </label>
+        <label style={rowStyle}>
+          <span>backend</span>
+          <select
+            value={model.agentDraft.backend}
+            onChange={(event) =>
+              model.setAgentDraft((current) => ({
+                ...current,
+                backend: event.target.value as 'tmux' | 'direct',
+              }))
+            }
+          >
+            <option value="tmux">Durable</option>
+            <option value="direct">Direct · ends with app</option>
+          </select>
+        </label>
+        <label style={rowStyle}>
+          <span>shell mode</span>
+          <span>
+            <input
+              type="checkbox"
+              checked={model.agentDraft.shellMode ?? false}
+              onChange={(event) =>
+                model.setAgentDraft((current) => ({
+                  ...current,
+                  shellMode: event.target.checked,
+                }))
+              }
+            />{' '}
+            explicit compatibility mode · only enable for a trusted custom
+            command
+          </span>
+        </label>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button
+            type="button"
+            disabled={model.agentBusy}
+            onClick={() => void model.saveAgentDraft()}
+          >
+            Save and use
+          </button>
+          <button
+            type="button"
+            disabled={model.agentBusy}
+            onClick={() => void model.reloadAgents()}
+          >
+            Rescan
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type AgentSettingsContentProps = {
+  available: boolean;
+  model: AgentSettingsModel;
+  shell: KfxViewProps['shell'];
+};
+
+function AgentSettingsContent(props: AgentSettingsContentProps) {
+  const { available, model, shell } = props;
+  return (
+    <section style={sectionStyle}>
+      <h2 style={headingStyle}>Agent Runtime Profiles</h2>
+      <div style={{ ...mono, color: '#858585', marginBottom: 12 }}>
+        Machine-global launch methods only. Kungfu inspects executable paths and
+        bounded --version output; provider auth and conversation data stay
+        private.
+      </div>
+      {!available ? (
+        <div style={{ ...mono, color: '#f48771' }}>
+          Agent Runtime capability unavailable
+        </div>
+      ) : (
+        <div style={{ display: 'grid', gap: 16 }}>
+          <ConfiguredAgentsSection model={model} shell={shell} />
+          <DiscoveredAgentsSection model={model} />
+          <CustomAgentSection model={model} />
+          <div style={{ ...mono, color: '#6a6a6a' }}>
+            config: {model.agentCatalog?.configPath ?? 'loading…'}
+          </div>
+          {model.agentMessage && (
+            <div style={{ ...mono, color: '#dcdcaa' }}>
+              {model.agentMessage}
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function SettingsView({ shell, caps }: KfxViewProps) {
+  const [drafts, setDrafts] = React.useState<Record<string, string>>({});
+  const [activeTab, setActiveTab] = React.useState<SettingsTab>('appearance');
+  const ui = shell.config?.config.ui ?? {
+    fontFamily: 'system',
+    fontSize: 14,
+    scale: 1,
+  };
+  const [uiDraft, setUiDraft] = React.useState({
+    fontFamily: ui.fontFamily,
+    fontSize: String(ui.fontSize),
+    scale: String(ui.scale),
+  });
+  const [uiError, setUiError] = React.useState('');
+  const [agentCatalog, setAgentCatalog] =
+    React.useState<AgentRuntimeCatalog | null>(null);
+  const [agentDraft, setAgentDraft] =
+    React.useState<AgentRuntimeProfileInput>(emptyAgentDraft);
+  const [agentArgv, setAgentArgv] = React.useState('');
+  const [agentMessage, setAgentMessage] = React.useState('');
+  const [agentBusy, setAgentBusy] = React.useState(false);
+
+  const reloadAgents = React.useCallback(async () => {
+    if (!caps.agentRuntime) return;
+    setAgentBusy(true);
+    try {
+      setAgentCatalog(await caps.agentRuntime.list());
+      setAgentMessage('');
+    } catch (error) {
+      setAgentMessage((error as Error).message);
+    } finally {
+      setAgentBusy(false);
+    }
+  }, [caps.agentRuntime]);
+
+  React.useEffect(() => {
+    if (activeTab === 'agents') void reloadAgents();
+  }, [activeTab, reloadAgents]);
+
+  React.useEffect(() => {
+    setUiDraft({
+      fontFamily: ui.fontFamily,
+      fontSize: String(ui.fontSize),
+      scale: String(ui.scale),
+    });
+  }, [ui.fontFamily, ui.fontSize, ui.scale]);
+
+  const declared = shell.registry.flatMap((entry) =>
+    entry.settings.map((decl) => ({ owner: entry.title, decl })),
+  );
+
+  const commit = (key: string) => {
+    const value = drafts[key];
+    if (value === undefined) return;
+    shell.updateState({ settings: { ...shell.state.settings, [key]: value } });
+    setDrafts((current) => {
+      const next = { ...current };
+      delete next[key];
+      return next;
+    });
+  };
+
+  const profile =
+    shell.profiles.find((p) => p.id === shell.state.profileId) ??
+    shell.profiles[0];
+
+  const saveAppearance = () => {
+    const fontSize = Number(uiDraft.fontSize);
+    const scale = Number(uiDraft.scale);
+    if (!Number.isFinite(fontSize) || fontSize < 8 || fontSize > 48) {
+      setUiError('font size must be between 8 and 48');
+      return;
+    }
+    if (!Number.isFinite(scale) || scale < 0.5 || scale > 3) {
+      setUiError('zoom must be between 50% and 300%');
+      return;
+    }
+    const fontFamily = uiDraft.fontFamily.trim() || 'system';
+    try {
+      shell.setConfigValue('ui.fontFamily', fontFamily);
+      shell.setConfigValue('ui.fontSize', fontSize);
+      shell.setConfigValue('ui.scale', scale);
+      setUiError('');
+    } catch (e) {
+      setUiError((e as Error).message);
+    }
+  };
+
+  const resetAppearance = () => {
+    try {
+      shell.unsetConfigValue('ui.fontFamily');
+      shell.unsetConfigValue('ui.fontSize');
+      shell.unsetConfigValue('ui.scale');
+      shell.reloadConfig();
+      setUiError('');
+    } catch (e) {
+      setUiError((e as Error).message);
+    }
+  };
+
+  const renderAppearance = () => (
+    <AppearanceSettings
+      resetAppearance={resetAppearance}
+      saveAppearance={saveAppearance}
+      setUiDraft={setUiDraft}
+      shell={shell}
+      uiDraft={uiDraft}
+      uiError={uiError}
+    />
+  );
+
+  const renderProfile = () => (
+    <ProfileSettings profile={profile} shell={shell} />
   );
 
   const configureDiscovered = async (
@@ -446,398 +996,56 @@ function SettingsView({ shell, caps }: KfxViewProps) {
     }
   };
 
-  const renderAgents = () => (
-    <section style={sectionStyle}>
-      <h2 style={headingStyle}>Agent Runtime Profiles</h2>
-      <div style={{ ...mono, color: '#858585', marginBottom: 12 }}>
-        Machine-global launch methods only. Kungfu inspects executable paths and
-        bounded --version output; provider auth and conversation data stay
-        private.
-      </div>
-      {!caps.agentRuntime ? (
-        <div style={{ ...mono, color: '#f48771' }}>
-          Agent Runtime capability unavailable
-        </div>
-      ) : (
-        <div style={{ display: 'grid', gap: 16 }}>
-          <div>
-            <h3 style={{ ...headingStyle, fontSize: 13 }}>Configured</h3>
-            <div style={{ display: 'flex', gap: 12, marginBottom: 10 }}>
-              <label style={{ ...mono, display: 'flex', gap: 6 }}>
-                startup
-                <select
-                  value={agentCatalog?.startupView ?? 'profile-home'}
-                  onChange={(event) => {
-                    shell.setConfigValue(
-                      'agent.startupView',
-                      event.target.value,
-                    );
-                    void reloadAgents();
-                  }}
-                >
-                  <option value="profile-home">Work Control</option>
-                  <option value="agent-console">Agent Console</option>
-                </select>
-              </label>
-              <label style={{ ...mono, display: 'flex', gap: 6 }}>
-                default backend
-                <select
-                  value={agentCatalog?.backendDefault ?? 'tmux'}
-                  onChange={(event) => {
-                    shell.setConfigValue(
-                      'agent.backendDefault',
-                      event.target.value,
-                    );
-                    void reloadAgents();
-                  }}
-                >
-                  <option value="tmux">Durable</option>
-                  <option value="direct">Direct</option>
-                </select>
-              </label>
-            </div>
-            {(agentCatalog?.configured ?? []).map((profile) => (
-              <div key={profile.id} style={rowStyle}>
-                <div>
-                  <div style={{ color: '#9cdcfe' }}>{profile.label}</div>
-                  <div style={{ color: '#6a6a6a' }}>{profile.id}</div>
-                </div>
-                <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-                  <code style={{ overflowWrap: 'anywhere' }}>
-                    {profile.launch.executable}
-                  </code>
-                  <button
-                    type="button"
-                    disabled={agentBusy}
-                    onClick={() => void setDefaultAgent(profile.id)}
-                  >
-                    {agentCatalog?.defaultProfileId === profile.id
-                      ? 'Default ✓'
-                      : 'Set default'}
-                  </button>
-                  <button
-                    type="button"
-                    disabled={agentBusy}
-                    onClick={() => void verifyAgent(profile.id)}
-                  >
-                    Verify
-                  </button>
-                  <button
-                    type="button"
-                    disabled={agentBusy}
-                    onClick={() => {
-                      setAgentDraft({
-                        id: profile.id,
-                        label: profile.label,
-                        provider: profile.provider,
-                        executable: profile.launch.executable,
-                        argv: profile.launch.argv,
-                        shellMode: profile.launch.shellMode,
-                        cwdPolicy: profile.cwdPolicy,
-                        backend: profile.backendDefault,
-                        envelope: profile.bootstrap.envelope,
-                      });
-                      setAgentArgv(profile.launch.argv.join('\n'));
-                    }}
-                  >
-                    Edit
-                  </button>
-                  <button
-                    type="button"
-                    disabled={agentBusy}
-                    onClick={() => void removeAgent(profile.id)}
-                  >
-                    Remove
-                  </button>
-                </div>
-              </div>
-            ))}
-            {(agentCatalog?.configured.length ?? 0) === 0 && (
-              <div style={{ ...mono, color: '#6a6a6a' }}>
-                No saved launch method yet.
-              </div>
-            )}
-          </div>
-          <div>
-            <h3 style={{ ...headingStyle, fontSize: 13 }}>
-              Detected on this Mac
-            </h3>
-            {(agentCatalog?.discovered ?? []).map((row) => (
-              <div key={row.profile.id} style={rowStyle}>
-                <div>
-                  <div style={{ color: '#9cdcfe' }}>{row.profile.label}</div>
-                  <div style={{ color: '#6a6a6a' }}>
-                    {row.version ?? 'version unknown'}
-                  </div>
-                </div>
-                <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-                  <code style={{ overflowWrap: 'anywhere' }}>
-                    {row.profile.launch.executable}
-                  </code>
-                  <button
-                    type="button"
-                    disabled={agentBusy}
-                    onClick={() => void configureDiscovered(row.profile)}
-                  >
-                    {agentCatalog?.defaultProfileId === row.profile.id
-                      ? 'Default ✓'
-                      : 'Use'}
-                  </button>
-                  <button
-                    type="button"
-                    disabled={agentBusy}
-                    onClick={() => void verifyAgent(row.profile.id)}
-                  >
-                    Verify
-                  </button>
-                </div>
-              </div>
-            ))}
-            {(agentCatalog?.discovered.length ?? 0) === 0 && (
-              <div style={{ ...mono, color: '#6a6a6a' }}>
-                No Codex or Claude executable found. Add a custom method below.
-              </div>
-            )}
-          </div>
-          <div>
-            <h3 style={{ ...headingStyle, fontSize: 13 }}>Custom method</h3>
-            <div style={{ display: 'grid', gap: 8, maxWidth: 720 }}>
-              <label style={rowStyle}>
-                <span>provider</span>
-                <select
-                  value={agentDraft.provider}
-                  onChange={(event) => {
-                    const provider = event.target.value as 'codex' | 'claude';
-                    setAgentDraft((current) => ({
-                      ...current,
-                      provider,
-                      id: `${provider}.custom`,
-                      label: `${provider === 'codex' ? 'Codex' : 'Claude'} · Custom`,
-                      executable: provider,
-                    }));
-                  }}
-                >
-                  <option value="codex">Codex</option>
-                  <option value="claude">Claude</option>
-                </select>
-              </label>
-              {(
-                [
-                  ['id', 'stable id'],
-                  ['label', 'label'],
-                  ['executable', 'executable'],
-                ] as const
-              ).map(([key, label]) => (
-                <label key={key} style={rowStyle}>
-                  <span>{label}</span>
-                  <input
-                    style={inputStyle}
-                    value={agentDraft[key]}
-                    onChange={(event) =>
-                      setAgentDraft((current) => ({
-                        ...current,
-                        [key]: event.target.value,
-                      }))
-                    }
-                  />
-                </label>
-              ))}
-              <label style={rowStyle}>
-                <span>argv · one per line</span>
-                <textarea
-                  rows={3}
-                  style={{ ...inputStyle, resize: 'vertical' }}
-                  value={agentArgv}
-                  onChange={(event) => setAgentArgv(event.target.value)}
-                  placeholder="Optional agentctl arguments"
-                />
-              </label>
-              <label style={rowStyle}>
-                <span>backend</span>
-                <select
-                  value={agentDraft.backend}
-                  onChange={(event) =>
-                    setAgentDraft((current) => ({
-                      ...current,
-                      backend: event.target.value as 'tmux' | 'direct',
-                    }))
-                  }
-                >
-                  <option value="tmux">Durable</option>
-                  <option value="direct">Direct · ends with app</option>
-                </select>
-              </label>
-              <label style={rowStyle}>
-                <span>shell mode</span>
-                <span>
-                  <input
-                    type="checkbox"
-                    checked={agentDraft.shellMode ?? false}
-                    onChange={(event) =>
-                      setAgentDraft((current) => ({
-                        ...current,
-                        shellMode: event.target.checked,
-                      }))
-                    }
-                  />{' '}
-                  explicit compatibility mode · only enable for a trusted custom
-                  command
-                </span>
-              </label>
-              <div style={{ display: 'flex', gap: 8 }}>
-                <button
-                  type="button"
-                  disabled={agentBusy}
-                  onClick={() => void saveAgentDraft()}
-                >
-                  Save and use
-                </button>
-                <button
-                  type="button"
-                  disabled={agentBusy}
-                  onClick={() => void reloadAgents()}
-                >
-                  Rescan
-                </button>
-              </div>
-            </div>
-          </div>
-          <div style={{ ...mono, color: '#6a6a6a' }}>
-            config: {agentCatalog?.configPath ?? 'loading…'}
-          </div>
-          {agentMessage && (
-            <div style={{ ...mono, color: '#dcdcaa' }}>{agentMessage}</div>
-          )}
-        </div>
-      )}
-    </section>
-  );
-
-  const renderKfx = () => (
-    <section style={sectionStyle}>
-      <h2 style={headingStyle}>KFX settings</h2>
-      {declared.length ? (
-        <div>
-          {declared.map(({ owner, decl }) => (
-            <div key={decl.key} style={rowStyle}>
-              <div style={{ color: '#858585' }}>
-                {owner}
-                <div style={{ color: '#6a6a6a' }}>{decl.key}</div>
-              </div>
-              <label style={{ display: 'block' }}>
-                <div style={{ marginBottom: 4 }}>{decl.label}</div>
-                <input
-                  style={{ ...inputStyle, width: 'min(360px, 100%)' }}
-                  value={drafts[decl.key] ?? shell.setting(decl.key)}
-                  onChange={(e) =>
-                    setDrafts((current) => ({
-                      ...current,
-                      [decl.key]: e.target.value,
-                    }))
-                  }
-                  onBlur={() => commit(decl.key)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') commit(decl.key);
-                  }}
-                />
-              </label>
-            </div>
-          ))}
-        </div>
-      ) : (
-        <div style={{ ...mono, color: '#6a6a6a' }}>
-          no kfx contributed settings
-        </div>
-      )}
-    </section>
-  );
-
-  const renderPaths = () => (
-    <section style={sectionStyle}>
-      <h2 style={headingStyle}>Runtime paths</h2>
-      {[
-        ['runtime home', shell.info.runtimeDir],
-        ['KF_HOME', shellEnv('KF_HOME')],
-        ['KF_CONFIG_HOME', shellEnv('KF_CONFIG_HOME')],
-        ['KF_EXTENSION_PATH', shellEnv('KF_EXTENSION_PATH')],
-        ['KF_BUNDLED_EXTENSION_ROOT', shellEnv('KF_BUNDLED_EXTENSION_ROOT')],
-      ].map(([label, value]) => (
-        <div key={label} style={rowStyle}>
-          <div style={{ color: '#858585' }}>{label}</div>
-          <div style={{ color: '#9cdcfe', overflowWrap: 'anywhere' }}>
-            {value}
-          </div>
-        </div>
-      ))}
-    </section>
-  );
-
-  const renderAdvanced = () => (
-    <section style={sectionStyle}>
-      <h2 style={headingStyle}>Shell state</h2>
-      <pre
-        style={{
-          ...mono,
-          margin: 0,
-          padding: 12,
-          overflow: 'auto',
-          border: '1px solid #3c3c3c',
-          borderRadius: 6,
-          background: '#1e1e1e',
-          color: '#cccccc',
-          maxHeight: 360,
-        }}
-      >
-        {JSON.stringify(shell.state, null, 2)}
-      </pre>
-    </section>
-  );
-
-  const renderActive = () => {
-    if (activeTab === 'appearance') return renderAppearance();
-    if (activeTab === 'agents') return renderAgents();
-    if (activeTab === 'profile') return renderProfile();
-    if (activeTab === 'kfx') return renderKfx();
-    if (activeTab === 'paths') return renderPaths();
-    return renderAdvanced();
+  const agentSettingsModel: AgentSettingsModel = {
+    agentArgv,
+    agentBusy,
+    agentCatalog,
+    agentDraft,
+    agentMessage,
+    configureDiscovered,
+    reloadAgents,
+    removeAgent,
+    saveAgentDraft,
+    setAgentArgv,
+    setAgentDraft,
+    setDefaultAgent,
+    verifyAgent,
   };
 
+  const renderAgents = () => (
+    <AgentSettingsContent
+      available={Boolean(caps.agentRuntime)}
+      model={agentSettingsModel}
+      shell={shell}
+    />
+  );
+  const renderKfx = () => (
+    <KfxSettings
+      commit={commit}
+      declared={declared}
+      drafts={drafts}
+      setDrafts={setDrafts}
+      shell={shell}
+    />
+  );
+
+  const renderPaths = () => <PathsSettings shell={shell} />;
+
+  const renderAdvanced = () => <AdvancedSettings shell={shell} />;
+
   return (
-    <div>
-      <div
-        role="tablist"
-        aria-label="Settings sections"
-        style={{
-          display: 'flex',
-          gap: 6,
-          marginBottom: 12,
-          borderBottom: '1px solid #3c3c3c',
-          paddingBottom: 8,
-        }}
-      >
-        {tabs.map((tab) => (
-          <button
-            key={tab}
-            type="button"
-            role="tab"
-            aria-selected={activeTab === tab}
-            onClick={() => setActiveTab(tab)}
-            style={{
-              ...mono,
-              padding: '6px 10px',
-              border: '1px solid #3c3c3c',
-              borderRadius: 6,
-              cursor: 'pointer',
-              background: activeTab === tab ? '#04395e' : '#1e1e1e',
-              color: activeTab === tab ? '#9cdcfe' : '#cccccc',
-            }}
-          >
-            {tabLabels[tab]}
-          </button>
-        ))}
-      </div>
-      {renderActive()}
-    </div>
+    <SettingsTabs
+      activeTab={activeTab}
+      content={activeSettingsContent(activeTab, {
+        advanced: renderAdvanced,
+        agents: renderAgents,
+        appearance: renderAppearance,
+        kfx: renderKfx,
+        paths: renderPaths,
+        profile: renderProfile,
+      })}
+      setActiveTab={setActiveTab}
+    />
   );
 }
 

--- a/extensions/system/skill-manager/src/view/index.tsx
+++ b/extensions/system/skill-manager/src/view/index.tsx
@@ -97,6 +97,142 @@ function AgentSkillRow({
   );
 }
 
+type RuntimeAuditSectionProps = {
+  runtimeAudit: SkillManagerView['runtimeAudit'];
+};
+
+type RuntimeAudit = NonNullable<SkillManagerView['runtimeAudit']>;
+
+function RuntimeSkillDetails({ skills }: { skills: RuntimeAudit['skills'] }) {
+  return skills.map((value, index) => {
+    const skill = record(value);
+    const identity = record(skill.identity);
+    const proof = record(skill.proof);
+    return (
+      <details
+        key={`${String(identity.key ?? 'skill')}:${index}`}
+        style={{ ...mono, marginTop: 6 }}
+      >
+        <summary style={{ color: '#9cdcfe' }}>
+          {String(identity.key ?? 'unknown')}@{String(identity.revision ?? '?')}{' '}
+          · {String(skill.lifecycle ?? 'unproved')} ·{' '}
+          {compact(skill.observedStates)}
+        </summary>
+        <div style={{ color: '#858585', marginLeft: 12 }}>
+          identity: content={String(identity.contentRoot ?? '-')} · definition=
+          {String(identity.definitionRoot ?? '-')} · class=
+          {String(identity.class ?? '-')}
+        </div>
+        <div style={{ color: '#858585', marginLeft: 12 }}>
+          Work bindings: {compact(skill.workBindings)}
+        </div>
+        <div style={{ color: '#858585', marginLeft: 12 }}>
+          dependencies/trust/authorization: {compact(skill.dependencies)}
+        </div>
+        <div style={{ color: '#858585', marginLeft: 12 }}>
+          receipts/history proof: {String(proof.status ?? 'unproved')} ·{' '}
+          {compact(proof.roots)} · preserved=
+          {String(skill.historyPreserved ?? false)}
+        </div>
+      </details>
+    );
+  });
+}
+
+type RuntimeEvidenceDetailsProps = { evidence: RuntimeAudit['evidence'] };
+
+function RuntimeEvidenceRow({ value }: { value: unknown }) {
+  const item = record(value);
+  const source = record(item.source);
+  const proof = record(item.proof);
+  return (
+    <div style={{ color: '#858585', marginLeft: 12 }}>
+      {String(item.state ?? 'unproved')} · {String(item.skillKey ?? '-')} · run=
+      {String(item.runId ?? '-')} · Work={String(item.workRef ?? '-')} · source=
+      {String(source.type ?? '-')} · {String(proof.status ?? 'unproved')}:{' '}
+      {compact(proof.roots)} · {compact(item.detail)}
+    </div>
+  );
+}
+
+function runtimeEvidenceKey(value: unknown) {
+  const item = record(value);
+  const source = record(item.source);
+  const proof = record(item.proof);
+  return `${String(item.runId ?? '-')}:${String(item.workRef ?? '-')}:${String(item.skillKey ?? '-')}:${String(item.state ?? 'unproved')}:${String(source.type ?? '-')}:${compact(proof.roots)}`;
+}
+
+function RuntimeEvidenceDetails(props: RuntimeEvidenceDetailsProps) {
+  const { evidence } = props;
+  return (
+    <details style={{ ...mono, marginTop: 6 }}>
+      <summary style={{ color: '#ce9178' }}>
+        audit, dependency, trust, authorization, and receipt evidence
+      </summary>
+      {evidence.map((value) => (
+        <RuntimeEvidenceRow key={runtimeEvidenceKey(value)} value={value} />
+      ))}
+    </details>
+  );
+}
+
+type RuntimeRecoveryDetailsProps = { runtimeAudit: RuntimeAudit };
+
+function RuntimeRecoveryDetails(props: RuntimeRecoveryDetailsProps) {
+  const { runtimeAudit } = props;
+  const gui = runtimeAudit.surfaceProjections.gui;
+  return (
+    <details style={{ ...mono, marginTop: 6 }}>
+      <summary style={{ color: '#dcdcaa' }}>recovery and history</summary>
+      <div style={{ color: '#858585', marginLeft: 12 }}>
+        roots: registry={gui.registryStateRoot} · history={gui.historyRoot} ·
+        diagnosis={gui.diagnosisRoot}
+      </div>
+      <div style={{ color: '#858585', marginLeft: 12 }}>
+        audit={compact(gui.auditRoots)} · dependency=
+        {compact(gui.dependencyRoots)}
+      </div>
+      <div style={{ color: '#858585', marginLeft: 12 }}>
+        recovery: {compact(runtimeAudit.recovery)}
+      </div>
+    </details>
+  );
+}
+
+function RuntimeAuditSection(props: RuntimeAuditSectionProps) {
+  const { runtimeAudit } = props;
+  if (!runtimeAudit) {
+    return (
+      <div style={{ ...mono, color: '#858585', marginBottom: 8 }}>
+        runtime audit unavailable · lifecycle/run claims remain unproved
+      </div>
+    );
+  }
+  const guiProjection = runtimeAudit.surfaceProjections.gui;
+  return (
+    <section style={{ marginBottom: 12 }}>
+      <div style={{ ...mono, color: '#4ec9b0' }}>
+        shared runtime audit · {guiProjection.runtimeAuditRoot}
+      </div>
+      <div style={{ ...mono, color: '#858585', marginTop: 4 }}>
+        lifecycle/work/history: {guiProjection.registryStateRoot} ·{' '}
+        {guiProjection.historyRoot}
+      </div>
+      <div style={{ ...mono, color: '#858585', marginTop: 4 }}>
+        evidence: {runtimeAudit.evidence.length} · recovery:{' '}
+        {String(runtimeAudit.recovery.verdict ?? 'unproved')}
+      </div>
+      <div style={{ ...mono, color: '#858585', marginTop: 4 }}>
+        run/work: {String(runtimeAudit.scope.runId ?? '-')} ·{' '}
+        {String(runtimeAudit.scope.workRef ?? '-')}
+      </div>
+      <RuntimeSkillDetails skills={runtimeAudit.skills} />
+      <RuntimeEvidenceDetails evidence={runtimeAudit.evidence} />
+      <RuntimeRecoveryDetails runtimeAudit={runtimeAudit} />
+    </section>
+  );
+}
+
 function SkillManagerViewComponent({ shell }: KfxViewProps) {
   const view =
     asSkillManagerView(shell.info.skillManager) ??
@@ -130,7 +266,6 @@ function SkillManagerViewComponent({ shell }: KfxViewProps) {
   }
 
   const runtimeAudit = view.runtimeAudit;
-  const guiProjection = runtimeAudit?.surfaceProjections.gui;
 
   return (
     <section style={panelStyle}>
@@ -141,103 +276,7 @@ function SkillManagerViewComponent({ shell }: KfxViewProps) {
       <div style={{ ...mono, color: '#6a6a6a', marginBottom: 8 }}>
         registry: {view.registry.root}
       </div>
-      {runtimeAudit ? (
-        <section style={{ marginBottom: 12 }}>
-          <div style={{ ...mono, color: '#4ec9b0' }}>
-            shared runtime audit · {guiProjection.runtimeAuditRoot}
-          </div>
-          <div style={{ ...mono, color: '#858585', marginTop: 4 }}>
-            lifecycle/work/history: {guiProjection.registryStateRoot} ·{' '}
-            {guiProjection.historyRoot}
-          </div>
-          <div style={{ ...mono, color: '#858585', marginTop: 4 }}>
-            evidence: {runtimeAudit.evidence.length} · recovery:{' '}
-            {String(runtimeAudit.recovery.verdict ?? 'unproved')}
-          </div>
-          <div style={{ ...mono, color: '#858585', marginTop: 4 }}>
-            run/work: {String(runtimeAudit.scope.runId ?? '-')} ·{' '}
-            {String(runtimeAudit.scope.workRef ?? '-')}
-          </div>
-          {runtimeAudit.skills.map((value, index) => {
-            const skill = record(value);
-            const identity = record(skill.identity);
-            const proof = record(skill.proof);
-            return (
-              <details
-                key={`${String(identity.key ?? 'skill')}:${index}`}
-                style={{ ...mono, marginTop: 6 }}
-              >
-                <summary style={{ color: '#9cdcfe' }}>
-                  {String(identity.key ?? 'unknown')}@
-                  {String(identity.revision ?? '?')} ·{' '}
-                  {String(skill.lifecycle ?? 'unproved')} ·{' '}
-                  {compact(skill.observedStates)}
-                </summary>
-                <div style={{ color: '#858585', marginLeft: 12 }}>
-                  identity: content={String(identity.contentRoot ?? '-')} ·
-                  definition={String(identity.definitionRoot ?? '-')} · class=
-                  {String(identity.class ?? '-')}
-                </div>
-                <div style={{ color: '#858585', marginLeft: 12 }}>
-                  Work bindings: {compact(skill.workBindings)}
-                </div>
-                <div style={{ color: '#858585', marginLeft: 12 }}>
-                  dependencies/trust/authorization:{' '}
-                  {compact(skill.dependencies)}
-                </div>
-                <div style={{ color: '#858585', marginLeft: 12 }}>
-                  receipts/history proof: {String(proof.status ?? 'unproved')} ·{' '}
-                  {compact(proof.roots)} · preserved=
-                  {String(skill.historyPreserved ?? false)}
-                </div>
-              </details>
-            );
-          })}
-          <details style={{ ...mono, marginTop: 6 }}>
-            <summary style={{ color: '#ce9178' }}>
-              audit, dependency, trust, authorization, and receipt evidence
-            </summary>
-            {runtimeAudit.evidence.map((value) => {
-              const evidence = record(value);
-              const source = record(evidence.source);
-              const proof = record(evidence.proof);
-              return (
-                <div
-                  key={`${String(evidence.runId ?? '-')}:${String(evidence.workRef ?? '-')}:${String(evidence.skillKey ?? '-')}:${String(evidence.state ?? 'unproved')}:${String(source.type ?? '-')}:${compact(proof.roots)}`}
-                  style={{ color: '#858585', marginLeft: 12 }}
-                >
-                  {String(evidence.state ?? 'unproved')} ·{' '}
-                  {String(evidence.skillKey ?? '-')} · run=
-                  {String(evidence.runId ?? '-')} · Work=
-                  {String(evidence.workRef ?? '-')} · source=
-                  {String(source.type ?? '-')} ·{' '}
-                  {String(proof.status ?? 'unproved')}: {compact(proof.roots)} ·{' '}
-                  {compact(evidence.detail)}
-                </div>
-              );
-            })}
-          </details>
-          <details style={{ ...mono, marginTop: 6 }}>
-            <summary style={{ color: '#dcdcaa' }}>recovery and history</summary>
-            <div style={{ color: '#858585', marginLeft: 12 }}>
-              roots: registry={guiProjection.registryStateRoot} · history=
-              {guiProjection.historyRoot} · diagnosis=
-              {guiProjection.diagnosisRoot}
-            </div>
-            <div style={{ color: '#858585', marginLeft: 12 }}>
-              audit={compact(guiProjection.auditRoots)} · dependency=
-              {compact(guiProjection.dependencyRoots)}
-            </div>
-            <div style={{ color: '#858585', marginLeft: 12 }}>
-              recovery: {compact(runtimeAudit.recovery)}
-            </div>
-          </details>
-        </section>
-      ) : (
-        <div style={{ ...mono, color: '#858585', marginBottom: 8 }}>
-          runtime audit unavailable · lifecycle/run claims remain unproved
-        </div>
-      )}
+      <RuntimeAuditSection runtimeAudit={runtimeAudit} />
       {view.skills.length === 0 ? (
         <div style={{ ...mono, color: '#6a6a6a' }}>no installed skills</div>
       ) : (

--- a/framework/site/src/kfx-site-impact-proofs/ecc7237be90a775eeef2c6e892294e5bcc2af8e35c89940562a13d3d4e449f7e.json
+++ b/framework/site/src/kfx-site-impact-proofs/ecc7237be90a775eeef2c6e892294e5bcc2af8e35c89940562a13d3d4e449f7e.json
@@ -1,0 +1,37 @@
+{
+  "contract": "kungfu.kfx-site-impact-proof/v1",
+  "baseRevision": "a5086fcdc01a0c0520dcb6c6031a43bc7c56846f",
+  "changeRoot": "sha256:bbf9cedc87886df5a768d65fa091bc356447480acc0e1cbede5a6d9b353ae978",
+  "changes": [
+    {
+      "baseContentRoot": "sha256:016c67c42618df951be534502108fdbde6b6ee35538094287d7dc10d754bb638",
+      "contentRoot": "sha256:588642db6fd8cccb15ebd0fe003be0715634cd168a34b165ea71566953f6c976",
+      "path": "extensions/system/kfx-manager/src/view/index.tsx",
+      "status": "modified"
+    },
+    {
+      "baseContentRoot": "sha256:a0fa463f1b4c9f303f22407446a0537616f9a5c63c815e892bedcdd3a70f8784",
+      "contentRoot": "sha256:676a68fd92a4cf29fd37c274272bb24f9f5613b0624ecaf95f1ce7e94c9ed6e1",
+      "path": "extensions/system/settings/src/view/index.tsx",
+      "status": "modified"
+    },
+    {
+      "baseContentRoot": "sha256:c46e24bb31a915f29676bfa588e8adf04085104bc7ae0fbb47367e3817cf2c87",
+      "contentRoot": "sha256:129a5adf4870a0d04e2b9d36f3991cf9ceacd5ade7d29a64f33dc087228165cf",
+      "path": "extensions/system/skill-manager/src/view/index.tsx",
+      "status": "modified"
+    }
+  ],
+  "affectedFacets": [
+    "capabilities",
+    "package-facets",
+    "profiles-suites"
+  ],
+  "rationale": "This refactor only decomposes existing KFX manager, settings, and skill manager view composition; it preserves rendered controls, runtime calls, public contracts, and Site reader journeys.",
+  "attestation": {
+    "publicBehaviorUnchanged": true,
+    "publicContractUnchanged": true,
+    "readerJourneyUnchanged": true
+  },
+  "proofRoot": "sha256:ecc7237be90a775eeef2c6e892294e5bcc2af8e35c89940562a13d3d4e449f7e"
+}


### PR DESCRIPTION
## Summary

Decompose the KFX manager, settings, and skill manager React view controllers into focused local helpers and components while preserving their visible behavior, IPC routing, settings contracts, and dialog flows.

- KfxManagerView is now below baseRisk 100.
- SettingsView falls from baseRisk 397 to 152.
- SkillManagerView falls from baseRisk 351 to 104.
- The exact KFX Site Bundle impact disposition is checked in.

## Validation

- ./shifu check:source
- strict changed-code function-risk ratchet against a5086fcdc01a0c0520dcb6c6031a43bc7c56846f
- KFX Site Bundle impact gate

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This maintainability refactor preserves the existing product architecture and public contracts."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
