### PR TITLE
fix(delivery): pin v4 parity warrant runtime

### DIFF
--- a/.github/actions/native-execution-under-warrant/action.yml
+++ b/.github/actions/native-execution-under-warrant/action.yml
@@ -39,7 +39,7 @@ runs:
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         repository: kungfu-systems/buildchain
-        ref: 8493bf140a7f567e76aff3119f3d39ff026afc84
+        ref: 2416a1eacbc87e902eceea467af72a95f24a51f0
         path: .buildchain/dev-delivery-native-runtime
         fetch-depth: 1
         persist-credentials: false
@@ -48,7 +48,7 @@ runs:
       working-directory: .buildchain/dev-delivery-native-runtime
       run: |
         set -euo pipefail
-        test "$(git rev-parse HEAD)" = 8493bf140a7f567e76aff3119f3d39ff026afc84
+        test "$(git rev-parse HEAD)" = 2416a1eacbc87e902eceea467af72a95f24a51f0
         if [ ! -d node_modules ]; then
           # shifu-entry-contract: allow exact pinned Buildchain dependency bootstrap before its CLI is runnable
           corepack pnpm install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/dev-delivery-warrant-terminal.yml
+++ b/.github/workflows/dev-delivery-warrant-terminal.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: kungfu-systems/buildchain
-          ref: 8493bf140a7f567e76aff3119f3d39ff026afc84
+          ref: 2416a1eacbc87e902eceea467af72a95f24a51f0
           path: .buildchain/runtime
           persist-credentials: false
 
@@ -206,9 +206,9 @@ jobs:
   close:
     needs: prepare
     if: needs.prepare.outputs.active == 'true' || needs.prepare.outputs.retry-terminal == 'true'
-    uses: kungfu-systems/buildchain/.github/workflows/dev-delivery-warrant-close.yml@8493bf140a7f567e76aff3119f3d39ff026afc84
+    uses: kungfu-systems/buildchain/.github/workflows/dev-delivery-warrant-close.yml@2416a1eacbc87e902eceea467af72a95f24a51f0
     with:
-      buildchain-ref: 8493bf140a7f567e76aff3119f3d39ff026afc84
+      buildchain-ref: 2416a1eacbc87e902eceea467af72a95f24a51f0
       target-branch: ${{ github.event.pull_request.base.ref }}
       expected-pr-number: ${{ github.event.pull_request.number }}
       expected-head-sha: ${{ needs.prepare.outputs.active-source-head-sha }}
@@ -226,9 +226,9 @@ jobs:
   cancel-queued:
     needs: prepare
     if: needs.prepare.outputs.queued == 'true'
-    uses: kungfu-systems/buildchain/.github/workflows/dev-delivery-warrant-cancel.yml@8493bf140a7f567e76aff3119f3d39ff026afc84
+    uses: kungfu-systems/buildchain/.github/workflows/dev-delivery-warrant-cancel.yml@2416a1eacbc87e902eceea467af72a95f24a51f0
     with:
-      buildchain-ref: 8493bf140a7f567e76aff3119f3d39ff026afc84
+      buildchain-ref: 2416a1eacbc87e902eceea467af72a95f24a51f0
       target-branch: ${{ github.event.pull_request.base.ref }}
       expected-pr-number: ${{ github.event.pull_request.number }}
       expected-candidate-id: ${{ needs.prepare.outputs.queued-candidate-id }}

--- a/.github/workflows/dev-pr-auto-merge.yml
+++ b/.github/workflows/dev-pr-auto-merge.yml
@@ -545,7 +545,7 @@ jobs:
       statuses: write
     uses: kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@2416a1eacbc87e902eceea467af72a95f24a51f0
     with:
-      buildchain-ref: 2416a1eacbc87e902eceea467af72a95f24a51f0
+      buildchain-ref: v4
       target-branch: ${{ needs.resolve-target.outputs.target-branch }}
       expected-pr-number: ${{ fromJSON(needs.resolve-target.outputs.expected-pr-number || '0') }}
       expected-head-sha: ${{ needs.resolve-target.outputs.expected-head-sha }}
@@ -884,7 +884,7 @@ jobs:
       statuses: write
     uses: kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@2416a1eacbc87e902eceea467af72a95f24a51f0
     with:
-      buildchain-ref: 2416a1eacbc87e902eceea467af72a95f24a51f0
+      buildchain-ref: v4
       target-branch: ${{ needs.resolve-target.outputs.target-branch }}
       expected-pr-number: ${{ fromJSON(needs.resolve-target.outputs.expected-pr-number) }}
       expected-head-sha: ${{ needs.resolve-target.outputs.expected-head-sha }}

--- a/.github/workflows/dev-pr-auto-merge.yml
+++ b/.github/workflows/dev-pr-auto-merge.yml
@@ -545,7 +545,7 @@ jobs:
       statuses: write
     uses: kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@2416a1eacbc87e902eceea467af72a95f24a51f0
     with:
-      buildchain-ref: v4
+      buildchain-ref: v4-alpha
       target-branch: ${{ needs.resolve-target.outputs.target-branch }}
       expected-pr-number: ${{ fromJSON(needs.resolve-target.outputs.expected-pr-number || '0') }}
       expected-head-sha: ${{ needs.resolve-target.outputs.expected-head-sha }}
@@ -884,7 +884,7 @@ jobs:
       statuses: write
     uses: kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@2416a1eacbc87e902eceea467af72a95f24a51f0
     with:
-      buildchain-ref: v4
+      buildchain-ref: v4-alpha
       target-branch: ${{ needs.resolve-target.outputs.target-branch }}
       expected-pr-number: ${{ fromJSON(needs.resolve-target.outputs.expected-pr-number) }}
       expected-head-sha: ${{ needs.resolve-target.outputs.expected-head-sha }}

--- a/.github/workflows/dev-pr-auto-merge.yml
+++ b/.github/workflows/dev-pr-auto-merge.yml
@@ -242,7 +242,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: kungfu-systems/buildchain
-          ref: 8493bf140a7f567e76aff3119f3d39ff026afc84
+          ref: 2416a1eacbc87e902eceea467af72a95f24a51f0
           path: .buildchain/dev-delivery-runtime
           fetch-depth: 1
           persist-credentials: false
@@ -543,9 +543,9 @@ jobs:
       contents: write
       pull-requests: write
       statuses: write
-    uses: kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@8493bf140a7f567e76aff3119f3d39ff026afc84
+    uses: kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@2416a1eacbc87e902eceea467af72a95f24a51f0
     with:
-      buildchain-ref: 8493bf140a7f567e76aff3119f3d39ff026afc84
+      buildchain-ref: 2416a1eacbc87e902eceea467af72a95f24a51f0
       target-branch: ${{ needs.resolve-target.outputs.target-branch }}
       expected-pr-number: ${{ fromJSON(needs.resolve-target.outputs.expected-pr-number || '0') }}
       expected-head-sha: ${{ needs.resolve-target.outputs.expected-head-sha }}
@@ -882,9 +882,9 @@ jobs:
       contents: write
       pull-requests: write
       statuses: write
-    uses: kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@8493bf140a7f567e76aff3119f3d39ff026afc84
+    uses: kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@2416a1eacbc87e902eceea467af72a95f24a51f0
     with:
-      buildchain-ref: 8493bf140a7f567e76aff3119f3d39ff026afc84
+      buildchain-ref: 2416a1eacbc87e902eceea467af72a95f24a51f0
       target-branch: ${{ needs.resolve-target.outputs.target-branch }}
       expected-pr-number: ${{ fromJSON(needs.resolve-target.outputs.expected-pr-number) }}
       expected-head-sha: ${{ needs.resolve-target.outputs.expected-head-sha }}

--- a/.github/workflows/queue-admission-lease.yml
+++ b/.github/workflows/queue-admission-lease.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: kungfu-systems/buildchain
-          ref: 8493bf140a7f567e76aff3119f3d39ff026afc84
+          ref: 2416a1eacbc87e902eceea467af72a95f24a51f0
           path: .buildchain/dev-delivery-runtime
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/docs/qualification/gates/dev-queue-admission.contract.json
+++ b/docs/qualification/gates/dev-queue-admission.contract.json
@@ -19,7 +19,7 @@
     "mergeGroup": ".github/workflows/queue-admission-lease.yml",
     "dequeueRevocation": ".github/workflows/cancel-dequeued-merge-group.yml",
     "dequeueControllerSource": "current-protected-pull-request-base-ref",
-    "queueAndWarrant": "kungfu-systems/buildchain@8493bf140a7f567e76aff3119f3d39ff026afc84",
+    "queueAndWarrant": "kungfu-systems/buildchain@2416a1eacbc87e902eceea467af72a95f24a51f0",
     "stateRefPattern": "buildchain/dev-delivery-warrant/dev-vN-vN.N"
   },
   "admission": {

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -530,9 +530,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:c744acf9e8ac53015ef9eae79399608ea3c3bd6a25d563887b185a5b7e5c75f8",
+          "definitionDigest": "sha256:198c7a6defcad264ff304f13885c3868b65353826b10099bcc77768edc33dccb",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-delivery-warrant-cancel.yml@8493bf140a7f567e76aff3119f3d39ff026afc84"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-delivery-warrant-cancel.yml@2416a1eacbc87e902eceea467af72a95f24a51f0"],
           "steps": []
         },
         {
@@ -540,9 +540,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:79755596a020ecc5708954c206020f8fb482fd9b48a816efc5564c1542f62c46",
+          "definitionDigest": "sha256:95d4169bea6c43d79e23c3a964e37991adaca7810bc34805aad9d47241c50e0c",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-delivery-warrant-close.yml@8493bf140a7f567e76aff3119f3d39ff026afc84"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-delivery-warrant-close.yml@2416a1eacbc87e902eceea467af72a95f24a51f0"],
           "steps": []
         },
         {
@@ -550,10 +550,10 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:3b6f76670fd77594415a298a472fa3c4e95a0b3fe3141c993e922ea4adae0b46",
+          "definitionDigest": "sha256:e1fa740044fba93fae53d3fb7464c5a6cbdd5b37eec44867d1d383b1ff7de33f",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"],
-          "steps": [{"index":1,"label":"name:Check out protected Buildchain runtime","definitionDigest":"sha256:c43b7452522937099f35131eaf27a17a964fbb57d21ba11e1c86ceb87982a4ea"},{"index":2,"label":"id:terminal","definitionDigest":"sha256:2ae9578516a524944e4022ce7329a088cc26c9a88a4f373be437b4cc29633961"}]
+          "steps": [{"index":1,"label":"name:Check out protected Buildchain runtime","definitionDigest":"sha256:81a058f81f80d4e5894c75f519948b2e15d9404cbaf3f12d429925363904f577"},{"index":2,"label":"id:terminal","definitionDigest":"sha256:2ae9578516a524944e4022ce7329a088cc26c9a88a4f373be437b4cc29633961"}]
         }
       ]
     },
@@ -631,9 +631,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:5878d15d8cf5e4ced6e07617bdc746213c39aa72c461cb5c116ff90f3f207689",
+          "definitionDigest": "sha256:5bb760fb2cd5da94e288c0292c7c71b17745648b0632f0d5a5e995857c012787",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@8493bf140a7f567e76aff3119f3d39ff026afc84"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@2416a1eacbc87e902eceea467af72a95f24a51f0"],
           "steps": []
         },
         {
@@ -641,19 +641,19 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:b066966efee6ebb1143bece9b39240a6bc7604cd6592dc35206343bf19fac346",
+          "definitionDigest": "sha256:b87e739c4142a0f028cf4e64a5342262cc38e56c72a34ef4540323576e6254af",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
-          "steps": [{"index":1,"label":"name:Check out protected consumer adapter","definitionDigest":"sha256:7a6e2b7a4219bc394a436c2b5c62af8c7e88a4ee217160392af47145517ded7e"},{"index":2,"label":"name:Check out exact Buildchain delivery runtime","authority":"evidence-publication","definitionDigest":"sha256:7f3687feffb0e67f9bcfbd6bda0dba5a72cb3d7fc4a44a89a29441d9e535ba59"},{"index":3,"label":"name:Use Node.js 24 for exact delivery proof","definitionDigest":"sha256:9a97d7c7a2267e05fe44eeb809814e7bf942ee5e9ac9b9471b9bde0e6be2c9a4"},{"index":4,"label":"name:Install exact Buildchain delivery runtime","authority":"evidence-publication","definitionDigest":"sha256:71ee76abd8d8d888d22ecd9ba4ea9c53746220b18a08f6431df9ac3f18948eb7"},{"index":5,"label":"name:Verify exact source qualification run","authority":"evidence-publication","definitionDigest":"sha256:8bafb626bf0e8a52d6bf1b7eeaa06d7bc5f10e851050e471e67d369d5c1e03da"},{"index":6,"label":"name:Download exact source qualification descriptor","authority":"evidence-publication","definitionDigest":"sha256:5c13a140aea8777e4749d8259cf091f804756e2b76ee35f00521d750c974429e"},{"index":7,"label":"id:contract","definitionDigest":"sha256:10d761264755f395be38654bf8df8d8d437d4972f631f5473a0c500f36c92bf5"},{"index":8,"label":"id:environment","authority":"evidence-publication","definitionDigest":"sha256:1714619b30678c461679e56bf5095bcbf66e71ba5a3ae12b929b967d0d3d71c1"},{"index":9,"label":"id:native-proof-artifact","authority":"evidence-publication","definitionDigest":"sha256:e6838b7eaad71c254944023a84d79a1c8b702c199bfaf305d7b922a6de3ce62e"},{"index":10,"label":"id:native-proof","definitionDigest":"sha256:f0bb5876cda8f809acc590b2fe37251ce13e1f23d4c2b8749f5cc37bfd8c8411"},{"index":11,"label":"id:project-cut","authority":"evidence-publication","definitionDigest":"sha256:ad91e14cd423a17c99cc037c1a3a15f85bbcdcbf3d0b8e487556f6f98f48c3e0"},{"index":12,"label":"name:Upload exact Warrant input projection","authority":"evidence-publication","definitionDigest":"sha256:374066139a234c9aa55cfffa25084b2938d17d83c6d14c62429fabef79a57bd8"}]
+          "steps": [{"index":1,"label":"name:Check out protected consumer adapter","definitionDigest":"sha256:7a6e2b7a4219bc394a436c2b5c62af8c7e88a4ee217160392af47145517ded7e"},{"index":2,"label":"name:Check out exact Buildchain delivery runtime","authority":"evidence-publication","definitionDigest":"sha256:ed6f101a8719f6fc63cc25d83f2cd840dd95f8f965cc614713fb18bd5a638ea6"},{"index":3,"label":"name:Use Node.js 24 for exact delivery proof","definitionDigest":"sha256:9a97d7c7a2267e05fe44eeb809814e7bf942ee5e9ac9b9471b9bde0e6be2c9a4"},{"index":4,"label":"name:Install exact Buildchain delivery runtime","authority":"evidence-publication","definitionDigest":"sha256:71ee76abd8d8d888d22ecd9ba4ea9c53746220b18a08f6431df9ac3f18948eb7"},{"index":5,"label":"name:Verify exact source qualification run","authority":"evidence-publication","definitionDigest":"sha256:8bafb626bf0e8a52d6bf1b7eeaa06d7bc5f10e851050e471e67d369d5c1e03da"},{"index":6,"label":"name:Download exact source qualification descriptor","authority":"evidence-publication","definitionDigest":"sha256:5c13a140aea8777e4749d8259cf091f804756e2b76ee35f00521d750c974429e"},{"index":7,"label":"id:contract","definitionDigest":"sha256:10d761264755f395be38654bf8df8d8d437d4972f631f5473a0c500f36c92bf5"},{"index":8,"label":"id:environment","authority":"evidence-publication","definitionDigest":"sha256:1714619b30678c461679e56bf5095bcbf66e71ba5a3ae12b929b967d0d3d71c1"},{"index":9,"label":"id:native-proof-artifact","authority":"evidence-publication","definitionDigest":"sha256:e6838b7eaad71c254944023a84d79a1c8b702c199bfaf305d7b922a6de3ce62e"},{"index":10,"label":"id:native-proof","definitionDigest":"sha256:f0bb5876cda8f809acc590b2fe37251ce13e1f23d4c2b8749f5cc37bfd8c8411"},{"index":11,"label":"id:project-cut","authority":"evidence-publication","definitionDigest":"sha256:ad91e14cd423a17c99cc037c1a3a15f85bbcdcbf3d0b8e487556f6f98f48c3e0"},{"index":12,"label":"name:Upload exact Warrant input projection","authority":"evidence-publication","definitionDigest":"sha256:374066139a234c9aa55cfffa25084b2938d17d83c6d14c62429fabef79a57bd8"}]
         },
         {
           "id": "landing",
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:c33327978e364138bd668e048d48f8c209a4dbcb0041f7b457bbb5a5d6dae504",
+          "definitionDigest": "sha256:d21738c2b1f5c48762d48d3fc98c4a8824536c21c2fa4e49ade8a7fb6d3e45ac",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@8493bf140a7f567e76aff3119f3d39ff026afc84"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@2416a1eacbc87e902eceea467af72a95f24a51f0"],
           "steps": []
         },
         {
@@ -1019,10 +1019,10 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:9b1b657efcd742ca3df105f6780412700af65e577146c15e22ca51d130f35124",
+          "definitionDigest": "sha256:ed01de64b27d078e98bc07e2335d97b12fc637d1020a30168376b87b1abc9a4f",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"],
-          "steps": [{"index":1,"label":"uses:actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","definitionDigest":"sha256:78d7ae6e479b47dfaedac84727a66b40468ac463895b29adc37ba62b1433a77c"},{"index":2,"label":"uses:actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","definitionDigest":"sha256:9a3d647abc814ba7ab8480a2eda59d4a22bb4d62627e2dff0c0b148359abe84d"},{"index":3,"label":"uses:actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","definitionDigest":"sha256:a869cc671103a9106dc90b4275a4148de9a5d18cd3578a2642d8ae8076d8dbf0"},{"index":4,"label":"name:Install pinned Buildchain Warrant runtime","definitionDigest":"sha256:ec7b05b5ce26fd88b9cf114ae1bec4d5a039b03f9982b9cbe04f51e8d77342f6"},{"index":5,"label":"name:Consume the exact Buildchain Warrant lease","definitionDigest":"sha256:c48365088276cd6104591cc238427fa409bb9f87255c27ba833d810754711368"}]
+          "steps": [{"index":1,"label":"uses:actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","definitionDigest":"sha256:78d7ae6e479b47dfaedac84727a66b40468ac463895b29adc37ba62b1433a77c"},{"index":2,"label":"uses:actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","definitionDigest":"sha256:ceb4b1571cafe4fe9680e41cef3c78518a0f15278a2a61430d6e0884a5b92a2f"},{"index":3,"label":"uses:actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","definitionDigest":"sha256:a869cc671103a9106dc90b4275a4148de9a5d18cd3578a2642d8ae8076d8dbf0"},{"index":4,"label":"name:Install pinned Buildchain Warrant runtime","definitionDigest":"sha256:ec7b05b5ce26fd88b9cf114ae1bec4d5a039b03f9982b9cbe04f51e8d77342f6"},{"index":5,"label":"name:Consume the exact Buildchain Warrant lease","definitionDigest":"sha256:c48365088276cd6104591cc238427fa409bb9f87255c27ba833d810754711368"}]
         }
       ]
     },

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -631,7 +631,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:aec7c49983a810bef02276e98b8e03c9921c0d34ed90c2f33003b8d4c818fd44",
+          "definitionDigest": "sha256:003e150dbc0b8536a89e8d23eab358a8660ef112338576882386c0c49f70b273",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@2416a1eacbc87e902eceea467af72a95f24a51f0"],
           "steps": []
@@ -651,7 +651,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:d0650e6541847ed1a2166d00380309d965915255c45e3a0bdfe70a61ffafdd27",
+          "definitionDigest": "sha256:46afbc7f4832b204600538325ee5502f77955fe4b7e9990bce34290c05cd3028",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@2416a1eacbc87e902eceea467af72a95f24a51f0"],
           "steps": []

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -631,7 +631,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:5bb760fb2cd5da94e288c0292c7c71b17745648b0632f0d5a5e995857c012787",
+          "definitionDigest": "sha256:aec7c49983a810bef02276e98b8e03c9921c0d34ed90c2f33003b8d4c818fd44",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@2416a1eacbc87e902eceea467af72a95f24a51f0"],
           "steps": []
@@ -651,7 +651,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:d21738c2b1f5c48762d48d3fc98c4a8824536c21c2fa4e49ade8a7fb6d3e45ac",
+          "definitionDigest": "sha256:d0650e6541847ed1a2166d00380309d965915255c45e3a0bdfe70a61ffafdd27",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@2416a1eacbc87e902eceea467af72a95f24a51f0"],
           "steps": []

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -160,7 +160,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:0b8f17c2dda31679c60133995904f809baa27e51e82d9cf0e83ac709a75a6515"
+          "sourceRoot": "sha256:a12adf5d49693b0b5e939633148178b22c107cd46b6342d7a804b370e4885994"
         },
         {
           "path": ".github/workflows/core-build-profiles.yml",
@@ -191,14 +191,14 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:25c930ad458abd332917919442c7505dd5c8ac5e3871c59c1ea6d0d5a874f0c2"
+          "sourceRoot": "sha256:703a5c0f87b906976286f22ca01ef3f8f856b46b5ad72f1f05749027ca97c0d3"
         },
         {
           "path": ".github/workflows/dev-pr-auto-merge.yml",
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:6c6c7a0161f0a244764379aefad7e48515182f6b8d46e7539f747b843c767a9f"
+          "sourceRoot": "sha256:5fbe052b625782b3447735cd8e5907a00dae54125671656b7a838c7c13a29e64"
         },
         {
           "path": ".github/workflows/dev-gate-latency-patrol.yml",
@@ -877,5 +877,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:dfc803bfc7dcbce2bd727c52351d9da3813aa4590a1167143961ce04bb31ff96"
+  "registryRoot": "sha256:ecad66a276ea872e40ef51b87f845fb1a10354c659ea7febb408883b59fa09c4"
 }

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -198,7 +198,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:5fbe052b625782b3447735cd8e5907a00dae54125671656b7a838c7c13a29e64"
+          "sourceRoot": "sha256:4bc1f0b2cb73f8ef4b2d9d0e1df5cd135cbc8ce426231f5086d5ddd3b0fcf3bc"
         },
         {
           "path": ".github/workflows/dev-gate-latency-patrol.yml",
@@ -877,5 +877,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:ecad66a276ea872e40ef51b87f845fb1a10354c659ea7febb408883b59fa09c4"
+  "registryRoot": "sha256:2d5339b310fc4553cef7fa5a12d07dc6e6233977f1e7f28d8a885b1b5eeb4f12"
 }

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -198,7 +198,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:4bc1f0b2cb73f8ef4b2d9d0e1df5cd135cbc8ce426231f5086d5ddd3b0fcf3bc"
+          "sourceRoot": "sha256:6151642d1884b964222a38f639fd25b393d46d405d3d00b7dda24c8b296235d3"
         },
         {
           "path": ".github/workflows/dev-gate-latency-patrol.yml",
@@ -877,5 +877,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:2d5339b310fc4553cef7fa5a12d07dc6e6233977f1e7f28d8a885b1b5eeb4f12"
+  "registryRoot": "sha256:da044c50f901dd489b15b7ead2798320bb2d11138fb6999123840ec87439cb3c"
 }

--- a/scripts/dev-delivery-warrant-input.test.mjs
+++ b/scripts/dev-delivery-warrant-input.test.mjs
@@ -245,11 +245,11 @@ test('terminal consumer executes only protected event and Buildchain authority',
   assert.match(workflow, /GITHUB_TOKEN: \$\{\{ github\.token \}\}/u);
   assert.match(
     workflow,
-    /dev-delivery-warrant-close\.yml@8493bf140a7f567e76aff3119f3d39ff026afc84/u,
+    /dev-delivery-warrant-close\.yml@2416a1eacbc87e902eceea467af72a95f24a51f0/u,
   );
   assert.match(
     workflow,
-    /dev-delivery-warrant-cancel\.yml@8493bf140a7f567e76aff3119f3d39ff026afc84/u,
+    /dev-delivery-warrant-cancel\.yml@2416a1eacbc87e902eceea467af72a95f24a51f0/u,
   );
   assert.doesNotMatch(workflow, /github\.event\.pull_request\.head\.ref/u);
   assert.doesNotMatch(workflow, /checkout[^\n]*pull_request\.head/u);

--- a/scripts/dev-pr-auto-merge.test.mjs
+++ b/scripts/dev-pr-auto-merge.test.mjs
@@ -19,11 +19,19 @@ const steadyStateDogfoodFixturePath =
   'framework/core/tests/fixtures/dev-delivery-warrant-steady-state.json';
 
 test('Dev auto-merge admits only explicitly ready reviewed same-repository PRs', () => {
-  const reusableRef = workflow.match(
-    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/dev-pr-auto-merge\.yml@([0-9a-f]{40})/u,
-  )?.[1];
-  assert.equal(reusableRef, '2416a1eacbc87e902eceea467af72a95f24a51f0');
-  assert.match(workflow, new RegExp(`buildchain-ref: ${reusableRef}`, 'u'));
+  const reusableRefs = [
+    ...workflow.matchAll(
+      /uses: kungfu-systems\/buildchain\/\.github\/workflows\/dev-pr-auto-merge\.yml@([0-9a-f]{40})/gu,
+    ),
+  ].map((match) => match[1]);
+  assert.deepEqual(reusableRefs, [
+    '2416a1eacbc87e902eceea467af72a95f24a51f0',
+    '2416a1eacbc87e902eceea467af72a95f24a51f0',
+  ]);
+  const runtimeSelectors = [
+    ...workflow.matchAll(/^\s+buildchain-ref:\s+(\S+)\s*$/gmu),
+  ].map((match) => match[1]);
+  assert.deepEqual(runtimeSelectors, ['v4', 'v4']);
   assert.match(workflow, /workflow_run:[\s\S]*Core affected native/u);
   assert.match(
     workflow,

--- a/scripts/dev-pr-auto-merge.test.mjs
+++ b/scripts/dev-pr-auto-merge.test.mjs
@@ -22,7 +22,7 @@ test('Dev auto-merge admits only explicitly ready reviewed same-repository PRs',
   const reusableRef = workflow.match(
     /uses: kungfu-systems\/buildchain\/\.github\/workflows\/dev-pr-auto-merge\.yml@([0-9a-f]{40})/u,
   )?.[1];
-  assert.equal(reusableRef, '8493bf140a7f567e76aff3119f3d39ff026afc84');
+  assert.equal(reusableRef, '2416a1eacbc87e902eceea467af72a95f24a51f0');
   assert.match(workflow, new RegExp(`buildchain-ref: ${reusableRef}`, 'u'));
   assert.match(workflow, /workflow_run:[\s\S]*Core affected native/u);
   assert.match(
@@ -280,7 +280,7 @@ test('Qualified native proof re-runs the exact failed source jobs before landing
   );
   assert.match(
     landing,
-    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/dev-pr-auto-merge\.yml@8493bf140a7f567e76aff3119f3d39ff026afc84/u,
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/dev-pr-auto-merge\.yml@2416a1eacbc87e902eceea467af72a95f24a51f0/u,
   );
   assert.match(landing, /queue-admission-context: Queue admission lease/u);
   assert.match(landing, /landing-mode: queue[\s\S]*dry-run: false/u);
@@ -312,7 +312,7 @@ test('Dev behind admission produces and forwards an exact Project Cut replay pro
   );
   assert.match(
     workflow,
-    /Check out exact Buildchain delivery runtime[\s\S]*ref: 8493bf140a7f567e76aff3119f3d39ff026afc84/u,
+    /Check out exact Buildchain delivery runtime[\s\S]*ref: 2416a1eacbc87e902eceea467af72a95f24a51f0/u,
   );
   assert.match(
     workflow,
@@ -623,10 +623,10 @@ test('native execution uses one exact protected runtime and continuous fence wra
     '.github/actions/native-execution-under-warrant/action.yml',
     'utf8',
   );
-  assert.match(action, /ref: 8493bf140a7f567e76aff3119f3d39ff026afc84/u);
+  assert.match(action, /ref: 2416a1eacbc87e902eceea467af72a95f24a51f0/u);
   assert.match(
     action,
-    /test "\$\(git rev-parse HEAD\)" = 8493bf140a7f567e76aff3119f3d39ff026afc84/u,
+    /test "\$\(git rev-parse HEAD\)" = 2416a1eacbc87e902eceea467af72a95f24a51f0/u,
   );
   assert.match(
     action,

--- a/scripts/dev-pr-auto-merge.test.mjs
+++ b/scripts/dev-pr-auto-merge.test.mjs
@@ -31,7 +31,7 @@ test('Dev auto-merge admits only explicitly ready reviewed same-repository PRs',
   const runtimeSelectors = [
     ...workflow.matchAll(/^\s+buildchain-ref:\s+(\S+)\s*$/gmu),
   ].map((match) => match[1]);
-  assert.deepEqual(runtimeSelectors, ['v4', 'v4']);
+  assert.deepEqual(runtimeSelectors, ['v4-alpha', 'v4-alpha']);
   assert.match(workflow, /workflow_run:[\s\S]*Core affected native/u);
   assert.match(
     workflow,

--- a/scripts/queue-admission-lease.test.mjs
+++ b/scripts/queue-admission-lease.test.mjs
@@ -13,7 +13,7 @@ import {
 } from './cancel-dequeued-merge-group-runs.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const WARRANT_RUNTIME_SHA = '8493bf140a7f567e76aff3119f3d39ff026afc84';
+const WARRANT_RUNTIME_SHA = '2416a1eacbc87e902eceea467af72a95f24a51f0';
 const WARRANT_READBACK_RUNTIME_SHA = '0f4004d0d2b2474c2135a3e88d29d9c85bc37834';
 const SOURCE_HEAD = '2'.repeat(40);
 const CONTRACT = JSON.parse(


### PR DESCRIPTION
## Summary

Pin the reusable protected-dev delivery workflow code to immutable Buildchain revision `2416a1eacbc87e902eceea467af72a95f24a51f0`, while resolving both runtime inputs through the documented persistent prerelease selector `v4-alpha`.

This repairs the stale delivery runtime that rejected a qualified Python responsibility-decomposition PR after the queue had already advanced it to `superseded`, without changing product APIs or release identity.

## Related issue

None.

## Changes

- update the governed dev-delivery, Warrant, queue-admission, and native-execution reusable workflow code pins to immutable Buildchain revision `2416a1eacbc87e902eceea467af72a95f24a51f0`
- keep code identity and runtime selection separate: reusable `uses:` references stay exact-SHA pinned, while both protected-dev `buildchain-ref` inputs use logical selector `v4-alpha`
- refresh the workflow-authority and publication-surface projections only through their canonical materializers
- strengthen the exact pin/selector contract tests so a stable-channel or train-ref regression fails closed

## Verification

- exact PR head: `5575223c9bd673a237d4050880d82eb705ae136c`
- alpha promotion preflight: 104/104 passed
- gate-latency qualification: 149/149 passed
- `./shifu check:source`: passed, including 1202 source acceptance tests
- hosted source workflow: run `33191197445`; `Candidate source acceptance / check` succeeded for the exact head
- independent hosted review by `kungfu-origin`: approved for the exact head
- native exact-cut review: `fit`; portable state seal `sha256:2cc5d187317060f5d2032963b6faf3383bb3c1fe506cf9ae365a00330f40c062`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This fixes immutable delivery workflow code identity and its documented prerelease runtime selector without altering an architecture contract"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change updates governed delivery workflow identity and runtime selection. Exact pin/selector assertions, focused lifecycle qualifications, full source acceptance, hosted exact-head approval, and native exact-cut review evidence prove the boundary.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (canonical governed projections refreshed)

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA4LTI5LWt1bmdmdS1kZXYtZGVsaXZlcnktdjQtYWxwaGEtc2VsZWN0b3ItZm9sbG93dXAiLCJkZWxpdmVyeUNsYXNzIjoibmF0aXZlLXByb29mLXJlcXVpcmVkIiwiZGV2SGVhZCI6IjhkZmM5OTZmOWMxNWFkNzg2ZWZkZjdmM2M0YWI0ZjYxOGQ2MGM3YzYiLCJwdWxsUmVxdWVzdEhlYWQiOiI1NTc1MjIzYzliZDY3M2EyMzdkNDA1MDg4MGQ4MmViNzA1YWUxMzZjIiwicmVwbGF5ZWRDYW5kaWRhdGUiOiJhNjExOGYwNGI5ODZlYWMwNTliMDdkODMxMDM4MWU5ZDEyZTI5YzhhIiwicmVwbGF5ZWRUcmVlIjoiMDI1ZTRmNWM1NWRmM2I3N2UwNGY4YjJiNTkxMGE5ZjkzMzc4YjBiYiIsInF1ZXVlQXR0ZW1wdCI6IjU1NzUyMjNjOWJkNjczYTIzN2Q0MDUwODgwZDgyZWI3MDVhZTEzNmNAOGRmYzk5NmY5YzE1YWQ3ODZlZmRmN2YzYzRhYjRmNjE4ZDYwYzdjNiIsImFkbWlzc2lvblByb29mUm9vdCI6InNoYTI1NjphODQzMDBjOWJhMmQzN2ZjZjAzMzcyZmI3ZWFlOTU3OGQ1MTQ1M2MyNTZkN2U3NTk1NzJlNDhhN2EwNWQzNmM0IiwiYWRtaXNzaW9uUHJvb2ZSb290cyI6WyJzaGEyNTY6MTE0OGU4M2UzZWU5YTY4NDFkYzgyNzkwYmQwYTUyMGU2ODQxODc2OWJiZGVhN2JjNzY4NzkyZDMwMmExMWVlNiIsInNoYTI1NjphODQzMDBjOWJhMmQzN2ZjZjAzMzcyZmI3ZWFlOTU3OGQ1MTQ1M2MyNTZkN2U3NTk1NzJlNDhhN2EwNWQzNmM0Il0sInN0YXR1c0NvbnRleHQiOiJRdWV1ZSBmYW1pbHkgbGVhc2UvZDk5ZjNhOTE2NjczOWUwZCIsImxlYXNlUm9vdCI6InNoYTI1NjowYjFmNDNjYTlhMjgxZmIzNTJjNjU0NjZlZDY5NzBmNmU0YWRkNzZkNDFjNWE4N2VmMmVhZGYwYjU2Nzg0MDg4In0 -->