### PR TITLE
fix(ci): admit exact fork delivery sources

### DIFF
--- a/.github/workflows/dev-pr-auto-merge.yml
+++ b/.github/workflows/dev-pr-auto-merge.yml
@@ -197,11 +197,26 @@ jobs:
           source_workflow_run_id=""
           if [ "$EVENT_NAME" = "workflow_run" ] && [ "$WORKFLOW_EVENT" = "pull_request" ]; then
             pr_count="$(jq -r 'if type == "array" then length else -1 end' <<<"$WORKFLOW_PULL_REQUESTS")"
-            if [ "$pr_count" != "1" ]; then
+            if [ "$pr_count" = "1" ]; then
+              expected_pr_number="$(jq -r '.[0].number' <<<"$WORKFLOW_PULL_REQUESTS")"
+            elif [ "$pr_count" = "0" ]; then
+              associated_prs="$(gh api \
+                -H 'Accept: application/vnd.github+json' \
+                "repos/$GITHUB_REPOSITORY/commits/$WORKFLOW_HEAD_SHA/pulls?per_page=100")"
+              matches="$(jq -c \
+                --arg branch "$DEFAULT_BRANCH" \
+                --arg head "$WORKFLOW_HEAD_SHA" \
+                '[.[] | select(.state == "open" and .base.ref == $branch and .head.sha == $head)]' \
+                <<<"$associated_prs")"
+              if [ "$(jq -r 'length' <<<"$matches")" != "1" ]; then
+                echo "workflow_run fork fallback must resolve to exactly one open pull request" >&2
+                exit 1
+              fi
+              expected_pr_number="$(jq -r '.[0].number' <<<"$matches")"
+            else
               echo "workflow_run must resolve to exactly one pull request; got: $pr_count" >&2
               exit 1
             fi
-            expected_pr_number="$(jq -r '.[0].number' <<<"$WORKFLOW_PULL_REQUESTS")"
             expected_head_sha="$WORKFLOW_HEAD_SHA"
             source_workflow_run_id="$WORKFLOW_RUN_ID"
           elif [ "$EVENT_NAME" = "pull_request_target" ] || [ "$EVENT_NAME" = "pull_request_review" ]; then
@@ -339,7 +354,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: kungfu-systems/buildchain
-          ref: cd8318d57b0506493114afcc63b9aacef741d3c4
+          ref: fcad6198e03ab5c52ecd6b7485a18c7a6a6380c1
           path: .buildchain/dev-delivery-runtime
           fetch-depth: 1
           persist-credentials: false
@@ -371,10 +386,12 @@ jobs:
           SOURCE_RUN_ID: ${{ needs.resolve-target.outputs.source-workflow-run-id }}
           EXPECTED_PR: ${{ needs.resolve-target.outputs.expected-pr-number }}
           EXPECTED_HEAD: ${{ needs.resolve-target.outputs.expected-head-sha }}
+          TARGET_BRANCH: ${{ needs.resolve-target.outputs.target-branch }}
         run: |
           set -euo pipefail
           mkdir -p .buildchain/dev-delivery-input
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID" > .buildchain/dev-delivery-input/source-workflow-run.json
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$EXPECTED_PR" > .buildchain/dev-delivery-input/source-pull-request.json
           jq -e \
             --argjson run "$SOURCE_RUN_ID" \
             --argjson pullRequest "$EXPECTED_PR" \
@@ -385,9 +402,18 @@ jobs:
              and .event == "pull_request"
              and .status == "completed"
              and .head_sha == $head
-             and (.pull_requests | length) == 1
-             and .pull_requests[0].number == $pullRequest' \
+             and (((.pull_requests | length) == 1 and .pull_requests[0].number == $pullRequest)
+                  or (.pull_requests | length) == 0)' \
             .buildchain/dev-delivery-input/source-workflow-run.json >/dev/null
+          jq -e \
+            --argjson pullRequest "$EXPECTED_PR" \
+            --arg head "$EXPECTED_HEAD" \
+            --arg branch "$TARGET_BRANCH" \
+            '.number == $pullRequest
+             and .head.sha == $head
+             and .base.ref == $branch
+             and .state == "open"' \
+            .buildchain/dev-delivery-input/source-pull-request.json >/dev/null
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID/jobs?filter=latest&per_page=100" \
             > .buildchain/dev-delivery-input/source-workflow-jobs.json
           jq -e \
@@ -640,9 +666,9 @@ jobs:
       contents: write
       pull-requests: write
       statuses: write
-    uses: kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@cd8318d57b0506493114afcc63b9aacef741d3c4
+    uses: kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@fcad6198e03ab5c52ecd6b7485a18c7a6a6380c1
     with:
-      buildchain-ref: cd8318d57b0506493114afcc63b9aacef741d3c4
+      buildchain-ref: fcad6198e03ab5c52ecd6b7485a18c7a6a6380c1
       target-branch: ${{ needs.resolve-target.outputs.target-branch }}
       expected-pr-number: ${{ fromJSON(needs.resolve-target.outputs.expected-pr-number || '0') }}
       expected-head-sha: ${{ needs.resolve-target.outputs.expected-head-sha }}
@@ -686,7 +712,7 @@ jobs:
       block-labels: state/blocked,blocked,do-not-merge,work-in-progress
       allowed-head-prefixes: feature/,fix/,chore/,docs/,ci/,refactor/
       require-approval: true
-      same-repository-only: true
+      same-repository-only: false
       max-merges: 1
       merge-method: rebase
       landing-mode: queue
@@ -979,9 +1005,9 @@ jobs:
       contents: write
       pull-requests: write
       statuses: write
-    uses: kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@cd8318d57b0506493114afcc63b9aacef741d3c4
+    uses: kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@fcad6198e03ab5c52ecd6b7485a18c7a6a6380c1
     with:
-      buildchain-ref: cd8318d57b0506493114afcc63b9aacef741d3c4
+      buildchain-ref: fcad6198e03ab5c52ecd6b7485a18c7a6a6380c1
       target-branch: ${{ needs.resolve-target.outputs.target-branch }}
       expected-pr-number: ${{ fromJSON(needs.resolve-target.outputs.expected-pr-number) }}
       expected-head-sha: ${{ needs.resolve-target.outputs.expected-head-sha }}
@@ -1025,7 +1051,7 @@ jobs:
       block-labels: state/blocked,blocked,do-not-merge,work-in-progress
       allowed-head-prefixes: feature/,fix/,chore/,docs/,ci/,refactor/
       require-approval: true
-      same-repository-only: true
+      same-repository-only: false
       max-merges: 1
       merge-method: rebase
       landing-mode: queue

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -631,9 +631,9 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:f718b2523f8bb1698477ffda93a210f7e1f9ef691a07e6e350a5ebee33ade38d",
+          "definitionDigest": "sha256:7ed9278bad1a2e307d188b56cab46ca4acd1d68104b5d11551c8ee457b5f4edf",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@cd8318d57b0506493114afcc63b9aacef741d3c4"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@fcad6198e03ab5c52ecd6b7485a18c7a6a6380c1"],
           "steps": []
         },
         {
@@ -641,19 +641,19 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:0af94f9f68768f18c8ce15e560a3ffce071406917505e9808e6598a67bab8f40",
+          "definitionDigest": "sha256:96b230de714a34a4871fd1d3b2848e76c371ffe8c43093ec5d1203f558e75014",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
-          "steps": [{"index":1,"label":"name:Check out protected consumer adapter","definitionDigest":"sha256:7a6e2b7a4219bc394a436c2b5c62af8c7e88a4ee217160392af47145517ded7e"},{"index":2,"label":"name:Check out exact Buildchain delivery runtime","authority":"evidence-publication","definitionDigest":"sha256:2ebf0ccffe55c5956044ed1b3ec452ffb40dcd149e41f29c5cc771d330fe6e34"},{"index":3,"label":"name:Use Node.js 24 for exact delivery proof","definitionDigest":"sha256:9a97d7c7a2267e05fe44eeb809814e7bf942ee5e9ac9b9471b9bde0e6be2c9a4"},{"index":4,"label":"name:Install exact Buildchain delivery runtime","authority":"evidence-publication","definitionDigest":"sha256:71ee76abd8d8d888d22ecd9ba4ea9c53746220b18a08f6431df9ac3f18948eb7"},{"index":5,"label":"name:Verify exact source qualification run","authority":"evidence-publication","definitionDigest":"sha256:8bafb626bf0e8a52d6bf1b7eeaa06d7bc5f10e851050e471e67d369d5c1e03da"},{"index":6,"label":"name:Download exact source qualification descriptor","authority":"evidence-publication","definitionDigest":"sha256:5c13a140aea8777e4749d8259cf091f804756e2b76ee35f00521d750c974429e"},{"index":7,"label":"id:contract","definitionDigest":"sha256:10d761264755f395be38654bf8df8d8d437d4972f631f5473a0c500f36c92bf5"},{"index":8,"label":"id:environment","authority":"evidence-publication","definitionDigest":"sha256:1714619b30678c461679e56bf5095bcbf66e71ba5a3ae12b929b967d0d3d71c1"},{"index":9,"label":"id:native-proof-artifact","authority":"evidence-publication","definitionDigest":"sha256:e6838b7eaad71c254944023a84d79a1c8b702c199bfaf305d7b922a6de3ce62e"},{"index":10,"label":"id:native-proof","definitionDigest":"sha256:f0bb5876cda8f809acc590b2fe37251ce13e1f23d4c2b8749f5cc37bfd8c8411"},{"index":11,"label":"id:project-cut","authority":"evidence-publication","definitionDigest":"sha256:ad91e14cd423a17c99cc037c1a3a15f85bbcdcbf3d0b8e487556f6f98f48c3e0"},{"index":12,"label":"name:Upload exact Warrant input projection","authority":"evidence-publication","definitionDigest":"sha256:374066139a234c9aa55cfffa25084b2938d17d83c6d14c62429fabef79a57bd8"}]
+          "steps": [{"index":1,"label":"name:Check out protected consumer adapter","definitionDigest":"sha256:7a6e2b7a4219bc394a436c2b5c62af8c7e88a4ee217160392af47145517ded7e"},{"index":2,"label":"name:Check out exact Buildchain delivery runtime","authority":"evidence-publication","definitionDigest":"sha256:f7c4afe6acd9a10d2e638fe21c28074166c2aa959bef976a59cee45661c309a0"},{"index":3,"label":"name:Use Node.js 24 for exact delivery proof","definitionDigest":"sha256:9a97d7c7a2267e05fe44eeb809814e7bf942ee5e9ac9b9471b9bde0e6be2c9a4"},{"index":4,"label":"name:Install exact Buildchain delivery runtime","authority":"evidence-publication","definitionDigest":"sha256:71ee76abd8d8d888d22ecd9ba4ea9c53746220b18a08f6431df9ac3f18948eb7"},{"index":5,"label":"name:Verify exact source qualification run","authority":"evidence-publication","definitionDigest":"sha256:64973e0d598fa1daf60b04031319955bb4b6929c99e6b3a47b4244ecc3b940e1"},{"index":6,"label":"name:Download exact source qualification descriptor","authority":"evidence-publication","definitionDigest":"sha256:5c13a140aea8777e4749d8259cf091f804756e2b76ee35f00521d750c974429e"},{"index":7,"label":"id:contract","definitionDigest":"sha256:10d761264755f395be38654bf8df8d8d437d4972f631f5473a0c500f36c92bf5"},{"index":8,"label":"id:environment","authority":"evidence-publication","definitionDigest":"sha256:1714619b30678c461679e56bf5095bcbf66e71ba5a3ae12b929b967d0d3d71c1"},{"index":9,"label":"id:native-proof-artifact","authority":"evidence-publication","definitionDigest":"sha256:e6838b7eaad71c254944023a84d79a1c8b702c199bfaf305d7b922a6de3ce62e"},{"index":10,"label":"id:native-proof","definitionDigest":"sha256:f0bb5876cda8f809acc590b2fe37251ce13e1f23d4c2b8749f5cc37bfd8c8411"},{"index":11,"label":"id:project-cut","authority":"evidence-publication","definitionDigest":"sha256:ad91e14cd423a17c99cc037c1a3a15f85bbcdcbf3d0b8e487556f6f98f48c3e0"},{"index":12,"label":"name:Upload exact Warrant input projection","authority":"evidence-publication","definitionDigest":"sha256:374066139a234c9aa55cfffa25084b2938d17d83c6d14c62429fabef79a57bd8"}]
         },
         {
           "id": "landing",
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:f5120f5865afb708f95fbb46c91144b26bfd9dcfb2d0acded2eb16bf1f1999af",
+          "definitionDigest": "sha256:da605df2c6c2c3a145c2cb65f28d5eac05fb0fb7fb9d4aede549a1bbb7f07e3e",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
-          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@cd8318d57b0506493114afcc63b9aacef741d3c4"],
+          "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@fcad6198e03ab5c52ecd6b7485a18c7a6a6380c1"],
           "steps": []
         },
         {
@@ -671,10 +671,10 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:e2731ad63ed7091c09f783186f989ebff9d5dd1c92cbbe6b82f80a1a2f577adf",
+          "definitionDigest": "sha256:513f996de00ae992a01101b2b707a58ad4081f35f1e8c4af9bee81850b358721",
           "credentials": {"githubToken":"read","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": [],
-          "steps": [{"index":1,"label":"id:target","definitionDigest":"sha256:1c7ea6422b20eea8233e9cbef19d34ee59af90fb8b3356f4553f0deae2b83368"}]
+          "steps": [{"index":1,"label":"id:target","definitionDigest":"sha256:34db525b038d513393e5c37cdf2cee4029df30b625bcf657ae74338b62aa188f"}]
         }
       ]
     },

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -198,7 +198,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:558cad14ca9f65a1c2b5570061b15e822226099061325a9c6e2365dab048eac9"
+          "sourceRoot": "sha256:0e3af8874440d2f846c7b9c276c8691a0c500c735753eea9060c5b1933265cfe"
         },
         {
           "path": ".github/workflows/dev-gate-latency-patrol.yml",
@@ -877,5 +877,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:db4ea497b8aa79218835a7f612993a6a241a967fe0b1e76782bf403227777fe1"
+  "registryRoot": "sha256:cbe6395a6a03e5b0dd1ef83eeff74cfe62205c81f76058207063c48b0848c5c4"
 }

--- a/scripts/dev-pr-auto-merge.test.mjs
+++ b/scripts/dev-pr-auto-merge.test.mjs
@@ -15,11 +15,11 @@ const workflow = fs.readFileSync(
 const steadyStateDogfoodFixturePath =
   'framework/core/tests/fixtures/dev-delivery-warrant-steady-state.json';
 
-test('Dev auto-merge admits only explicitly ready reviewed same-repository PRs', () => {
+test('Dev auto-merge admits only explicitly ready reviewed source-bound PRs', () => {
   const reusableRef = workflow.match(
     /uses: kungfu-systems\/buildchain\/\.github\/workflows\/dev-pr-auto-merge\.yml@([0-9a-f]{40})/u,
   )?.[1];
-  assert.equal(reusableRef, 'cd8318d57b0506493114afcc63b9aacef741d3c4');
+  assert.equal(reusableRef, 'fcad6198e03ab5c52ecd6b7485a18c7a6a6380c1');
   assert.match(workflow, new RegExp(`buildchain-ref: ${reusableRef}`, 'u'));
   assert.match(workflow, /workflow_run:[\s\S]*Core affected native/u);
   assert.match(
@@ -39,7 +39,7 @@ test('Dev auto-merge admits only explicitly ready reviewed same-repository PRs',
     /allowed-head-prefixes: feature\/,fix\/,chore\/,docs\/,ci\/,refactor\//u,
   );
   assert.match(workflow, /require-approval: true/u);
-  assert.match(workflow, /same-repository-only: true/u);
+  assert.match(workflow, /same-repository-only: false/u);
   assert.match(workflow, /max-merges: 1/u);
 });
 
@@ -89,6 +89,10 @@ test('Dev Agent admission binds every targeted run to one exact PR head', () => 
   );
   assert.match(
     workflow,
+    /commits\/\$WORKFLOW_HEAD_SHA\/pulls\?per_page=100[\s\S]*\.state == "open"[\s\S]*\.base\.ref == \$branch[\s\S]*\.head\.sha == \$head[\s\S]*fork fallback must resolve to exactly one open pull request/u,
+  );
+  assert.match(
+    workflow,
     /expected-pr-number and expected-head-sha must be provided together/u,
   );
   assert.match(
@@ -101,7 +105,7 @@ test('Dev Agent admission binds every targeted run to one exact PR head', () => 
   );
   assert.match(
     workflow,
-    /Verify exact source qualification run[\s\S]*\.name == "Core affected native"[\s\S]*\.path == "\.github\/workflows\/affected-native-pr\.yml"[\s\S]*\.head_sha == \$head[\s\S]*\.pull_requests\[0\]\.number == \$pullRequest/u,
+    /Verify exact source qualification run[\s\S]*\.name == "Core affected native"[\s\S]*\.path == "\.github\/workflows\/affected-native-pr\.yml"[\s\S]*\.head_sha == \$head[\s\S]*\.pull_requests\[0\]\.number == \$pullRequest[\s\S]*\(\.pull_requests \| length\) == 0[\s\S]*source-pull-request\.json[\s\S]*\.head\.sha == \$head[\s\S]*\.base\.ref == \$branch[\s\S]*\.state == "open"/u,
   );
   assert.match(
     workflow,
@@ -315,7 +319,7 @@ test('Qualified native proof re-runs the exact failed source jobs before landing
   );
   assert.match(
     landing,
-    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/dev-pr-auto-merge\.yml@cd8318d57b0506493114afcc63b9aacef741d3c4/u,
+    /uses: kungfu-systems\/buildchain\/\.github\/workflows\/dev-pr-auto-merge\.yml@fcad6198e03ab5c52ecd6b7485a18c7a6a6380c1/u,
   );
   assert.match(landing, /queue-admission-context: Queue admission lease/u);
   assert.match(landing, /landing-mode: queue[\s\S]*dry-run: false/u);
@@ -347,7 +351,7 @@ test('Dev behind admission produces and forwards an exact Project Cut replay pro
   );
   assert.match(
     workflow,
-    /Check out exact Buildchain delivery runtime[\s\S]*ref: cd8318d57b0506493114afcc63b9aacef741d3c4/u,
+    /Check out exact Buildchain delivery runtime[\s\S]*ref: fcad6198e03ab5c52ecd6b7485a18c7a6a6380c1/u,
   );
   assert.match(
     workflow,


### PR DESCRIPTION
## Summary

- resolve fork `workflow_run` sources through exactly one open PR bound to the exact head and protected base
- verify the source PR independently when GitHub omits `workflow_run.pull_requests`
- pin the merged Buildchain dev-delivery stateRoot fix and admit fork heads without weakening exact-source checks

## Validation

- `./shifu test:alpha-promotion-preflight` (103 passed)
- `./shifu check:source`

Goal: `2026-08-28-kungfu-installed-product-reliability-convergence`

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded delivery-controller compatibility fix preserves the existing protected delivery and architecture contracts while restoring exact fork source resolution."
}
-->
