### PR TITLE
fix(work): preserve exact Assignment recovery on linear successor

### DIFF
--- a/framework/core/src/python/kungfu/agent/run_agent.py
+++ b/framework/core/src/python/kungfu/agent/run_agent.py
@@ -177,6 +177,7 @@ def bind_current_native_work(
             request,
             fallback_runtime_dir=project_runtime_dir,
             cwd=workspace_root,
+            project_runtime_dir=project_runtime_dir,
         )
 
     plan = invoke_session(

--- a/framework/core/src/python/kungfu/agent/run_agent.py
+++ b/framework/core/src/python/kungfu/agent/run_agent.py
@@ -10,6 +10,7 @@ successful process exit or provider self-report never settles Work.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import partial
 import json
 import os
 from pathlib import Path
@@ -172,13 +173,12 @@ def bind_current_native_work(
     session_contract.require_expected_binding(expected_binding, work_ref, session)
     actor_id = os.environ.get("KUNGFU_AGENT_SESSION_ACTOR", f"cli:{os.getpid()}")
 
-    def invoke_session(request):
-        return session_surface.invoke_for_project(
-            request,
-            fallback_runtime_dir=project_runtime_dir,
-            cwd=workspace_root,
-            project_runtime_dir=project_runtime_dir,
-        )
+    invoke_session = partial(
+        session_surface.invoke_for_project,
+        fallback_runtime_dir=project_runtime_dir,
+        cwd=workspace_root,
+        environ={"KUNGFU_AGENT_SESSION_ENDPOINT": None},
+    )
 
     plan = invoke_session(
         {

--- a/framework/core/src/python/kungfu/agent/session_surface.py
+++ b/framework/core/src/python/kungfu/agent/session_surface.py
@@ -305,13 +305,34 @@ def endpoint_for_runtime(runtime_dir):
     return str(socket_root / f"{scope}.sock")
 
 
-def invoke_for_project(request, *, fallback_runtime_dir, endpoint=None, cwd=None):
+def invoke_for_project(
+    request,
+    *,
+    fallback_runtime_dir,
+    endpoint=None,
+    cwd=None,
+    project_runtime_dir=None,
+):
     """Invoke the project surface and revive its detached host when needed."""
 
-    environment_endpoint = os.environ.get("KUNGFU_AGENT_SESSION_ENDPOINT")
+    if project_runtime_dir is not None and endpoint is not None:
+        raise ValueError("pass either project_runtime_dir or endpoint, not both")
+    runtime_dir = (
+        str(Path(project_runtime_dir).expanduser().resolve())
+        if project_runtime_dir is not None
+        else None
+    )
+    environment_endpoint = (
+        None
+        if runtime_dir is not None
+        else os.environ.get("KUNGFU_AGENT_SESSION_ENDPOINT")
+    )
     endpoint_is_explicit = endpoint is not None or environment_endpoint is not None
-    resolved_endpoint = endpoint or environment_endpoint
-    runtime_dir = None
+    resolved_endpoint = (
+        endpoint_for_runtime(runtime_dir)
+        if runtime_dir is not None
+        else endpoint or environment_endpoint
+    )
     if not resolved_endpoint:
         try:
             runtime_dir = str(

--- a/framework/core/src/python/kungfu/agent/session_surface.py
+++ b/framework/core/src/python/kungfu/agent/session_surface.py
@@ -311,44 +311,30 @@ def invoke_for_project(
     fallback_runtime_dir,
     endpoint=None,
     cwd=None,
-    project_runtime_dir=None,
+    environ=None,
 ):
     """Invoke the project surface and revive its detached host when needed."""
 
-    if project_runtime_dir is not None and endpoint is not None:
-        raise ValueError("pass either project_runtime_dir or endpoint, not both")
-    runtime_dir = (
-        str(Path(project_runtime_dir).expanduser().resolve())
-        if project_runtime_dir is not None
-        else None
-    )
-    environment_endpoint = (
-        None
-        if runtime_dir is not None
-        else os.environ.get("KUNGFU_AGENT_SESSION_ENDPOINT")
-    )
+    environment_endpoint = (environ or os.environ).get("KUNGFU_AGENT_SESSION_ENDPOINT")
     endpoint_is_explicit = endpoint is not None or environment_endpoint is not None
-    resolved_endpoint = (
-        endpoint_for_runtime(runtime_dir)
-        if runtime_dir is not None
-        else endpoint or environment_endpoint
-    )
+    resolved_endpoint = endpoint or environment_endpoint
+    runtime_dir = fallback_runtime_dir
     if not resolved_endpoint:
         try:
             runtime_dir = str(
                 resolve_workspace_target(
-                    "read-only", cwd=cwd or os.getcwd()
+                    "read-only", cwd=cwd or os.getcwd(), env=environ
                 ).runtime_dir
             )
         except WorkspaceTargetRequired:
-            runtime_dir = str(fallback_runtime_dir)
+            pass
         resolved_endpoint = endpoint_for_runtime(runtime_dir)
     try:
         return invoke(request, endpoint=resolved_endpoint)
     except OSError:
         if endpoint_is_explicit:
             raise
-        resolved_endpoint = ensure(runtime_dir or str(fallback_runtime_dir))
+        resolved_endpoint = ensure(runtime_dir)
         return invoke(request, endpoint=resolved_endpoint)
 
 

--- a/framework/maintainability/agent-python-responsibility-map.json
+++ b/framework/maintainability/agent-python-responsibility-map.json
@@ -42,9 +42,9 @@
         "functionRisk": { "functions": 22, "total": 171, "maximum": 28 }
       },
       "current": {
-        "physicalLines": 1209,
+        "physicalLines": 1210,
         "responsibilities": 33,
-        "functionRisk": { "functions": 21, "total": 137, "maximum": 27 }
+        "functionRisk": { "functions": 20, "total": 133, "maximum": 27 }
       },
       "ownerFiles": ["framework/core/src/python/kungfu/agent/native_launch.py"],
       "ownedDefinitions": ["provider_interactive_argv"],


### PR DESCRIPTION
## Summary

- supersedes #3531 and #3539 without rewriting either published head
- preserves exact project session endpoint authority after merged #3533
- updates the agent Python responsibility budget for the exact source cut

## Validation

- pinned product runtime agent console contract: 141 passed, 3 skipped
- generated-report authority: 46 Node and 6 Python passed
- full ./shifu check:source: 1203 total, 1192 passed, 11 skipped; Python work-state 40, runtime-upgrade 143, desktop 73, mypy clean, zero-write roots conserved

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This rebased exact-attempt recovery repair preserves existing architecture authority and does not alter an architecture decision."
}
-->

## Delivery

This exact head must land through the protected Buildchain Warrant and PR engine; no manual merge.