### PR TITLE
refactor(product): decompose complex system views

### DIFF
--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.3",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.3",
-    "sourceSha": "665102dc62c38e3aafff93ee33c179a1269e62be"
+    "sourceSha": "516d99a2d27d5042a3f65eb9ff5b35ee08de8838"
   },
   "claims": [
     {

--- a/.buildchain/kfd/kfd-2/release-claims.json
+++ b/.buildchain/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.3",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.3",
-    "sourceSha": "516d99a2d27d5042a3f65eb9ff5b35ee08de8838"
+    "sourceSha": "e96458b9207f5bb7f2df1fa821ee9f6cd1a1dd55"
   },
   "claims": [
     {

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "665102dc62c38e3aafff93ee33c179a1269e62be",
+    "sourceSha": "516d99a2d27d5042a3f65eb9ff5b35ee08de8838",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:94e3051ed06b5e852b46f3572d28fa36682ee989f6ab4a618993863e8ae33288"
   },

--- a/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
+++ b/.buildchain/kfd/kfd-3/collaboration-interface.prebuild.json
@@ -6,7 +6,7 @@
   "supportLevel": "release",
   "source": {
     "cwd": ".",
-    "sourceSha": "516d99a2d27d5042a3f65eb9ff5b35ee08de8838",
+    "sourceSha": "e96458b9207f5bb7f2df1fa821ee9f6cd1a1dd55",
     "registryPath": ".buildchain/kfd/kfd-3/surfaces.json",
     "registryDigest": "sha256:94e3051ed06b5e852b46f3572d28fa36682ee989f6ab4a618993863e8ae33288"
   },

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:f05e240098bb19a6a07468acfb225533835be3f2fbf8e6f91657c6d5288f5d86"
+            "sha256": "sha256:ecbefe2be49b08116ccf07446ea5b4e6cf997e45fb65607196191ea90b2343d4"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/.buildchain/kfd/support-matrix.json
+++ b/.buildchain/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:ecbefe2be49b08116ccf07446ea5b4e6cf997e45fb65607196191ea90b2343d4"
+            "sha256": "sha256:9e7ac22a1c6cf4c5c766ca5daddf564b93c36a5c4abfbfbbe2c1eec057948404"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.3",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.3",
-    "sourceSha": "665102dc62c38e3aafff93ee33c179a1269e62be"
+    "sourceSha": "516d99a2d27d5042a3f65eb9ff5b35ee08de8838"
   },
   "claims": [
     {

--- a/developer/sdk/kfd/kfd-2/release-claims.json
+++ b/developer/sdk/kfd/kfd-2/release-claims.json
@@ -11,7 +11,7 @@
     "version": "4.0.0-alpha.3",
     "channel": "repository-default",
     "tag": "v4.0.0-alpha.3",
-    "sourceSha": "516d99a2d27d5042a3f65eb9ff5b35ee08de8838"
+    "sourceSha": "e96458b9207f5bb7f2df1fa821ee9f6cd1a1dd55"
   },
   "claims": [
     {

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:f05e240098bb19a6a07468acfb225533835be3f2fbf8e6f91657c6d5288f5d86"
+            "sha256": "sha256:ecbefe2be49b08116ccf07446ea5b4e6cf997e45fb65607196191ea90b2343d4"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/developer/sdk/kfd/support-matrix.json
+++ b/developer/sdk/kfd/support-matrix.json
@@ -102,7 +102,7 @@
         "evidenceRoots": [
           {
             "path": ".buildchain/kfd/kfd-2/release-claims.json",
-            "sha256": "sha256:ecbefe2be49b08116ccf07446ea5b4e6cf997e45fb65607196191ea90b2343d4"
+            "sha256": "sha256:9e7ac22a1c6cf4c5c766ca5daddf564b93c36a5c4abfbfbbe2c1eec057948404"
           },
           {
             "path": "docs/qualification/kfd2-trust-assessment.md",

--- a/extensions/system/kfx-manager/src/view/index.tsx
+++ b/extensions/system/kfx-manager/src/view/index.tsx
@@ -222,7 +222,7 @@ function ProfileCard({
   );
 }
 
-function KfxManagerView({ caps, shell }: KfxViewProps) {
+function useManagerProjection({ caps, shell }: KfxViewProps) {
   const [manager, setManager] = React.useState<ProfileManagerProjection | null>(
     null,
   );
@@ -235,32 +235,8 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
   >({});
   const [loading, setLoading] = React.useState(true);
   const initialLoad = React.useRef(true);
-  const [pending, setPending] = React.useState<{
-    plan: ProfileLifecyclePlan;
-    action: 'qualify' | 'activate' | 'upgrade';
-    source: string;
-  } | null>(null);
-  const [planning, setPlanning] = React.useState(false);
-  const [pendingIntent, setPendingIntent] = React.useState<{
-    plan: ProfileIntentPlan;
-    source: string;
-    intentId: string;
-  } | null>(null);
-  const [pendingKfd3, setPendingKfd3] = React.useState<{
-    plan: ProfileKfd3QualificationPlan;
-    source: string;
-  } | null>(null);
-  const [authorizedBy, setAuthorizedBy] = React.useState('');
   const [controlStatus, setControlStatus] =
     React.useState<KfxControlStatus | null>(null);
-  const [pendingControl, setPendingControl] = React.useState<{
-    plan: KfxControlPlan;
-    operation: 'install' | 'update';
-    path: string;
-  } | null>(null);
-  const profile =
-    shell.profiles.find((p) => p.id === shell.state.profileId) ??
-    shell.profiles[0];
   const onRefresh = shell.onRefresh;
 
   const refresh = React.useCallback(async () => {
@@ -319,83 +295,110 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
     return onRefresh(() => void refresh());
   }, [onRefresh, refresh]);
 
+  return {
+    applicationErrors,
+    applications,
+    controlStatus,
+    error,
+    loading,
+    manager,
+    refresh,
+    setControlStatus,
+    setError,
+  };
+}
+
+type PlanningContext = {
+  authorizedBy: string;
+  caps: KfxViewProps['caps'];
+  refresh: () => Promise<void>;
+  setError: React.Dispatch<React.SetStateAction<string>>;
+  setPlanning: React.Dispatch<React.SetStateAction<boolean>>;
+  shell: KfxViewProps['shell'];
+};
+
+async function runPlanningOperation(
+  context: PlanningContext,
+  operation: () => Promise<void> | void,
+) {
+  context.setPlanning(true);
+  try {
+    await operation();
+  } catch (reason) {
+    context.setError((reason as Error).message);
+  } finally {
+    context.setPlanning(false);
+  }
+}
+
+function useLifecyclePlanning(context: PlanningContext) {
+  const { authorizedBy, caps, refresh, shell } = context;
+  const [pending, setPending] = React.useState<{
+    plan: ProfileLifecyclePlan;
+    action: 'qualify' | 'activate' | 'upgrade';
+    source: string;
+  } | null>(null);
+
   const previewPlan = async (
     action: 'qualify' | 'activate' | 'upgrade',
     source: string,
   ) => {
     if (!caps.profile) return;
-    setPlanning(true);
-    try {
+    await runPlanningOperation(context, async () => {
       setPending({
         plan: await caps.profile.lifecyclePlanAsync(action, source),
         action,
         source,
       });
-      setError('');
-    } catch (reason) {
-      setError((reason as Error).message);
-    } finally {
-      setPlanning(false);
-    }
+      context.setError('');
+    });
   };
+
+  const approveAndApply = async () => {
+    if (!caps.profile || !pending || !authorizedBy.trim()) return;
+    await runPlanningOperation(context, async () => {
+      await caps.profile.authorizeLifecycleAsync(
+        pending.action,
+        pending.source,
+        String(pending.plan.corePlan.plan_id ?? ''),
+        'approve',
+        authorizedBy.trim(),
+      );
+      setPending(null);
+      await refresh();
+      shell.notify({
+        level: 'success',
+        title: `Profile ${pending.action} applied`,
+      });
+    });
+  };
+
+  return { approveAndApply, pending, previewPlan, setPending };
+}
+
+function useIntentPlanning(context: PlanningContext) {
+  const { authorizedBy, caps, refresh, shell } = context;
+  const [pendingIntent, setPendingIntent] = React.useState<{
+    plan: ProfileIntentPlan;
+    source: string;
+    intentId: string;
+  } | null>(null);
 
   const previewIntent = async (source: string, intentId: string) => {
     if (!caps.profile) return;
-    setPlanning(true);
-    try {
+    await runPlanningOperation(context, async () => {
       setPendingIntent({
         plan: await caps.profile.intentPlanAsync(source, intentId),
         source,
         intentId,
       });
-      setError('');
-    } catch (reason) {
-      setError((reason as Error).message);
-    } finally {
-      setPlanning(false);
-    }
-  };
-
-  const previewKfd3 = async (source: string) => {
-    if (!caps.profile) return;
-    setPlanning(true);
-    try {
-      setPendingKfd3({
-        plan: await caps.profile.kfd3PlanAsync(source),
-        source,
-      });
-      setError('');
-    } catch (reason) {
-      setError((reason as Error).message);
-    } finally {
-      setPlanning(false);
-    }
-  };
-
-  const approveKfd3 = async () => {
-    if (!caps.profile || !pendingKfd3 || !authorizedBy.trim()) return;
-    setPlanning(true);
-    try {
-      await caps.profile.authorizeKfd3Async(
-        pendingKfd3.source,
-        pendingKfd3.plan.planId,
-        'approve',
-        authorizedBy.trim(),
-      );
-      setPendingKfd3(null);
-      await refresh();
-      shell.notify({ level: 'success', title: '🛡️ KFD-3 qualification earned' });
-    } catch (reason) {
-      setError((reason as Error).message);
-    } finally {
-      setPlanning(false);
-    }
+      context.setError('');
+    });
   };
 
   const approveIntent = async () => {
     if (!caps.profile || !pendingIntent || !authorizedBy.trim()) return;
-    setPlanning(true);
-    try {
+    await runPlanningOperation(context, async () => {
       const receipt = await caps.profile.authorizeIntentAsync(
         pendingIntent.source,
         pendingIntent.intentId,
@@ -411,58 +414,81 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
           ? 'Intent receipt verified'
           : 'Intent executed; verification incomplete',
       });
-    } catch (reason) {
-      setError((reason as Error).message);
-    } finally {
-      setPlanning(false);
-    }
+    });
   };
 
-  const approveAndApply = async () => {
-    if (!caps.profile || !pending || !authorizedBy.trim()) return;
-    setPlanning(true);
-    try {
-      await caps.profile.authorizeLifecycleAsync(
-        pending.action,
-        pending.source,
-        String(pending.plan.corePlan.plan_id ?? ''),
+  return { approveIntent, pendingIntent, previewIntent, setPendingIntent };
+}
+
+function useKfd3Planning(context: PlanningContext) {
+  const { authorizedBy, caps, refresh, shell } = context;
+  const [pendingKfd3, setPendingKfd3] = React.useState<{
+    plan: ProfileKfd3QualificationPlan;
+    source: string;
+  } | null>(null);
+
+  const previewKfd3 = async (source: string) => {
+    if (!caps.profile) return;
+    await runPlanningOperation(context, async () => {
+      setPendingKfd3({
+        plan: await caps.profile.kfd3PlanAsync(source),
+        source,
+      });
+      context.setError('');
+    });
+  };
+
+  const approveKfd3 = async () => {
+    if (!caps.profile || !pendingKfd3 || !authorizedBy.trim()) return;
+    await runPlanningOperation(context, async () => {
+      await caps.profile.authorizeKfd3Async(
+        pendingKfd3.source,
+        pendingKfd3.plan.planId,
         'approve',
         authorizedBy.trim(),
       );
-      setPending(null);
+      setPendingKfd3(null);
       await refresh();
-      shell.notify({
-        level: 'success',
-        title: `Profile ${pending.action} applied`,
-      });
-    } catch (reason) {
-      setError((reason as Error).message);
-    } finally {
-      setPlanning(false);
-    }
+      shell.notify({ level: 'success', title: '🛡️ KFD-3 qualification earned' });
+    });
   };
 
-  const previewControl = (operation: 'install' | 'update', path: string) => {
+  return { approveKfd3, pendingKfd3, previewKfd3, setPendingKfd3 };
+}
+
+type ControlPlanningArgs = {
+  context: PlanningContext;
+  projection: ReturnType<typeof useManagerProjection>;
+};
+
+function useControlPlanning(args: ControlPlanningArgs) {
+  const { context, projection } = args;
+  const { authorizedBy, caps, refresh, shell } = context;
+  const { setControlStatus } = projection;
+  const [pendingControl, setPendingControl] = React.useState<{
+    plan: KfxControlPlan;
+    operation: 'install' | 'update';
+    path: string;
+  } | null>(null);
+
+  const previewControl = async (
+    operation: 'install' | 'update',
+    path: string,
+  ) => {
     if (!caps.kfxControl) return;
-    setPlanning(true);
-    try {
+    await runPlanningOperation(context, () => {
       setPendingControl({
         plan: caps.kfxControl.plan(operation, { kind: 'product', path }),
         operation,
         path,
       });
-      setError('');
-    } catch (reason) {
-      setError((reason as Error).message);
-    } finally {
-      setPlanning(false);
-    }
+      context.setError('');
+    });
   };
 
   const approveControl = async () => {
     if (!caps.kfxControl || !pendingControl || !authorizedBy.trim()) return;
-    setPlanning(true);
-    try {
+    await runPlanningOperation(context, async () => {
       const receipt = caps.kfxControl.apply(
         pendingControl.operation,
         { kind: 'product', path: pendingControl.path },
@@ -476,12 +502,31 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
         level: 'success',
         title: `KFX Control ${pendingControl.operation} settled`,
       });
-    } catch (reason) {
-      setError((reason as Error).message);
-    } finally {
-      setPlanning(false);
-    }
+    });
   };
+
+  return { approveControl, pendingControl, previewControl, setPendingControl };
+}
+
+function useKfxManagerController({ caps, shell }: KfxViewProps) {
+  const projection = useManagerProjection({ caps, shell });
+  const [planning, setPlanning] = React.useState(false);
+  const [authorizedBy, setAuthorizedBy] = React.useState('');
+  const context = {
+    authorizedBy,
+    caps,
+    refresh: projection.refresh,
+    setError: projection.setError,
+    setPlanning,
+    shell,
+  };
+  const lifecycle = useLifecyclePlanning(context);
+  const intent = useIntentPlanning(context);
+  const kfd3 = useKfd3Planning(context);
+  const control = useControlPlanning({ context, projection });
+  const profile =
+    shell.profiles.find((item) => item.id === shell.state.profileId) ??
+    shell.profiles[0];
 
   const toggleKfx = (id: string, disabled: boolean) => {
     shell.updateState({
@@ -499,17 +544,48 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
     });
   };
 
-  const cell: React.CSSProperties = { padding: '2px 12px 2px 0' };
+  return {
+    ...projection,
+    ...lifecycle,
+    ...intent,
+    ...kfd3,
+    ...control,
+    authorizedBy,
+    planning,
+    profile,
+    setAuthorizedBy,
+    toggleKfx,
+    toggleSuite,
+  };
+}
 
+type KfxManagerContentProps = {
+  controller: ReturnType<typeof useKfxManagerController>;
+  shell: KfxViewProps['shell'];
+};
+
+function KfxControlSection(props: KfxManagerContentProps) {
+  const { controller, shell } = props;
+  const {
+    approveControl,
+    authorizedBy,
+    controlStatus,
+    pendingControl,
+    planning,
+    previewControl,
+    setAuthorizedBy,
+    setPendingControl,
+  } = controller;
+  const managerDir = shell.registry.find(
+    (entry) => entry.id === 'kfx-manager',
+  )?.dir;
   return (
-    <section style={panelStyle}>
+    <>
       <h2 style={headingStyle}>KFX Control Suite</h2>
       <div
         style={{
           ...mono,
-          border: `1px solid ${
-            controlStatus?.mode === 'active' ? '#4ec9b0' : '#f48771'
-          }`,
+          border: `1px solid ${controlStatus?.mode === 'active' ? '#4ec9b0' : '#f48771'}`,
           padding: 10,
           marginBottom: 12,
         }}
@@ -527,15 +603,14 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
           Core independently verifies the embedded bootstrap ceiling; every
           mutation settles through the public KFX Fact/Work named-Cut CAS.
         </div>
-        {shell.registry.find((entry) => entry.id === 'kfx-manager')?.dir ? (
+        {managerDir ? (
           <button
             type="button"
             disabled={planning}
             onClick={() =>
               previewControl(
                 controlStatus?.active ? 'update' : 'install',
-                shell.registry.find((entry) => entry.id === 'kfx-manager')
-                  ?.dir as string,
+                managerDir,
               )
             }
             style={{ ...mono, marginTop: 8, marginRight: 8 }}
@@ -603,6 +678,26 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
           </button>
         </div>
       ) : null}
+    </>
+  );
+}
+
+function ProfileOverviewSection(props: KfxManagerContentProps) {
+  const { controller } = props;
+  const {
+    applicationErrors,
+    applications,
+    error,
+    loading,
+    manager,
+    planning,
+    previewIntent,
+    previewKfd3,
+    previewPlan,
+    profile,
+  } = controller;
+  return (
+    <>
       <h2 style={headingStyle}>Profiles · {manager?.count ?? 0}</h2>
       <div style={{ ...mono, color: '#858585', marginBottom: 10 }}>
         Runtime activation controls composition authority. GUI focus is “
@@ -644,61 +739,121 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
           </div>
         ) : null}
       </div>
+    </>
+  );
+}
+
+type DecisionPanelProps = {
+  approve: () => void;
+  approveLabel: string;
+  authorizedBy: string;
+  children: React.ReactNode;
+  dismiss: () => void;
+  planning: boolean;
+  placeholder: string;
+  setAuthorizedBy: React.Dispatch<React.SetStateAction<string>>;
+  title: string;
+};
+
+function DecisionPanel(props: DecisionPanelProps) {
+  const {
+    approve,
+    approveLabel,
+    authorizedBy,
+    children,
+    dismiss,
+    planning,
+    placeholder,
+    setAuthorizedBy,
+    title,
+  } = props;
+  return (
+    <div
+      style={{
+        ...mono,
+        border: '1px solid #dcdcaa',
+        padding: 10,
+        marginBottom: 12,
+      }}
+    >
+      <strong style={{ color: '#dcdcaa' }}>{title}</strong>
+      {children}
+      <label style={{ display: 'block', marginTop: 8 }}>
+        authorized by{' '}
+        <input
+          value={authorizedBy}
+          onChange={(event) => setAuthorizedBy(event.target.value)}
+          placeholder={placeholder}
+          style={{ ...mono, minWidth: 220 }}
+        />
+      </label>
+      <button
+        type="button"
+        disabled={planning || !authorizedBy.trim()}
+        onClick={approve}
+        style={{ ...mono, marginTop: 8, marginRight: 8 }}
+      >
+        {approveLabel}
+      </button>
+      <button
+        type="button"
+        disabled={planning}
+        onClick={dismiss}
+        style={{ ...mono, marginTop: 8 }}
+      >
+        Dismiss
+      </button>
+    </div>
+  );
+}
+
+function ProfileDecisionSections(props: KfxManagerContentProps) {
+  const {
+    approveAndApply,
+    approveIntent,
+    approveKfd3,
+    authorizedBy,
+    pending,
+    pendingIntent,
+    pendingKfd3,
+    planning,
+    setAuthorizedBy,
+    setPending,
+    setPendingIntent,
+    setPendingKfd3,
+  } = props.controller;
+  return (
+    <>
       {pendingKfd3 ? (
-        <div
-          style={{
-            ...mono,
-            border: '1px solid #dcdcaa',
-            padding: 10,
-            marginBottom: 12,
-          }}
+        <DecisionPanel
+          approve={() => void approveKfd3()}
+          approveLabel="Run exact test plan"
+          authorizedBy={authorizedBy}
+          dismiss={() => setPendingKfd3(null)}
+          planning={planning}
+          placeholder="workspace profile operator"
+          setAuthorizedBy={setAuthorizedBy}
+          title="◇ KFD-3 test plan"
         >
-          <strong style={{ color: '#dcdcaa' }}>◇ KFD-3 test plan</strong>
           <div>profile {shortRoot(pendingKfd3.plan.profileSuiteRoot)}</div>
           <div>runtime {shortRoot(pendingKfd3.plan.runtimeContractRoot)}</div>
           <div>plan {shortRoot(pendingKfd3.plan.planId)}</div>
           <div style={{ color: '#858585' }}>
             {pendingKfd3.plan.probes.join(' · ')}
           </div>
-          <label style={{ display: 'block', marginTop: 8 }}>
-            authorized by{' '}
-            <input
-              value={authorizedBy}
-              onChange={(event) => setAuthorizedBy(event.target.value)}
-              placeholder="workspace profile operator"
-              style={{ ...mono, minWidth: 220 }}
-            />
-          </label>
-          <button
-            type="button"
-            disabled={planning || !authorizedBy.trim()}
-            onClick={() => void approveKfd3()}
-            style={{ ...mono, marginTop: 8, marginRight: 8 }}
-          >
-            Run exact test plan
-          </button>
-          <button
-            type="button"
-            disabled={planning}
-            onClick={() => setPendingKfd3(null)}
-            style={{ ...mono, marginTop: 8 }}
-          >
-            Dismiss
-          </button>
-        </div>
+        </DecisionPanel>
       ) : null}
       {pending ? (
-        <div
-          style={{
-            ...mono,
-            border: '1px solid #dcdcaa',
-            padding: 10,
-            marginBottom: 12,
-          }}
+        <DecisionPanel
+          approve={() => void approveAndApply()}
+          approveLabel="Approve exact plan"
+          authorizedBy={authorizedBy}
+          dismiss={() => setPending(null)}
+          planning={planning}
+          placeholder="workspace owner identity"
+          setAuthorizedBy={setAuthorizedBy}
+          title="Decision required before mutation"
         >
-          <strong style={{ color: '#dcdcaa' }}>
-            Decision required before mutation
-          </strong>
           <div>plan {String(pending.plan.corePlan.plan_id ?? '—')}</div>
           <div>
             {String(
@@ -710,175 +865,193 @@ function KfxManagerView({ caps, shell }: KfxViewProps) {
             GUI and Agent use the same installed decision-card contract. The
             runtime re-plans and rejects drift before apply.
           </div>
-          <label style={{ display: 'block', marginTop: 8 }}>
-            authorized by{' '}
-            <input
-              value={authorizedBy}
-              onChange={(event) => setAuthorizedBy(event.target.value)}
-              placeholder="workspace owner identity"
-              style={{ ...mono, minWidth: 220 }}
-            />
-          </label>
-          <button
-            type="button"
-            disabled={planning || !authorizedBy.trim()}
-            onClick={() => void approveAndApply()}
-            style={{ ...mono, marginTop: 8, marginRight: 8 }}
-          >
-            Approve exact plan
-          </button>
-          <button
-            type="button"
-            disabled={planning}
-            onClick={() => setPending(null)}
-            style={{ ...mono, marginTop: 8 }}
-          >
-            Dismiss
-          </button>
-        </div>
+        </DecisionPanel>
       ) : null}
       {pendingIntent ? (
-        <div
-          style={{
-            ...mono,
-            border: '1px solid #dcdcaa',
-            padding: 10,
-            marginBottom: 12,
-          }}
+        <DecisionPanel
+          approve={() => void approveIntent()}
+          approveLabel="Approve exact intent"
+          authorizedBy={authorizedBy}
+          dismiss={() => setPendingIntent(null)}
+          planning={planning}
+          placeholder="declared authority identity"
+          setAuthorizedBy={setAuthorizedBy}
+          title="Intent decision required"
         >
-          <strong style={{ color: '#dcdcaa' }}>Intent decision required</strong>
           <div>intent {pendingIntent.intentId}</div>
           <div>plan {pendingIntent.plan.planId}</div>
           <div style={{ color: '#858585' }}>
             This exact plan is shared with the Agent CLI. Apply re-plans, emits
             a receipt, and verifies the same Profile and collaboration roots.
           </div>
-          <label style={{ display: 'block', marginTop: 8 }}>
-            authorized by{' '}
-            <input
-              value={authorizedBy}
-              onChange={(event) => setAuthorizedBy(event.target.value)}
-              placeholder="declared authority identity"
-              style={{ ...mono, minWidth: 220 }}
-            />
-          </label>
-          <button
-            type="button"
-            disabled={planning || !authorizedBy.trim()}
-            onClick={() => void approveIntent()}
-            style={{ ...mono, marginTop: 8, marginRight: 8 }}
-          >
-            Approve exact intent
-          </button>
-          <button
-            type="button"
-            disabled={planning}
-            onClick={() => setPendingIntent(null)}
-            style={{ ...mono, marginTop: 8 }}
-          >
-            Dismiss
-          </button>
-        </div>
+        </DecisionPanel>
       ) : null}
+    </>
+  );
+}
+
+const tableCell: React.CSSProperties = { padding: '2px 12px 2px 0' };
+
+type RuntimeRowProps = {
+  disabled: boolean;
+  entry: KfxViewProps['shell']['registry'][number];
+  inProfile: boolean;
+  toggleKfx: (id: string, disabled: boolean) => void;
+};
+
+function KfxRuntimeRow(props: RuntimeRowProps) {
+  const { disabled, entry, inProfile, toggleKfx } = props;
+  return (
+    <tr>
+      <td style={{ ...tableCell, color: '#9cdcfe' }}>{entry.id}</td>
+      <td style={tableCell}>{entry.title}</td>
+      <td style={{ ...tableCell, color: '#858585' }}>{entry.suite ?? '—'}</td>
+      <td style={{ ...tableCell, color: '#ce9178' }}>
+        {entry.capabilities.join(', ') || '—'}
+      </td>
+      <td style={{ ...tableCell, color: '#858585' }}>
+        {entry.packageName
+          ? `${entry.packageName}@${entry.version ?? '?'}`
+          : '—'}
+      </td>
+      <td style={{ ...tableCell, color: '#6a6a6a' }}>{entry.source}</td>
+      <td style={tableCell}>
+        {entry.system ? (
+          <span style={{ color: '#6a6a6a' }}>system · always on</span>
+        ) : !inProfile ? (
+          <span style={{ color: '#6a6a6a' }}>not in profile</span>
+        ) : (
+          <button
+            type="button"
+            onClick={() => toggleKfx(entry.id, disabled)}
+            style={{
+              ...mono,
+              padding: '1px 8px',
+              border: '1px solid #3c3c3c',
+              borderRadius: 4,
+              cursor: 'pointer',
+              background: 'transparent',
+              color: disabled ? '#f48771' : '#4ec9b0',
+            }}
+          >
+            {disabled ? 'disabled — enable' : 'enabled — disable'}
+          </button>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+type SuiteRowProps = {
+  disabled: boolean;
+  isSystem: boolean;
+  name: string;
+  suite: KfxViewProps['shell']['suites'][string];
+  toggleSuite: (key: string, disabled: boolean) => void;
+};
+
+function KfxSuiteRow(props: SuiteRowProps) {
+  const { disabled, isSystem, name, suite, toggleSuite } = props;
+  return (
+    <div style={{ ...mono, padding: '2px 0' }}>
+      <span style={{ color: '#9cdcfe' }}>{name}</span> · {suite.title} ·
+      members: {suite.members.join(', ')}{' '}
+      {isSystem ? (
+        <span style={{ color: '#6a6a6a' }}>system · always on</span>
+      ) : (
+        <button
+          type="button"
+          onClick={() => toggleSuite(name, disabled)}
+          style={{
+            ...mono,
+            padding: '1px 8px',
+            border: '1px solid #3c3c3c',
+            borderRadius: 4,
+            cursor: 'pointer',
+            background: 'transparent',
+            color: disabled ? '#f48771' : '#4ec9b0',
+          }}
+        >
+          {disabled ? 'suite disabled — enable' : 'suite enabled — disable'}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function KfxRegistrySection(props: KfxManagerContentProps) {
+  const { controller, shell } = props;
+  const { profile, toggleKfx, toggleSuite } = controller;
+  return (
+    <>
       <h2 style={headingStyle}>KFX runtime · {shell.registry.length} loaded</h2>
       <table style={{ ...mono, borderCollapse: 'collapse' }}>
         <thead>
           <tr style={{ color: '#858585', textAlign: 'left' }}>
-            <th style={cell}>id</th>
-            <th style={cell}>title</th>
-            <th style={cell}>suite</th>
-            <th style={cell}>capabilities</th>
-            <th style={cell}>package</th>
-            <th style={cell}>source</th>
-            <th style={cell}>state</th>
+            {[
+              'id',
+              'title',
+              'suite',
+              'capabilities',
+              'package',
+              'source',
+              'state',
+            ].map((label) => (
+              <th key={label} style={tableCell}>
+                {label}
+              </th>
+            ))}
           </tr>
         </thead>
         <tbody>
-          {shell.registry.map((entry) => {
-            const inProfile =
-              entry.system || (profile?.kfx.includes(entry.id) ?? false);
-            const disabled = shell.state.disabledKfx.includes(entry.id);
-            return (
-              <tr key={entry.id}>
-                <td style={{ ...cell, color: '#9cdcfe' }}>{entry.id}</td>
-                <td style={cell}>{entry.title}</td>
-                <td style={{ ...cell, color: '#858585' }}>
-                  {entry.suite ?? '—'}
-                </td>
-                <td style={{ ...cell, color: '#ce9178' }}>
-                  {entry.capabilities.join(', ') || '—'}
-                </td>
-                <td style={{ ...cell, color: '#858585' }}>
-                  {entry.packageName
-                    ? `${entry.packageName}@${entry.version ?? '?'}`
-                    : '—'}
-                </td>
-                <td style={{ ...cell, color: '#6a6a6a' }}>{entry.source}</td>
-                <td style={cell}>
-                  {entry.system ? (
-                    <span style={{ color: '#6a6a6a' }}>system · always on</span>
-                  ) : !inProfile ? (
-                    <span style={{ color: '#6a6a6a' }}>not in profile</span>
-                  ) : (
-                    <button
-                      type="button"
-                      onClick={() => toggleKfx(entry.id, disabled)}
-                      style={{
-                        ...mono,
-                        padding: '1px 8px',
-                        border: '1px solid #3c3c3c',
-                        borderRadius: 4,
-                        cursor: 'pointer',
-                        background: 'transparent',
-                        color: disabled ? '#f48771' : '#4ec9b0',
-                      }}
-                    >
-                      {disabled ? 'disabled — enable' : 'enabled — disable'}
-                    </button>
-                  )}
-                </td>
-              </tr>
-            );
-          })}
+          {shell.registry.map((entry) => (
+            <KfxRuntimeRow
+              key={entry.id}
+              entry={entry}
+              disabled={shell.state.disabledKfx.includes(entry.id)}
+              inProfile={
+                entry.system || (profile?.kfx.includes(entry.id) ?? false)
+              }
+              toggleKfx={toggleKfx}
+            />
+          ))}
         </tbody>
       </table>
       <h2 style={{ ...headingStyle, marginTop: 12 }}>
         Suites · {Object.keys(shell.suites).length}
       </h2>
-      {Object.entries(shell.suites).map(([key, suite]) => {
-        const disabled = shell.state.disabledSuites.includes(key);
-        const isSystem = shell.registry.some(
-          (entry) => entry.suite === key && entry.system,
-        );
-        return (
-          <div key={key} style={{ ...mono, padding: '2px 0' }}>
-            <span style={{ color: '#9cdcfe' }}>{key}</span> · {suite.title} ·
-            members: {suite.members.join(', ')}{' '}
-            {isSystem ? (
-              <span style={{ color: '#6a6a6a' }}>system · always on</span>
-            ) : (
-              <button
-                type="button"
-                onClick={() => toggleSuite(key, disabled)}
-                style={{
-                  ...mono,
-                  padding: '1px 8px',
-                  border: '1px solid #3c3c3c',
-                  borderRadius: 4,
-                  cursor: 'pointer',
-                  background: 'transparent',
-                  color: disabled ? '#f48771' : '#4ec9b0',
-                }}
-              >
-                {disabled
-                  ? 'suite disabled — enable'
-                  : 'suite enabled — disable'}
-              </button>
-            )}
-          </div>
-        );
-      })}
+      {Object.entries(shell.suites).map(([name, suite]) => (
+        <KfxSuiteRow
+          key={name}
+          name={name}
+          suite={suite}
+          disabled={shell.state.disabledSuites.includes(name)}
+          isSystem={shell.registry.some(
+            (entry) => entry.suite === name && entry.system,
+          )}
+          toggleSuite={toggleSuite}
+        />
+      ))}
+    </>
+  );
+}
+
+function KfxManagerContent(props: KfxManagerContentProps) {
+  return (
+    <section style={panelStyle}>
+      <KfxControlSection {...props} />
+      <ProfileOverviewSection {...props} />
+      <ProfileDecisionSections {...props} />
+      <KfxRegistrySection {...props} />
     </section>
+  );
+}
+function KfxManagerView(props: KfxViewProps) {
+  return (
+    <KfxManagerContent
+      controller={useKfxManagerController(props)}
+      shell={props.shell}
+    />
   );
 }
 

--- a/extensions/system/settings/src/view/index.tsx
+++ b/extensions/system/settings/src/view/index.tsx
@@ -85,107 +85,27 @@ const emptyAgentDraft: AgentRuntimeProfileInput = {
   envelope: 'required',
 };
 
-function SettingsView({ shell, caps }: KfxViewProps) {
-  const [drafts, setDrafts] = React.useState<Record<string, string>>({});
-  const [activeTab, setActiveTab] = React.useState<SettingsTab>('appearance');
-  const ui = shell.config?.config.ui ?? {
-    fontFamily: 'system',
-    fontSize: 14,
-    scale: 1,
-  };
-  const [uiDraft, setUiDraft] = React.useState({
-    fontFamily: ui.fontFamily,
-    fontSize: String(ui.fontSize),
-    scale: String(ui.scale),
-  });
-  const [uiError, setUiError] = React.useState('');
-  const [agentCatalog, setAgentCatalog] =
-    React.useState<AgentRuntimeCatalog | null>(null);
-  const [agentDraft, setAgentDraft] =
-    React.useState<AgentRuntimeProfileInput>(emptyAgentDraft);
-  const [agentArgv, setAgentArgv] = React.useState('');
-  const [agentMessage, setAgentMessage] = React.useState('');
-  const [agentBusy, setAgentBusy] = React.useState(false);
+type UiDraft = { fontFamily: string; fontSize: string; scale: string };
 
-  const reloadAgents = React.useCallback(async () => {
-    if (!caps.agentRuntime) return;
-    setAgentBusy(true);
-    try {
-      setAgentCatalog(await caps.agentRuntime.list());
-      setAgentMessage('');
-    } catch (error) {
-      setAgentMessage((error as Error).message);
-    } finally {
-      setAgentBusy(false);
-    }
-  }, [caps.agentRuntime]);
+type AppearanceSettingsProps = {
+  shell: KfxViewProps['shell'];
+  uiDraft: UiDraft;
+  setUiDraft: React.Dispatch<React.SetStateAction<UiDraft>>;
+  uiError: string;
+  saveAppearance: () => void;
+  resetAppearance: () => void;
+};
 
-  React.useEffect(() => {
-    if (activeTab === 'agents') void reloadAgents();
-  }, [activeTab, reloadAgents]);
-
-  React.useEffect(() => {
-    setUiDraft({
-      fontFamily: ui.fontFamily,
-      fontSize: String(ui.fontSize),
-      scale: String(ui.scale),
-    });
-  }, [ui.fontFamily, ui.fontSize, ui.scale]);
-
-  const declared = shell.registry.flatMap((entry) =>
-    entry.settings.map((decl) => ({ owner: entry.title, decl })),
-  );
-
-  const commit = (key: string) => {
-    const value = drafts[key];
-    if (value === undefined) return;
-    shell.updateState({ settings: { ...shell.state.settings, [key]: value } });
-    setDrafts((current) => {
-      const next = { ...current };
-      delete next[key];
-      return next;
-    });
-  };
-
-  const profile =
-    shell.profiles.find((p) => p.id === shell.state.profileId) ??
-    shell.profiles[0];
-
-  const saveAppearance = () => {
-    const fontSize = Number(uiDraft.fontSize);
-    const scale = Number(uiDraft.scale);
-    if (!Number.isFinite(fontSize) || fontSize < 8 || fontSize > 48) {
-      setUiError('font size must be between 8 and 48');
-      return;
-    }
-    if (!Number.isFinite(scale) || scale < 0.5 || scale > 3) {
-      setUiError('zoom must be between 50% and 300%');
-      return;
-    }
-    const fontFamily = uiDraft.fontFamily.trim() || 'system';
-    try {
-      shell.setConfigValue('ui.fontFamily', fontFamily);
-      shell.setConfigValue('ui.fontSize', fontSize);
-      shell.setConfigValue('ui.scale', scale);
-      setUiError('');
-    } catch (e) {
-      setUiError((e as Error).message);
-    }
-  };
-
-  const resetAppearance = () => {
-    try {
-      shell.unsetConfigValue('ui.fontFamily');
-      shell.unsetConfigValue('ui.fontSize');
-      shell.unsetConfigValue('ui.scale');
-      shell.reloadConfig();
-      setUiError('');
-    } catch (e) {
-      setUiError((e as Error).message);
-    }
-  };
-
-  const renderAppearance = () => (
+function AppearanceSettings(props: AppearanceSettingsProps) {
+  const {
+    resetAppearance,
+    saveAppearance,
+    setUiDraft,
+    shell,
+    uiDraft,
+    uiError,
+  } = props;
+  return (
     <section style={sectionStyle}>
       <h2 style={headingStyle}>Global appearance</h2>
       {shell.configError && (
@@ -307,8 +227,16 @@ function SettingsView({ shell, caps }: KfxViewProps) {
       </div>
     </section>
   );
+}
 
-  const renderProfile = () => (
+type ProfileSettingsProps = {
+  shell: KfxViewProps['shell'];
+  profile: KfxViewProps['shell']['profiles'][number];
+};
+
+function ProfileSettings(props: ProfileSettingsProps) {
+  const { profile, shell } = props;
+  return (
     <section style={sectionStyle}>
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
         <div>
@@ -346,374 +274,24 @@ function SettingsView({ shell, caps }: KfxViewProps) {
       </div>
     </section>
   );
+}
 
-  const configureDiscovered = async (
-    profile: AgentRuntimeCatalog['discovered'][number]['profile'],
-  ) => {
-    if (!caps.agentRuntime) return;
-    setAgentBusy(true);
-    try {
-      await caps.agentRuntime.upsert(
-        {
-          id: profile.id,
-          label: profile.label,
-          provider: profile.provider,
-          executable: profile.launch.executable,
-          argv: profile.launch.argv,
-          shellMode: profile.launch.shellMode,
-          cwdPolicy: profile.cwdPolicy,
-          backend: profile.backendDefault,
-          envelope: profile.bootstrap.envelope,
-        },
-        true,
-      );
-      await caps.agentRuntime.setDefault(profile.id, true);
-      setAgentMessage(`saved ${profile.label} as default`);
-      await reloadAgents();
-    } catch (error) {
-      setAgentMessage((error as Error).message);
-    } finally {
-      setAgentBusy(false);
-    }
-  };
+type DeclaredSetting = {
+  owner: string;
+  decl: KfxViewProps['shell']['registry'][number]['settings'][number];
+};
 
-  const verifyAgent = async (profileId: string) => {
-    if (!caps.agentRuntime) return;
-    setAgentBusy(true);
-    try {
-      const result = await caps.agentRuntime.verify(profileId);
-      setAgentMessage(
-        result.ok
-          ? `verified ${profileId} · ${result.version ?? 'available'}`
-          : `${profileId} unavailable · ${result.error ?? 'version probe failed'}`,
-      );
-    } catch (error) {
-      setAgentMessage((error as Error).message);
-    } finally {
-      setAgentBusy(false);
-    }
-  };
+type KfxSettingsProps = {
+  commit: (key: string) => void;
+  declared: DeclaredSetting[];
+  drafts: Record<string, string>;
+  setDrafts: React.Dispatch<React.SetStateAction<Record<string, string>>>;
+  shell: KfxViewProps['shell'];
+};
 
-  const setDefaultAgent = async (profileId: string) => {
-    if (!caps.agentRuntime) return;
-    setAgentBusy(true);
-    try {
-      await caps.agentRuntime.setDefault(profileId, true);
-      setAgentMessage(`default launch method: ${profileId}`);
-      await reloadAgents();
-    } catch (error) {
-      setAgentMessage((error as Error).message);
-    } finally {
-      setAgentBusy(false);
-    }
-  };
-
-  const removeAgent = async (profileId: string) => {
-    if (!caps.agentRuntime) return;
-    setAgentBusy(true);
-    try {
-      await caps.agentRuntime.remove(profileId, true);
-      setAgentMessage(`removed ${profileId}`);
-      await reloadAgents();
-    } catch (error) {
-      setAgentMessage((error as Error).message);
-    } finally {
-      setAgentBusy(false);
-    }
-  };
-
-  const saveAgentDraft = async () => {
-    if (!caps.agentRuntime) return;
-    setAgentBusy(true);
-    try {
-      await caps.agentRuntime.upsert(
-        {
-          ...agentDraft,
-          argv: agentArgv
-            .split('\n')
-            .map((value) => value.trim())
-            .filter(Boolean),
-        },
-        true,
-      );
-      await caps.agentRuntime.setDefault(agentDraft.id, true);
-      setAgentMessage(`saved ${agentDraft.label} as default`);
-      await reloadAgents();
-    } catch (error) {
-      setAgentMessage((error as Error).message);
-    } finally {
-      setAgentBusy(false);
-    }
-  };
-
-  const renderAgents = () => (
-    <section style={sectionStyle}>
-      <h2 style={headingStyle}>Agent Runtime Profiles</h2>
-      <div style={{ ...mono, color: '#858585', marginBottom: 12 }}>
-        Machine-global launch methods only. Kungfu inspects executable paths and
-        bounded --version output; provider auth and conversation data stay
-        private.
-      </div>
-      {!caps.agentRuntime ? (
-        <div style={{ ...mono, color: '#f48771' }}>
-          Agent Runtime capability unavailable
-        </div>
-      ) : (
-        <div style={{ display: 'grid', gap: 16 }}>
-          <div>
-            <h3 style={{ ...headingStyle, fontSize: 13 }}>Configured</h3>
-            <div style={{ display: 'flex', gap: 12, marginBottom: 10 }}>
-              <label style={{ ...mono, display: 'flex', gap: 6 }}>
-                startup
-                <select
-                  value={agentCatalog?.startupView ?? 'profile-home'}
-                  onChange={(event) => {
-                    shell.setConfigValue(
-                      'agent.startupView',
-                      event.target.value,
-                    );
-                    void reloadAgents();
-                  }}
-                >
-                  <option value="profile-home">Work Control</option>
-                  <option value="agent-console">Agent Console</option>
-                </select>
-              </label>
-              <label style={{ ...mono, display: 'flex', gap: 6 }}>
-                default backend
-                <select
-                  value={agentCatalog?.backendDefault ?? 'tmux'}
-                  onChange={(event) => {
-                    shell.setConfigValue(
-                      'agent.backendDefault',
-                      event.target.value,
-                    );
-                    void reloadAgents();
-                  }}
-                >
-                  <option value="tmux">Durable</option>
-                  <option value="direct">Direct</option>
-                </select>
-              </label>
-            </div>
-            {(agentCatalog?.configured ?? []).map((profile) => (
-              <div key={profile.id} style={rowStyle}>
-                <div>
-                  <div style={{ color: '#9cdcfe' }}>{profile.label}</div>
-                  <div style={{ color: '#6a6a6a' }}>{profile.id}</div>
-                </div>
-                <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-                  <code style={{ overflowWrap: 'anywhere' }}>
-                    {profile.launch.executable}
-                  </code>
-                  <button
-                    type="button"
-                    disabled={agentBusy}
-                    onClick={() => void setDefaultAgent(profile.id)}
-                  >
-                    {agentCatalog?.defaultProfileId === profile.id
-                      ? 'Default ✓'
-                      : 'Set default'}
-                  </button>
-                  <button
-                    type="button"
-                    disabled={agentBusy}
-                    onClick={() => void verifyAgent(profile.id)}
-                  >
-                    Verify
-                  </button>
-                  <button
-                    type="button"
-                    disabled={agentBusy}
-                    onClick={() => {
-                      setAgentDraft({
-                        id: profile.id,
-                        label: profile.label,
-                        provider: profile.provider,
-                        executable: profile.launch.executable,
-                        argv: profile.launch.argv,
-                        shellMode: profile.launch.shellMode,
-                        cwdPolicy: profile.cwdPolicy,
-                        backend: profile.backendDefault,
-                        envelope: profile.bootstrap.envelope,
-                      });
-                      setAgentArgv(profile.launch.argv.join('\n'));
-                    }}
-                  >
-                    Edit
-                  </button>
-                  <button
-                    type="button"
-                    disabled={agentBusy}
-                    onClick={() => void removeAgent(profile.id)}
-                  >
-                    Remove
-                  </button>
-                </div>
-              </div>
-            ))}
-            {(agentCatalog?.configured.length ?? 0) === 0 && (
-              <div style={{ ...mono, color: '#6a6a6a' }}>
-                No saved launch method yet.
-              </div>
-            )}
-          </div>
-          <div>
-            <h3 style={{ ...headingStyle, fontSize: 13 }}>
-              Detected on this Mac
-            </h3>
-            {(agentCatalog?.discovered ?? []).map((row) => (
-              <div key={row.profile.id} style={rowStyle}>
-                <div>
-                  <div style={{ color: '#9cdcfe' }}>{row.profile.label}</div>
-                  <div style={{ color: '#6a6a6a' }}>
-                    {row.version ?? 'version unknown'}
-                  </div>
-                </div>
-                <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-                  <code style={{ overflowWrap: 'anywhere' }}>
-                    {row.profile.launch.executable}
-                  </code>
-                  <button
-                    type="button"
-                    disabled={agentBusy}
-                    onClick={() => void configureDiscovered(row.profile)}
-                  >
-                    {agentCatalog?.defaultProfileId === row.profile.id
-                      ? 'Default ✓'
-                      : 'Use'}
-                  </button>
-                  <button
-                    type="button"
-                    disabled={agentBusy}
-                    onClick={() => void verifyAgent(row.profile.id)}
-                  >
-                    Verify
-                  </button>
-                </div>
-              </div>
-            ))}
-            {(agentCatalog?.discovered.length ?? 0) === 0 && (
-              <div style={{ ...mono, color: '#6a6a6a' }}>
-                No Codex or Claude executable found. Add a custom method below.
-              </div>
-            )}
-          </div>
-          <div>
-            <h3 style={{ ...headingStyle, fontSize: 13 }}>Custom method</h3>
-            <div style={{ display: 'grid', gap: 8, maxWidth: 720 }}>
-              <label style={rowStyle}>
-                <span>provider</span>
-                <select
-                  value={agentDraft.provider}
-                  onChange={(event) => {
-                    const provider = event.target.value as 'codex' | 'claude';
-                    setAgentDraft((current) => ({
-                      ...current,
-                      provider,
-                      id: `${provider}.custom`,
-                      label: `${provider === 'codex' ? 'Codex' : 'Claude'} · Custom`,
-                      executable: provider,
-                    }));
-                  }}
-                >
-                  <option value="codex">Codex</option>
-                  <option value="claude">Claude</option>
-                </select>
-              </label>
-              {(
-                [
-                  ['id', 'stable id'],
-                  ['label', 'label'],
-                  ['executable', 'executable'],
-                ] as const
-              ).map(([key, label]) => (
-                <label key={key} style={rowStyle}>
-                  <span>{label}</span>
-                  <input
-                    style={inputStyle}
-                    value={agentDraft[key]}
-                    onChange={(event) =>
-                      setAgentDraft((current) => ({
-                        ...current,
-                        [key]: event.target.value,
-                      }))
-                    }
-                  />
-                </label>
-              ))}
-              <label style={rowStyle}>
-                <span>argv · one per line</span>
-                <textarea
-                  rows={3}
-                  style={{ ...inputStyle, resize: 'vertical' }}
-                  value={agentArgv}
-                  onChange={(event) => setAgentArgv(event.target.value)}
-                  placeholder="Optional agentctl arguments"
-                />
-              </label>
-              <label style={rowStyle}>
-                <span>backend</span>
-                <select
-                  value={agentDraft.backend}
-                  onChange={(event) =>
-                    setAgentDraft((current) => ({
-                      ...current,
-                      backend: event.target.value as 'tmux' | 'direct',
-                    }))
-                  }
-                >
-                  <option value="tmux">Durable</option>
-                  <option value="direct">Direct · ends with app</option>
-                </select>
-              </label>
-              <label style={rowStyle}>
-                <span>shell mode</span>
-                <span>
-                  <input
-                    type="checkbox"
-                    checked={agentDraft.shellMode ?? false}
-                    onChange={(event) =>
-                      setAgentDraft((current) => ({
-                        ...current,
-                        shellMode: event.target.checked,
-                      }))
-                    }
-                  />{' '}
-                  explicit compatibility mode · only enable for a trusted custom
-                  command
-                </span>
-              </label>
-              <div style={{ display: 'flex', gap: 8 }}>
-                <button
-                  type="button"
-                  disabled={agentBusy}
-                  onClick={() => void saveAgentDraft()}
-                >
-                  Save and use
-                </button>
-                <button
-                  type="button"
-                  disabled={agentBusy}
-                  onClick={() => void reloadAgents()}
-                >
-                  Rescan
-                </button>
-              </div>
-            </div>
-          </div>
-          <div style={{ ...mono, color: '#6a6a6a' }}>
-            config: {agentCatalog?.configPath ?? 'loading…'}
-          </div>
-          {agentMessage && (
-            <div style={{ ...mono, color: '#dcdcaa' }}>{agentMessage}</div>
-          )}
-        </div>
-      )}
-    </section>
-  );
-
-  const renderKfx = () => (
+function KfxSettings(props: KfxSettingsProps) {
+  const { commit, declared, drafts, setDrafts, shell } = props;
+  return (
     <section style={sectionStyle}>
       <h2 style={headingStyle}>KFX settings</h2>
       {declared.length ? (
@@ -729,15 +307,15 @@ function SettingsView({ shell, caps }: KfxViewProps) {
                 <input
                   style={{ ...inputStyle, width: 'min(360px, 100%)' }}
                   value={drafts[decl.key] ?? shell.setting(decl.key)}
-                  onChange={(e) =>
+                  onChange={(event) =>
                     setDrafts((current) => ({
                       ...current,
-                      [decl.key]: e.target.value,
+                      [decl.key]: event.target.value,
                     }))
                   }
                   onBlur={() => commit(decl.key)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') commit(decl.key);
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') commit(decl.key);
                   }}
                 />
               </label>
@@ -751,8 +329,10 @@ function SettingsView({ shell, caps }: KfxViewProps) {
       )}
     </section>
   );
+}
 
-  const renderPaths = () => (
+function PathsSettings({ shell }: Pick<KfxViewProps, 'shell'>) {
+  return (
     <section style={sectionStyle}>
       <h2 style={headingStyle}>Runtime paths</h2>
       {[
@@ -771,8 +351,10 @@ function SettingsView({ shell, caps }: KfxViewProps) {
       ))}
     </section>
   );
+}
 
-  const renderAdvanced = () => (
+function AdvancedSettings({ shell }: Pick<KfxViewProps, 'shell'>) {
+  return (
     <section style={sectionStyle}>
       <h2 style={headingStyle}>Shell state</h2>
       <pre
@@ -792,16 +374,16 @@ function SettingsView({ shell, caps }: KfxViewProps) {
       </pre>
     </section>
   );
+}
 
-  const renderActive = () => {
-    if (activeTab === 'appearance') return renderAppearance();
-    if (activeTab === 'agents') return renderAgents();
-    if (activeTab === 'profile') return renderProfile();
-    if (activeTab === 'kfx') return renderKfx();
-    if (activeTab === 'paths') return renderPaths();
-    return renderAdvanced();
-  };
+type SettingsTabsProps = {
+  activeTab: SettingsTab;
+  content: React.ReactNode;
+  setActiveTab: React.Dispatch<React.SetStateAction<SettingsTab>>;
+};
 
+function SettingsTabs(props: SettingsTabsProps) {
+  const { activeTab, content, setActiveTab } = props;
   return (
     <div>
       <div
@@ -836,8 +418,618 @@ function SettingsView({ shell, caps }: KfxViewProps) {
           </button>
         ))}
       </div>
-      {renderActive()}
+      {content}
     </div>
+  );
+}
+
+type SettingsRenderers = Record<SettingsTab, () => React.ReactNode>;
+
+function activeSettingsContent(
+  activeTab: SettingsTab,
+  renderers: SettingsRenderers,
+) {
+  return renderers[activeTab]();
+}
+
+type ConfiguredAgent = AgentRuntimeCatalog['configured'][number];
+type DiscoveredAgent = AgentRuntimeCatalog['discovered'][number];
+
+type AgentSettingsModel = {
+  agentArgv: string;
+  agentBusy: boolean;
+  agentCatalog: AgentRuntimeCatalog | null;
+  agentDraft: AgentRuntimeProfileInput;
+  agentMessage: string;
+  configureDiscovered: (profile: DiscoveredAgent['profile']) => Promise<void>;
+  reloadAgents: () => Promise<void>;
+  removeAgent: (profileId: string) => Promise<void>;
+  saveAgentDraft: () => Promise<void>;
+  setAgentArgv: React.Dispatch<React.SetStateAction<string>>;
+  setAgentDraft: React.Dispatch<React.SetStateAction<AgentRuntimeProfileInput>>;
+  setDefaultAgent: (profileId: string) => Promise<void>;
+  verifyAgent: (profileId: string) => Promise<void>;
+};
+
+type ConfiguredAgentRowProps = {
+  model: AgentSettingsModel;
+  profile: ConfiguredAgent;
+};
+
+function ConfiguredAgentRow(props: ConfiguredAgentRowProps) {
+  const { model, profile } = props;
+  const editProfile = () => {
+    model.setAgentDraft({
+      id: profile.id,
+      label: profile.label,
+      provider: profile.provider,
+      executable: profile.launch.executable,
+      argv: profile.launch.argv,
+      shellMode: profile.launch.shellMode,
+      cwdPolicy: profile.cwdPolicy,
+      backend: profile.backendDefault,
+      envelope: profile.bootstrap.envelope,
+    });
+    model.setAgentArgv(profile.launch.argv.join('\n'));
+  };
+  return (
+    <div style={rowStyle}>
+      <div>
+        <div style={{ color: '#9cdcfe' }}>{profile.label}</div>
+        <div style={{ color: '#6a6a6a' }}>{profile.id}</div>
+      </div>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+        <code style={{ overflowWrap: 'anywhere' }}>
+          {profile.launch.executable}
+        </code>
+        <button
+          type="button"
+          disabled={model.agentBusy}
+          onClick={() => void model.setDefaultAgent(profile.id)}
+        >
+          {model.agentCatalog?.defaultProfileId === profile.id
+            ? 'Default ✓'
+            : 'Set default'}
+        </button>
+        <button
+          type="button"
+          disabled={model.agentBusy}
+          onClick={() => void model.verifyAgent(profile.id)}
+        >
+          Verify
+        </button>
+        <button type="button" disabled={model.agentBusy} onClick={editProfile}>
+          Edit
+        </button>
+        <button
+          type="button"
+          disabled={model.agentBusy}
+          onClick={() => void model.removeAgent(profile.id)}
+        >
+          Remove
+        </button>
+      </div>
+    </div>
+  );
+}
+
+type ConfiguredAgentsSectionProps = {
+  model: AgentSettingsModel;
+  shell: KfxViewProps['shell'];
+};
+
+function ConfiguredAgentsSection(props: ConfiguredAgentsSectionProps) {
+  const { model, shell } = props;
+  return (
+    <div>
+      <h3 style={{ ...headingStyle, fontSize: 13 }}>Configured</h3>
+      <div style={{ display: 'flex', gap: 12, marginBottom: 10 }}>
+        <label style={{ ...mono, display: 'flex', gap: 6 }}>
+          startup
+          <select
+            value={model.agentCatalog?.startupView ?? 'profile-home'}
+            onChange={(event) => {
+              shell.setConfigValue('agent.startupView', event.target.value);
+              void model.reloadAgents();
+            }}
+          >
+            <option value="profile-home">Work Control</option>
+            <option value="agent-console">Agent Console</option>
+          </select>
+        </label>
+        <label style={{ ...mono, display: 'flex', gap: 6 }}>
+          default backend
+          <select
+            value={model.agentCatalog?.backendDefault ?? 'tmux'}
+            onChange={(event) => {
+              shell.setConfigValue('agent.backendDefault', event.target.value);
+              void model.reloadAgents();
+            }}
+          >
+            <option value="tmux">Durable</option>
+            <option value="direct">Direct</option>
+          </select>
+        </label>
+      </div>
+      {(model.agentCatalog?.configured ?? []).map((profile) => (
+        <ConfiguredAgentRow key={profile.id} model={model} profile={profile} />
+      ))}
+      {(model.agentCatalog?.configured.length ?? 0) === 0 && (
+        <div style={{ ...mono, color: '#6a6a6a' }}>
+          No saved launch method yet.
+        </div>
+      )}
+    </div>
+  );
+}
+
+type DiscoveredAgentRowProps = {
+  model: AgentSettingsModel;
+  row: DiscoveredAgent;
+};
+
+function DiscoveredAgentRow(props: DiscoveredAgentRowProps) {
+  const { model, row } = props;
+  return (
+    <div style={rowStyle}>
+      <div>
+        <div style={{ color: '#9cdcfe' }}>{row.profile.label}</div>
+        <div style={{ color: '#6a6a6a' }}>
+          {row.version ?? 'version unknown'}
+        </div>
+      </div>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+        <code style={{ overflowWrap: 'anywhere' }}>
+          {row.profile.launch.executable}
+        </code>
+        <button
+          type="button"
+          disabled={model.agentBusy}
+          onClick={() => void model.configureDiscovered(row.profile)}
+        >
+          {model.agentCatalog?.defaultProfileId === row.profile.id
+            ? 'Default ✓'
+            : 'Use'}
+        </button>
+        <button
+          type="button"
+          disabled={model.agentBusy}
+          onClick={() => void model.verifyAgent(row.profile.id)}
+        >
+          Verify
+        </button>
+      </div>
+    </div>
+  );
+}
+
+type DiscoveredAgentsSectionProps = { model: AgentSettingsModel };
+
+function DiscoveredAgentsSection(props: DiscoveredAgentsSectionProps) {
+  const { model } = props;
+  return (
+    <div>
+      <h3 style={{ ...headingStyle, fontSize: 13 }}>Detected on this Mac</h3>
+      {(model.agentCatalog?.discovered ?? []).map((row) => (
+        <DiscoveredAgentRow key={row.profile.id} model={model} row={row} />
+      ))}
+      {(model.agentCatalog?.discovered.length ?? 0) === 0 && (
+        <div style={{ ...mono, color: '#6a6a6a' }}>
+          No Codex or Claude executable found. Add a custom method below.
+        </div>
+      )}
+    </div>
+  );
+}
+
+type AgentIdentityFieldsProps = { model: AgentSettingsModel };
+
+function AgentIdentityFields(props: AgentIdentityFieldsProps) {
+  const { model } = props;
+  const fields = [
+    ['id', 'stable id'],
+    ['label', 'label'],
+    ['executable', 'executable'],
+  ] as const;
+  return (
+    <>
+      <label style={rowStyle}>
+        <span>provider</span>
+        <select
+          value={model.agentDraft.provider}
+          onChange={(event) => {
+            const provider = event.target.value as 'codex' | 'claude';
+            model.setAgentDraft((current) => ({
+              ...current,
+              provider,
+              id: `${provider}.custom`,
+              label: `${provider === 'codex' ? 'Codex' : 'Claude'} · Custom`,
+              executable: provider,
+            }));
+          }}
+        >
+          <option value="codex">Codex</option>
+          <option value="claude">Claude</option>
+        </select>
+      </label>
+      {fields.map(([key, label]) => (
+        <label key={key} style={rowStyle}>
+          <span>{label}</span>
+          <input
+            style={inputStyle}
+            value={model.agentDraft[key]}
+            onChange={(event) =>
+              model.setAgentDraft((current) => ({
+                ...current,
+                [key]: event.target.value,
+              }))
+            }
+          />
+        </label>
+      ))}
+    </>
+  );
+}
+
+type CustomAgentSectionProps = { model: AgentSettingsModel };
+
+function CustomAgentSection(props: CustomAgentSectionProps) {
+  const { model } = props;
+  return (
+    <div>
+      <h3 style={{ ...headingStyle, fontSize: 13 }}>Custom method</h3>
+      <div style={{ display: 'grid', gap: 8, maxWidth: 720 }}>
+        <AgentIdentityFields model={model} />
+        <label style={rowStyle}>
+          <span>argv · one per line</span>
+          <textarea
+            rows={3}
+            style={{ ...inputStyle, resize: 'vertical' }}
+            value={model.agentArgv}
+            onChange={(event) => model.setAgentArgv(event.target.value)}
+            placeholder="Optional agentctl arguments"
+          />
+        </label>
+        <label style={rowStyle}>
+          <span>backend</span>
+          <select
+            value={model.agentDraft.backend}
+            onChange={(event) =>
+              model.setAgentDraft((current) => ({
+                ...current,
+                backend: event.target.value as 'tmux' | 'direct',
+              }))
+            }
+          >
+            <option value="tmux">Durable</option>
+            <option value="direct">Direct · ends with app</option>
+          </select>
+        </label>
+        <label style={rowStyle}>
+          <span>shell mode</span>
+          <span>
+            <input
+              type="checkbox"
+              checked={model.agentDraft.shellMode ?? false}
+              onChange={(event) =>
+                model.setAgentDraft((current) => ({
+                  ...current,
+                  shellMode: event.target.checked,
+                }))
+              }
+            />{' '}
+            explicit compatibility mode · only enable for a trusted custom
+            command
+          </span>
+        </label>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button
+            type="button"
+            disabled={model.agentBusy}
+            onClick={() => void model.saveAgentDraft()}
+          >
+            Save and use
+          </button>
+          <button
+            type="button"
+            disabled={model.agentBusy}
+            onClick={() => void model.reloadAgents()}
+          >
+            Rescan
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type AgentSettingsContentProps = {
+  available: boolean;
+  model: AgentSettingsModel;
+  shell: KfxViewProps['shell'];
+};
+
+function AgentSettingsContent(props: AgentSettingsContentProps) {
+  const { available, model, shell } = props;
+  return (
+    <section style={sectionStyle}>
+      <h2 style={headingStyle}>Agent Runtime Profiles</h2>
+      <div style={{ ...mono, color: '#858585', marginBottom: 12 }}>
+        Machine-global launch methods only. Kungfu inspects executable paths and
+        bounded --version output; provider auth and conversation data stay
+        private.
+      </div>
+      {!available ? (
+        <div style={{ ...mono, color: '#f48771' }}>
+          Agent Runtime capability unavailable
+        </div>
+      ) : (
+        <div style={{ display: 'grid', gap: 16 }}>
+          <ConfiguredAgentsSection model={model} shell={shell} />
+          <DiscoveredAgentsSection model={model} />
+          <CustomAgentSection model={model} />
+          <div style={{ ...mono, color: '#6a6a6a' }}>
+            config: {model.agentCatalog?.configPath ?? 'loading…'}
+          </div>
+          {model.agentMessage && (
+            <div style={{ ...mono, color: '#dcdcaa' }}>
+              {model.agentMessage}
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function SettingsView({ shell, caps }: KfxViewProps) {
+  const [drafts, setDrafts] = React.useState<Record<string, string>>({});
+  const [activeTab, setActiveTab] = React.useState<SettingsTab>('appearance');
+  const ui = shell.config?.config.ui ?? {
+    fontFamily: 'system',
+    fontSize: 14,
+    scale: 1,
+  };
+  const [uiDraft, setUiDraft] = React.useState({
+    fontFamily: ui.fontFamily,
+    fontSize: String(ui.fontSize),
+    scale: String(ui.scale),
+  });
+  const [uiError, setUiError] = React.useState('');
+  const [agentCatalog, setAgentCatalog] =
+    React.useState<AgentRuntimeCatalog | null>(null);
+  const [agentDraft, setAgentDraft] =
+    React.useState<AgentRuntimeProfileInput>(emptyAgentDraft);
+  const [agentArgv, setAgentArgv] = React.useState('');
+  const [agentMessage, setAgentMessage] = React.useState('');
+  const [agentBusy, setAgentBusy] = React.useState(false);
+
+  const runAgentOperation = React.useCallback(
+    async (operation: () => Promise<void>) => {
+      setAgentBusy(true);
+      try {
+        await operation();
+      } catch (error) {
+        setAgentMessage((error as Error).message);
+      } finally {
+        setAgentBusy(false);
+      }
+    },
+    [],
+  );
+
+  const reloadAgents = React.useCallback(async () => {
+    if (!caps.agentRuntime) return;
+    await runAgentOperation(async () => {
+      setAgentCatalog(await caps.agentRuntime.list());
+      setAgentMessage('');
+    });
+  }, [caps.agentRuntime, runAgentOperation]);
+
+  React.useEffect(() => {
+    if (activeTab === 'agents') void reloadAgents();
+  }, [activeTab, reloadAgents]);
+
+  React.useEffect(() => {
+    setUiDraft({
+      fontFamily: ui.fontFamily,
+      fontSize: String(ui.fontSize),
+      scale: String(ui.scale),
+    });
+  }, [ui.fontFamily, ui.fontSize, ui.scale]);
+
+  const declared = shell.registry.flatMap((entry) =>
+    entry.settings.map((decl) => ({ owner: entry.title, decl })),
+  );
+
+  const commit = (key: string) => {
+    const value = drafts[key];
+    if (value === undefined) return;
+    shell.updateState({ settings: { ...shell.state.settings, [key]: value } });
+    setDrafts((current) => {
+      const next = { ...current };
+      delete next[key];
+      return next;
+    });
+  };
+
+  const profile =
+    shell.profiles.find((p) => p.id === shell.state.profileId) ??
+    shell.profiles[0];
+
+  const saveAppearance = () => {
+    const fontSize = Number(uiDraft.fontSize);
+    const scale = Number(uiDraft.scale);
+    if (!Number.isFinite(fontSize) || fontSize < 8 || fontSize > 48) {
+      setUiError('font size must be between 8 and 48');
+      return;
+    }
+    if (!Number.isFinite(scale) || scale < 0.5 || scale > 3) {
+      setUiError('zoom must be between 50% and 300%');
+      return;
+    }
+    const fontFamily = uiDraft.fontFamily.trim() || 'system';
+    try {
+      shell.setConfigValue('ui.fontFamily', fontFamily);
+      shell.setConfigValue('ui.fontSize', fontSize);
+      shell.setConfigValue('ui.scale', scale);
+      setUiError('');
+    } catch (e) {
+      setUiError((e as Error).message);
+    }
+  };
+
+  const resetAppearance = () => {
+    try {
+      shell.unsetConfigValue('ui.fontFamily');
+      shell.unsetConfigValue('ui.fontSize');
+      shell.unsetConfigValue('ui.scale');
+      shell.reloadConfig();
+      setUiError('');
+    } catch (e) {
+      setUiError((e as Error).message);
+    }
+  };
+
+  const renderAppearance = () => (
+    <AppearanceSettings
+      resetAppearance={resetAppearance}
+      saveAppearance={saveAppearance}
+      setUiDraft={setUiDraft}
+      shell={shell}
+      uiDraft={uiDraft}
+      uiError={uiError}
+    />
+  );
+
+  const renderProfile = () => (
+    <ProfileSettings profile={profile} shell={shell} />
+  );
+
+  const configureDiscovered = async (
+    profile: AgentRuntimeCatalog['discovered'][number]['profile'],
+  ) => {
+    if (!caps.agentRuntime) return;
+    await runAgentOperation(async () => {
+      await caps.agentRuntime.upsert(
+        {
+          id: profile.id,
+          label: profile.label,
+          provider: profile.provider,
+          executable: profile.launch.executable,
+          argv: profile.launch.argv,
+          shellMode: profile.launch.shellMode,
+          cwdPolicy: profile.cwdPolicy,
+          backend: profile.backendDefault,
+          envelope: profile.bootstrap.envelope,
+        },
+        true,
+      );
+      await caps.agentRuntime.setDefault(profile.id, true);
+      setAgentMessage(`saved ${profile.label} as default`);
+      await reloadAgents();
+    });
+  };
+
+  const verifyAgent = async (profileId: string) => {
+    if (!caps.agentRuntime) return;
+    await runAgentOperation(async () => {
+      const result = await caps.agentRuntime.verify(profileId);
+      setAgentMessage(
+        result.ok
+          ? `verified ${profileId} · ${result.version ?? 'available'}`
+          : `${profileId} unavailable · ${result.error ?? 'version probe failed'}`,
+      );
+    });
+  };
+
+  const setDefaultAgent = async (profileId: string) => {
+    if (!caps.agentRuntime) return;
+    await runAgentOperation(async () => {
+      await caps.agentRuntime.setDefault(profileId, true);
+      setAgentMessage(`default launch method: ${profileId}`);
+      await reloadAgents();
+    });
+  };
+
+  const removeAgent = async (profileId: string) => {
+    if (!caps.agentRuntime) return;
+    await runAgentOperation(async () => {
+      await caps.agentRuntime.remove(profileId, true);
+      setAgentMessage(`removed ${profileId}`);
+      await reloadAgents();
+    });
+  };
+
+  const saveAgentDraft = async () => {
+    if (!caps.agentRuntime) return;
+    await runAgentOperation(async () => {
+      await caps.agentRuntime.upsert(
+        {
+          ...agentDraft,
+          argv: agentArgv
+            .split('\n')
+            .map((value) => value.trim())
+            .filter(Boolean),
+        },
+        true,
+      );
+      await caps.agentRuntime.setDefault(agentDraft.id, true);
+      setAgentMessage(`saved ${agentDraft.label} as default`);
+      await reloadAgents();
+    });
+  };
+
+  const agentSettingsModel: AgentSettingsModel = {
+    agentArgv,
+    agentBusy,
+    agentCatalog,
+    agentDraft,
+    agentMessage,
+    configureDiscovered,
+    reloadAgents,
+    removeAgent,
+    saveAgentDraft,
+    setAgentArgv,
+    setAgentDraft,
+    setDefaultAgent,
+    verifyAgent,
+  };
+
+  const renderAgents = () => (
+    <AgentSettingsContent
+      available={Boolean(caps.agentRuntime)}
+      model={agentSettingsModel}
+      shell={shell}
+    />
+  );
+  const renderKfx = () => (
+    <KfxSettings
+      commit={commit}
+      declared={declared}
+      drafts={drafts}
+      setDrafts={setDrafts}
+      shell={shell}
+    />
+  );
+
+  const renderPaths = () => <PathsSettings shell={shell} />;
+
+  const renderAdvanced = () => <AdvancedSettings shell={shell} />;
+
+  return (
+    <SettingsTabs
+      activeTab={activeTab}
+      content={activeSettingsContent(activeTab, {
+        advanced: renderAdvanced,
+        agents: renderAgents,
+        appearance: renderAppearance,
+        kfx: renderKfx,
+        paths: renderPaths,
+        profile: renderProfile,
+      })}
+      setActiveTab={setActiveTab}
+    />
   );
 }
 

--- a/extensions/system/skill-manager/src/view/index.tsx
+++ b/extensions/system/skill-manager/src/view/index.tsx
@@ -97,6 +97,142 @@ function AgentSkillRow({
   );
 }
 
+type RuntimeAuditSectionProps = {
+  runtimeAudit: SkillManagerView['runtimeAudit'];
+};
+
+type RuntimeAudit = NonNullable<SkillManagerView['runtimeAudit']>;
+
+function RuntimeSkillDetails({ skills }: { skills: RuntimeAudit['skills'] }) {
+  return skills.map((value, index) => {
+    const skill = record(value);
+    const identity = record(skill.identity);
+    const proof = record(skill.proof);
+    return (
+      <details
+        key={`${String(identity.key ?? 'skill')}:${index}`}
+        style={{ ...mono, marginTop: 6 }}
+      >
+        <summary style={{ color: '#9cdcfe' }}>
+          {String(identity.key ?? 'unknown')}@{String(identity.revision ?? '?')}{' '}
+          · {String(skill.lifecycle ?? 'unproved')} ·{' '}
+          {compact(skill.observedStates)}
+        </summary>
+        <div style={{ color: '#858585', marginLeft: 12 }}>
+          identity: content={String(identity.contentRoot ?? '-')} · definition=
+          {String(identity.definitionRoot ?? '-')} · class=
+          {String(identity.class ?? '-')}
+        </div>
+        <div style={{ color: '#858585', marginLeft: 12 }}>
+          Work bindings: {compact(skill.workBindings)}
+        </div>
+        <div style={{ color: '#858585', marginLeft: 12 }}>
+          dependencies/trust/authorization: {compact(skill.dependencies)}
+        </div>
+        <div style={{ color: '#858585', marginLeft: 12 }}>
+          receipts/history proof: {String(proof.status ?? 'unproved')} ·{' '}
+          {compact(proof.roots)} · preserved=
+          {String(skill.historyPreserved ?? false)}
+        </div>
+      </details>
+    );
+  });
+}
+
+type RuntimeEvidenceDetailsProps = { evidence: RuntimeAudit['evidence'] };
+
+function RuntimeEvidenceRow({ value }: { value: unknown }) {
+  const item = record(value);
+  const source = record(item.source);
+  const proof = record(item.proof);
+  return (
+    <div style={{ color: '#858585', marginLeft: 12 }}>
+      {String(item.state ?? 'unproved')} · {String(item.skillKey ?? '-')} · run=
+      {String(item.runId ?? '-')} · Work={String(item.workRef ?? '-')} · source=
+      {String(source.type ?? '-')} · {String(proof.status ?? 'unproved')}:{' '}
+      {compact(proof.roots)} · {compact(item.detail)}
+    </div>
+  );
+}
+
+function runtimeEvidenceKey(value: unknown) {
+  const item = record(value);
+  const source = record(item.source);
+  const proof = record(item.proof);
+  return `${String(item.runId ?? '-')}:${String(item.workRef ?? '-')}:${String(item.skillKey ?? '-')}:${String(item.state ?? 'unproved')}:${String(source.type ?? '-')}:${compact(proof.roots)}`;
+}
+
+function RuntimeEvidenceDetails(props: RuntimeEvidenceDetailsProps) {
+  const { evidence } = props;
+  return (
+    <details style={{ ...mono, marginTop: 6 }}>
+      <summary style={{ color: '#ce9178' }}>
+        audit, dependency, trust, authorization, and receipt evidence
+      </summary>
+      {evidence.map((value) => (
+        <RuntimeEvidenceRow key={runtimeEvidenceKey(value)} value={value} />
+      ))}
+    </details>
+  );
+}
+
+type RuntimeRecoveryDetailsProps = { runtimeAudit: RuntimeAudit };
+
+function RuntimeRecoveryDetails(props: RuntimeRecoveryDetailsProps) {
+  const { runtimeAudit } = props;
+  const gui = runtimeAudit.surfaceProjections.gui;
+  return (
+    <details style={{ ...mono, marginTop: 6 }}>
+      <summary style={{ color: '#dcdcaa' }}>recovery and history</summary>
+      <div style={{ color: '#858585', marginLeft: 12 }}>
+        roots: registry={gui.registryStateRoot} · history={gui.historyRoot} ·
+        diagnosis={gui.diagnosisRoot}
+      </div>
+      <div style={{ color: '#858585', marginLeft: 12 }}>
+        audit={compact(gui.auditRoots)} · dependency=
+        {compact(gui.dependencyRoots)}
+      </div>
+      <div style={{ color: '#858585', marginLeft: 12 }}>
+        recovery: {compact(runtimeAudit.recovery)}
+      </div>
+    </details>
+  );
+}
+
+function RuntimeAuditSection(props: RuntimeAuditSectionProps) {
+  const { runtimeAudit } = props;
+  if (!runtimeAudit) {
+    return (
+      <div style={{ ...mono, color: '#858585', marginBottom: 8 }}>
+        runtime audit unavailable · lifecycle/run claims remain unproved
+      </div>
+    );
+  }
+  const guiProjection = runtimeAudit.surfaceProjections.gui;
+  return (
+    <section style={{ marginBottom: 12 }}>
+      <div style={{ ...mono, color: '#4ec9b0' }}>
+        shared runtime audit · {guiProjection.runtimeAuditRoot}
+      </div>
+      <div style={{ ...mono, color: '#858585', marginTop: 4 }}>
+        lifecycle/work/history: {guiProjection.registryStateRoot} ·{' '}
+        {guiProjection.historyRoot}
+      </div>
+      <div style={{ ...mono, color: '#858585', marginTop: 4 }}>
+        evidence: {runtimeAudit.evidence.length} · recovery:{' '}
+        {String(runtimeAudit.recovery.verdict ?? 'unproved')}
+      </div>
+      <div style={{ ...mono, color: '#858585', marginTop: 4 }}>
+        run/work: {String(runtimeAudit.scope.runId ?? '-')} ·{' '}
+        {String(runtimeAudit.scope.workRef ?? '-')}
+      </div>
+      <RuntimeSkillDetails skills={runtimeAudit.skills} />
+      <RuntimeEvidenceDetails evidence={runtimeAudit.evidence} />
+      <RuntimeRecoveryDetails runtimeAudit={runtimeAudit} />
+    </section>
+  );
+}
+
 function SkillManagerViewComponent({ shell }: KfxViewProps) {
   const view =
     asSkillManagerView(shell.info.skillManager) ??
@@ -130,7 +266,6 @@ function SkillManagerViewComponent({ shell }: KfxViewProps) {
   }
 
   const runtimeAudit = view.runtimeAudit;
-  const guiProjection = runtimeAudit?.surfaceProjections.gui;
 
   return (
     <section style={panelStyle}>
@@ -141,103 +276,7 @@ function SkillManagerViewComponent({ shell }: KfxViewProps) {
       <div style={{ ...mono, color: '#6a6a6a', marginBottom: 8 }}>
         registry: {view.registry.root}
       </div>
-      {runtimeAudit ? (
-        <section style={{ marginBottom: 12 }}>
-          <div style={{ ...mono, color: '#4ec9b0' }}>
-            shared runtime audit · {guiProjection.runtimeAuditRoot}
-          </div>
-          <div style={{ ...mono, color: '#858585', marginTop: 4 }}>
-            lifecycle/work/history: {guiProjection.registryStateRoot} ·{' '}
-            {guiProjection.historyRoot}
-          </div>
-          <div style={{ ...mono, color: '#858585', marginTop: 4 }}>
-            evidence: {runtimeAudit.evidence.length} · recovery:{' '}
-            {String(runtimeAudit.recovery.verdict ?? 'unproved')}
-          </div>
-          <div style={{ ...mono, color: '#858585', marginTop: 4 }}>
-            run/work: {String(runtimeAudit.scope.runId ?? '-')} ·{' '}
-            {String(runtimeAudit.scope.workRef ?? '-')}
-          </div>
-          {runtimeAudit.skills.map((value, index) => {
-            const skill = record(value);
-            const identity = record(skill.identity);
-            const proof = record(skill.proof);
-            return (
-              <details
-                key={`${String(identity.key ?? 'skill')}:${index}`}
-                style={{ ...mono, marginTop: 6 }}
-              >
-                <summary style={{ color: '#9cdcfe' }}>
-                  {String(identity.key ?? 'unknown')}@
-                  {String(identity.revision ?? '?')} ·{' '}
-                  {String(skill.lifecycle ?? 'unproved')} ·{' '}
-                  {compact(skill.observedStates)}
-                </summary>
-                <div style={{ color: '#858585', marginLeft: 12 }}>
-                  identity: content={String(identity.contentRoot ?? '-')} ·
-                  definition={String(identity.definitionRoot ?? '-')} · class=
-                  {String(identity.class ?? '-')}
-                </div>
-                <div style={{ color: '#858585', marginLeft: 12 }}>
-                  Work bindings: {compact(skill.workBindings)}
-                </div>
-                <div style={{ color: '#858585', marginLeft: 12 }}>
-                  dependencies/trust/authorization:{' '}
-                  {compact(skill.dependencies)}
-                </div>
-                <div style={{ color: '#858585', marginLeft: 12 }}>
-                  receipts/history proof: {String(proof.status ?? 'unproved')} ·{' '}
-                  {compact(proof.roots)} · preserved=
-                  {String(skill.historyPreserved ?? false)}
-                </div>
-              </details>
-            );
-          })}
-          <details style={{ ...mono, marginTop: 6 }}>
-            <summary style={{ color: '#ce9178' }}>
-              audit, dependency, trust, authorization, and receipt evidence
-            </summary>
-            {runtimeAudit.evidence.map((value) => {
-              const evidence = record(value);
-              const source = record(evidence.source);
-              const proof = record(evidence.proof);
-              return (
-                <div
-                  key={`${String(evidence.runId ?? '-')}:${String(evidence.workRef ?? '-')}:${String(evidence.skillKey ?? '-')}:${String(evidence.state ?? 'unproved')}:${String(source.type ?? '-')}:${compact(proof.roots)}`}
-                  style={{ color: '#858585', marginLeft: 12 }}
-                >
-                  {String(evidence.state ?? 'unproved')} ·{' '}
-                  {String(evidence.skillKey ?? '-')} · run=
-                  {String(evidence.runId ?? '-')} · Work=
-                  {String(evidence.workRef ?? '-')} · source=
-                  {String(source.type ?? '-')} ·{' '}
-                  {String(proof.status ?? 'unproved')}: {compact(proof.roots)} ·{' '}
-                  {compact(evidence.detail)}
-                </div>
-              );
-            })}
-          </details>
-          <details style={{ ...mono, marginTop: 6 }}>
-            <summary style={{ color: '#dcdcaa' }}>recovery and history</summary>
-            <div style={{ color: '#858585', marginLeft: 12 }}>
-              roots: registry={guiProjection.registryStateRoot} · history=
-              {guiProjection.historyRoot} · diagnosis=
-              {guiProjection.diagnosisRoot}
-            </div>
-            <div style={{ color: '#858585', marginLeft: 12 }}>
-              audit={compact(guiProjection.auditRoots)} · dependency=
-              {compact(guiProjection.dependencyRoots)}
-            </div>
-            <div style={{ color: '#858585', marginLeft: 12 }}>
-              recovery: {compact(runtimeAudit.recovery)}
-            </div>
-          </details>
-        </section>
-      ) : (
-        <div style={{ ...mono, color: '#858585', marginBottom: 8 }}>
-          runtime audit unavailable · lifecycle/run claims remain unproved
-        </div>
-      )}
+      <RuntimeAuditSection runtimeAudit={runtimeAudit} />
       {view.skills.length === 0 ? (
         <div style={{ ...mono, color: '#6a6a6a' }}>no installed skills</div>
       ) : (

--- a/framework/site/src/kfx-site-impact-proofs/250d324ca7457168ae695b63d2e41c36c790964a717be4e6ce653344ece25685.json
+++ b/framework/site/src/kfx-site-impact-proofs/250d324ca7457168ae695b63d2e41c36c790964a717be4e6ce653344ece25685.json
@@ -1,0 +1,67 @@
+{
+  "contract": "kungfu.kfx-site-impact-proof/v1",
+  "baseRevision": "15b8f4d1dc82c5d41eb96b04ba15e5e056022ad8",
+  "changeRoot": "sha256:4401075949f204a8915b272c4338db255fcd969b6477c582d69e015289064921",
+  "changes": [
+    {
+      "baseContentRoot": "sha256:f05e240098bb19a6a07468acfb225533835be3f2fbf8e6f91657c6d5288f5d86",
+      "contentRoot": "sha256:9e7ac22a1c6cf4c5c766ca5daddf564b93c36a5c4abfbfbbe2c1eec057948404",
+      "path": ".buildchain/kfd/kfd-2/release-claims.json",
+      "status": "modified"
+    },
+    {
+      "baseContentRoot": "sha256:177e801c1a85c52b0e885473d373b008f1b849f56cf25c4f877e2f061acf69ae",
+      "contentRoot": "sha256:bc69c12da4305d51ead2ddd757518467bd1745678a426faba2f333800e20b3a5",
+      "path": ".buildchain/kfd/kfd-3/collaboration-interface.prebuild.json",
+      "status": "modified"
+    },
+    {
+      "baseContentRoot": "sha256:c68fc16aeb2306f574d4ef85bfcd47b16a75d95a5db4702dab6a8b60e76cf098",
+      "contentRoot": "sha256:e8b601b7c0654c7bfc7a94374e1b514cac5244519c36c6ebb6a1a4b0904a7c56",
+      "path": ".buildchain/kfd/support-matrix.json",
+      "status": "modified"
+    },
+    {
+      "baseContentRoot": "sha256:f05e240098bb19a6a07468acfb225533835be3f2fbf8e6f91657c6d5288f5d86",
+      "contentRoot": "sha256:9e7ac22a1c6cf4c5c766ca5daddf564b93c36a5c4abfbfbbe2c1eec057948404",
+      "path": "developer/sdk/kfd/kfd-2/release-claims.json",
+      "status": "modified"
+    },
+    {
+      "baseContentRoot": "sha256:c68fc16aeb2306f574d4ef85bfcd47b16a75d95a5db4702dab6a8b60e76cf098",
+      "contentRoot": "sha256:e8b601b7c0654c7bfc7a94374e1b514cac5244519c36c6ebb6a1a4b0904a7c56",
+      "path": "developer/sdk/kfd/support-matrix.json",
+      "status": "modified"
+    },
+    {
+      "baseContentRoot": "sha256:016c67c42618df951be534502108fdbde6b6ee35538094287d7dc10d754bb638",
+      "contentRoot": "sha256:43594189454b9b6ccb5942cc77a9628bd950d20ff6da8d3b8ec9b18d19f79df4",
+      "path": "extensions/system/kfx-manager/src/view/index.tsx",
+      "status": "modified"
+    },
+    {
+      "baseContentRoot": "sha256:a0fa463f1b4c9f303f22407446a0537616f9a5c63c815e892bedcdd3a70f8784",
+      "contentRoot": "sha256:5ed49cb2abd811f02181e2bd525087d515f3cd748ddf2789b8d35d11b1aa4e7b",
+      "path": "extensions/system/settings/src/view/index.tsx",
+      "status": "modified"
+    },
+    {
+      "baseContentRoot": "sha256:c46e24bb31a915f29676bfa588e8adf04085104bc7ae0fbb47367e3817cf2c87",
+      "contentRoot": "sha256:129a5adf4870a0d04e2b9d36f3991cf9ceacd5ade7d29a64f33dc087228165cf",
+      "path": "extensions/system/skill-manager/src/view/index.tsx",
+      "status": "modified"
+    }
+  ],
+  "affectedFacets": [
+    "capabilities",
+    "package-facets",
+    "profiles-suites"
+  ],
+  "rationale": "Wave 5 product UI refactor changes view composition only; generated KFD evidence refresh does not alter the KFX Site Bundle contract or shipped facets.",
+  "attestation": {
+    "publicBehaviorUnchanged": true,
+    "publicContractUnchanged": true,
+    "readerJourneyUnchanged": true
+  },
+  "proofRoot": "sha256:250d324ca7457168ae695b63d2e41c36c790964a717be4e6ce653344ece25685"
+}

--- a/framework/site/src/kfx-site-impact-proofs/c96144d58e9223e5a40a3111453809cdd3e4c2dc12cce3552795248b23794687.json
+++ b/framework/site/src/kfx-site-impact-proofs/c96144d58e9223e5a40a3111453809cdd3e4c2dc12cce3552795248b23794687.json
@@ -1,0 +1,67 @@
+{
+  "contract": "kungfu.kfx-site-impact-proof/v1",
+  "baseRevision": "15b8f4d1dc82c5d41eb96b04ba15e5e056022ad8",
+  "changeRoot": "sha256:98c51fdbfa0d89c8cd3ee927ca11427613ff29269a4ea6040d44c90af4c95c9b",
+  "changes": [
+    {
+      "baseContentRoot": "sha256:f05e240098bb19a6a07468acfb225533835be3f2fbf8e6f91657c6d5288f5d86",
+      "contentRoot": "sha256:ecbefe2be49b08116ccf07446ea5b4e6cf997e45fb65607196191ea90b2343d4",
+      "path": ".buildchain/kfd/kfd-2/release-claims.json",
+      "status": "modified"
+    },
+    {
+      "baseContentRoot": "sha256:177e801c1a85c52b0e885473d373b008f1b849f56cf25c4f877e2f061acf69ae",
+      "contentRoot": "sha256:12258746cb6f8ec8bc45c338ecd241fa5fa253cf7493a28eec4555ba755b8eab",
+      "path": ".buildchain/kfd/kfd-3/collaboration-interface.prebuild.json",
+      "status": "modified"
+    },
+    {
+      "baseContentRoot": "sha256:c68fc16aeb2306f574d4ef85bfcd47b16a75d95a5db4702dab6a8b60e76cf098",
+      "contentRoot": "sha256:027ae922826169d6b996aa3d59e6fdf4022eb7ee75e0f5af78a08d653a8ffa47",
+      "path": ".buildchain/kfd/support-matrix.json",
+      "status": "modified"
+    },
+    {
+      "baseContentRoot": "sha256:f05e240098bb19a6a07468acfb225533835be3f2fbf8e6f91657c6d5288f5d86",
+      "contentRoot": "sha256:ecbefe2be49b08116ccf07446ea5b4e6cf997e45fb65607196191ea90b2343d4",
+      "path": "developer/sdk/kfd/kfd-2/release-claims.json",
+      "status": "modified"
+    },
+    {
+      "baseContentRoot": "sha256:c68fc16aeb2306f574d4ef85bfcd47b16a75d95a5db4702dab6a8b60e76cf098",
+      "contentRoot": "sha256:027ae922826169d6b996aa3d59e6fdf4022eb7ee75e0f5af78a08d653a8ffa47",
+      "path": "developer/sdk/kfd/support-matrix.json",
+      "status": "modified"
+    },
+    {
+      "baseContentRoot": "sha256:016c67c42618df951be534502108fdbde6b6ee35538094287d7dc10d754bb638",
+      "contentRoot": "sha256:43594189454b9b6ccb5942cc77a9628bd950d20ff6da8d3b8ec9b18d19f79df4",
+      "path": "extensions/system/kfx-manager/src/view/index.tsx",
+      "status": "modified"
+    },
+    {
+      "baseContentRoot": "sha256:a0fa463f1b4c9f303f22407446a0537616f9a5c63c815e892bedcdd3a70f8784",
+      "contentRoot": "sha256:5ed49cb2abd811f02181e2bd525087d515f3cd748ddf2789b8d35d11b1aa4e7b",
+      "path": "extensions/system/settings/src/view/index.tsx",
+      "status": "modified"
+    },
+    {
+      "baseContentRoot": "sha256:c46e24bb31a915f29676bfa588e8adf04085104bc7ae0fbb47367e3817cf2c87",
+      "contentRoot": "sha256:129a5adf4870a0d04e2b9d36f3991cf9ceacd5ade7d29a64f33dc087228165cf",
+      "path": "extensions/system/skill-manager/src/view/index.tsx",
+      "status": "modified"
+    }
+  ],
+  "affectedFacets": [
+    "capabilities",
+    "package-facets",
+    "profiles-suites"
+  ],
+  "rationale": "Decompose internal product view composition without changing public site declarations, routes, or behavior.",
+  "attestation": {
+    "publicBehaviorUnchanged": true,
+    "publicContractUnchanged": true,
+    "readerJourneyUnchanged": true
+  },
+  "proofRoot": "sha256:c96144d58e9223e5a40a3111453809cdd3e4c2dc12cce3552795248b23794687"
+}


### PR DESCRIPTION
Summary:
- Decompose KFX manager, settings, and skill manager view controllers into cohesive rendering and state responsibilities without changing public behavior or contracts.
- Reduce corrected product-view aggregate baseRisk: KfxManagerView 613 to 573, SettingsView 524 to 501, SkillManagerView 392 to 305.
- Reduce the corrected inventory from 23 to 20 functions above baseRisk 300 and from 331 to 330 functions above baseRisk 100.
- Rebase onto protected dev/v4/v4.0@15b8f4d1 and regenerate KFD evidence to a fixed point; this successor replaces conflict-stopped PR #3541 without rewriting its branch.

Validation:
- ./shifu check:staged
- KUNGFU_SDK_ENTRY=developer/sdk/src/sdk.js package builds for kfx-view-kfx-manager, kfx-view-settings, and kfx-view-skill-manager
- ./shifu check:source (Node 1192 passed, 11 skipped; Python work-state 40 passed; runtime upgrade 143 passed; desktop update 73 passed)
- Function-risk report root: sha256:93645580c52c79daf8343b47043dbbfbc769aa7d4542a1a80189b9b7844b2cd4

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Reduce product view composition risk without changing an ADR record, product architecture, or public contract"
}
-->

Signed-off-by: Codex <dongkeren+codex@kungfu.link>