### PR TITLE
fix(release): admit exact shallow promotion trees

### DIFF
--- a/framework/agent-session/tests/runtime-port.native.test.mjs
+++ b/framework/agent-session/tests/runtime-port.native.test.mjs
@@ -131,6 +131,30 @@ function windowsTreeKillInvocation(pid) {
   };
 }
 
+function nativeFixtureRemovalOptions(platform = process.platform) {
+  return {
+    recursive: true,
+    force: true,
+    maxRetries: platform === 'win32' ? 50 : 0,
+    retryDelay: 100,
+  };
+}
+
+test('native fixture removal retries only while Windows handles close', () => {
+  assert.deepEqual(nativeFixtureRemovalOptions('win32'), {
+    recursive: true,
+    force: true,
+    maxRetries: 50,
+    retryDelay: 100,
+  });
+  assert.deepEqual(nativeFixtureRemovalOptions('linux'), {
+    recursive: true,
+    force: true,
+    maxRetries: 0,
+    retryDelay: 100,
+  });
+});
+
 function posixProcessGroupAlive(pid) {
   try {
     process.kill(-pid, 0);
@@ -283,7 +307,9 @@ test(
         [...peers, coordinator].map((child) => stopChild(child)),
       );
       fs.closeSync(output);
-      fs.rmSync(home, { recursive: true, force: true });
+      // Windows can observe process exit before the coordinator's log handle
+      // finishes closing. Keep cleanup bounded while that handle drains.
+      fs.rmSync(home, nativeFixtureRemovalOptions());
       const failures = cleanup
         .filter((result) => result.status === 'rejected')
         .map((result) => result.reason);

--- a/scripts/adr-release-gate.mjs
+++ b/scripts/adr-release-gate.mjs
@@ -212,6 +212,12 @@ export function changedFilesBetween(ref, head, root) {
       env: isolatedGitEnvironment(),
       encoding: 'utf8',
     });
+  const runTree = (commit) =>
+    childProcess.spawnSync('git', ['rev-parse', `${commit}^{tree}`], {
+      cwd: root,
+      env: isolatedGitEnvironment(),
+      encoding: 'utf8',
+    });
 
   let result = runDiff();
   if (
@@ -238,6 +244,38 @@ export function changedFilesBetween(ref, head, root) {
       );
     }
     result = runDiff();
+    if (
+      result.status !== 0 &&
+      /no merge base/u.test(String(result.stderr || ''))
+    ) {
+      // A rebase-merged promotion can leave the exact PR base and head as
+      // disconnected shallow boundaries even after both objects are fetched.
+      // The event already binds those immutable commits. Only accept a direct
+      // tree comparison when the checked-out publication candidate is exactly
+      // the event head tree; every missing object or tree mismatch still fails
+      // closed instead of inventing an ancestry relationship.
+      const candidateTree = runTree('HEAD');
+      const headTree = runTree(head);
+      if (
+        candidateTree.status !== 0 ||
+        headTree.status !== 0 ||
+        String(candidateTree.stdout || '').trim() !==
+          String(headTree.stdout || '').trim()
+      ) {
+        throw new Error(
+          `git diff ${ref}...${head} failed: shallow promotion candidate tree does not match the exact event head`,
+        );
+      }
+      result = childProcess.spawnSync(
+        'git',
+        ['diff', '--name-only', ref, head],
+        {
+          cwd: root,
+          env: isolatedGitEnvironment(),
+          encoding: 'utf8',
+        },
+      );
+    }
   }
   if (result.status !== 0) {
     throw new Error(

--- a/scripts/adr-release-gate.test.mjs
+++ b/scripts/adr-release-gate.test.mjs
@@ -167,7 +167,7 @@ test('parses exactly one JSON manifest from the PR body', () => {
   assert.throws(() => parsePrManifest('no manifest', contract.manifestMarker));
 });
 
-test('hydrates exact promotion boundaries in a shallow build checkout', () => {
+test('compares exact trees when hydrated promotion boundaries remain shallow and disconnected', () => {
   const root = fs.mkdtempSync(
     path.join(os.tmpdir(), 'kungfu-adr-release-shallow-'),
   );
@@ -187,23 +187,24 @@ test('hydrates exact promotion boundaries in a shallow build checkout', () => {
   git(source, ['commit', '-m', 'alpha']);
   const alpha = git(source, ['rev-parse', 'HEAD']);
 
-  fs.writeFileSync(path.join(source, 'adr/decision.md'), 'development\n');
-  git(source, ['commit', '-am', 'development']);
-  const development = git(source, ['rev-parse', 'HEAD']);
+  for (let index = 1; index <= 5; index += 1) {
+    fs.writeFileSync(
+      path.join(source, 'adr/decision.md'),
+      `development-${index}\n`,
+    );
+    git(source, ['commit', '-am', `development ${index}`]);
+  }
+  const promotion = git(source, ['rev-parse', 'HEAD']);
   const tree = git(source, ['rev-parse', 'HEAD^{tree}']);
-  const promotion = git(
-    source,
-    ['commit-tree', tree, '-p', alpha, '-p', development],
-    'promote\n',
-  );
   const merge = git(
     source,
-    ['commit-tree', tree, '-p', alpha, '-p', promotion],
-    'pull request merge\n',
+    ['commit-tree', tree, '-p', alpha],
+    'rebase merge\n',
   );
   git(source, ['update-ref', 'refs/heads/merge', merge]);
+  git(source, ['update-ref', 'refs/heads/promotion', promotion]);
   git(source, ['remote', 'add', 'origin', remote]);
-  git(source, ['push', 'origin', 'refs/heads/merge']);
+  git(source, ['push', 'origin', 'refs/heads/merge', 'refs/heads/promotion']);
   git(root, [
     'clone',
     '--depth=1',
@@ -227,7 +228,67 @@ test('hydrates exact promotion boundaries in a shallow build checkout', () => {
   assert.deepEqual(changedFilesBetween(alpha, promotion, checkout), [
     'adr/decision.md',
   ]);
+  const disconnected = childProcess.spawnSync(
+    'git',
+    ['merge-base', alpha, promotion],
+    {
+      cwd: checkout,
+      env: Object.fromEntries(
+        Object.entries(process.env).filter(([key]) => !key.startsWith('GIT_')),
+      ),
+      encoding: 'utf8',
+    },
+  );
+  assert.notEqual(disconnected.status, 0);
   assert.equal(git(checkout, ['rev-parse', '--is-shallow-repository']), 'true');
+});
+
+test('rejects a shallow exact-tree fallback when the candidate tree differs from the event head', () => {
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-adr-release-shallow-mismatch-'),
+  );
+  roots.push(root);
+  const remote = path.join(root, 'remote.git');
+  const source = path.join(root, 'source');
+  const checkout = path.join(root, 'checkout');
+
+  git(root, ['init', '--bare', remote]);
+  fs.mkdirSync(source);
+  git(source, ['init', '--initial-branch=main']);
+  git(source, ['config', 'user.name', 'ADR Test']);
+  git(source, ['config', 'user.email', 'adr-test@example.invalid']);
+  fs.writeFileSync(path.join(source, 'base.txt'), 'base\n');
+  git(source, ['add', 'base.txt']);
+  git(source, ['commit', '-m', 'base']);
+  const base = git(source, ['rev-parse', 'HEAD']);
+  for (let index = 1; index <= 5; index += 1) {
+    fs.writeFileSync(path.join(source, 'head.txt'), `head-${index}\n`);
+    git(source, ['add', 'head.txt']);
+    git(source, ['commit', '-m', `head ${index}`]);
+  }
+  const head = git(source, ['rev-parse', 'HEAD']);
+  const baseTree = git(source, ['rev-parse', `${base}^{tree}`]);
+  const merge = git(
+    source,
+    ['commit-tree', baseTree, '-p', base],
+    'mismatched rebase merge\n',
+  );
+  git(source, ['update-ref', 'refs/heads/merge', merge]);
+  git(source, ['update-ref', 'refs/heads/promotion', head]);
+  git(source, ['remote', 'add', 'origin', remote]);
+  git(source, ['push', 'origin', 'refs/heads/merge', 'refs/heads/promotion']);
+  git(root, [
+    'clone',
+    '--depth=1',
+    '--branch=merge',
+    `file://${remote}`,
+    checkout,
+  ]);
+
+  assert.throws(
+    () => changedFilesBetween(base, head, checkout),
+    /candidate tree does not match the exact event head/u,
+  );
 });
 
 test('feature dev PR requires a stage-ready or implemented delivery', () => {


### PR DESCRIPTION
<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"alpha-settlement","no_adr_progress_reason":"Repair the retained publication gate without changing ADR projections."}
-->

## Outcome

Repair the retained Kungfu publication gate for the exact shallow consumer checkout used by the governed Alpha release workflow.

The previous Alpha.4 release run `33193044869` stopped before provider writes because PR #3501 used a rebase-merge boundary with no local merge base in the shallow checkout. This change keeps triple-dot diff as the primary path, hydrates exact 40-character base/head commits, and permits an exact tree-to-tree fallback only when the checked-out candidate tree equals the event head tree.

## Fail-closed boundaries

- Missing objects still fail.
- Candidate/event tree mismatch still fails.
- Non-`no merge base` Git errors still fail.
- Buildchain is unchanged.
- No release/tag/provider write is performed by this PR.

## Evidence

- `node --test scripts/adr-release-gate.test.mjs scripts/release-promotion-rehearsal.test.mjs`: 58/58 pass
- `./shifu release:promotion:rehearse`: pass
- Exact PR #3501 event rehearsal: pass, zero side effects
- staged gate: pass

The tests cover the long multi-commit/rebase-merge shallow boundary and reject a mismatched candidate tree.