### PR TITLE
fix(buildchain): admit KFD replay through project cut

### DIFF
--- a/scripts/source-acceptance-git.test.mjs
+++ b/scripts/source-acceptance-git.test.mjs
@@ -10,11 +10,104 @@ import { test } from 'node:test';
 import { resolveCompositionBase } from './check-project-cut-composition-gate.mjs';
 import {
   fetchSourceAcceptanceCommit,
+  findGitTreeEquivalentAncestor,
   readSourceAcceptanceGit,
   sourceAcceptanceMergeBaseCandidates,
   sourceAcceptancePlan,
   sourceMergeGroupBase,
 } from './source-acceptance.mjs';
+
+test('KFD replay traverses only a composition-preserving Project Cut', (t) => {
+  const repository = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-kfd-project-cut-replay-'),
+  );
+  t.after(() => fs.rmSync(repository, { recursive: true, force: true }));
+  const gitRead = (args) => readSourceAcceptanceGit(args, { cwd: repository });
+  gitRead(['init', '--quiet']);
+  gitRead(['config', 'user.name', 'KFD Fixture']);
+  gitRead(['config', 'user.email', 'kfd-fixture@kungfu.invalid']);
+  fs.writeFileSync(path.join(repository, 'base.txt'), 'base\n');
+  gitRead(['add', 'base.txt']);
+  gitRead(['commit', '--quiet', '-m', 'shared base']);
+  const sharedBase = gitRead(['rev-parse', 'HEAD']);
+
+  gitRead(['switch', '--quiet', '-c', 'kfd-source']);
+  fs.writeFileSync(
+    path.join(repository, 'runtime.txt'),
+    'semantic authority\n',
+  );
+  gitRead(['add', 'runtime.txt']);
+  gitRead(['commit', '--quiet', '-m', 'original KFD source']);
+  const sourceSha = gitRead(['rev-parse', 'HEAD']);
+
+  gitRead(['switch', '--quiet', '-c', 'dev', sharedBase]);
+  gitRead(['cherry-pick', '--quiet', sourceSha]);
+  const protectedReplay = gitRead(['rev-parse', 'HEAD']);
+  fs.writeFileSync(
+    path.join(repository, 'work-design.txt'),
+    'install closure\n',
+  );
+  gitRead(['add', 'work-design.txt']);
+  gitRead(['commit', '--quiet', '-m', 'later dev work']);
+  const developmentHead = gitRead(['rev-parse', 'HEAD']);
+
+  gitRead(['switch', '--quiet', '-c', 'alpha', sharedBase]);
+  fs.writeFileSync(path.join(repository, 'alpha.txt'), 'previous release\n');
+  gitRead(['add', 'alpha.txt']);
+  gitRead(['commit', '--quiet', '-m', 'protected alpha']);
+  const alphaHead = gitRead(['rev-parse', 'HEAD']);
+  const cutSha = gitRead([
+    'commit-tree',
+    `${developmentHead}^{tree}`,
+    '-p',
+    alphaHead,
+    '-p',
+    developmentHead,
+    '-m',
+    'composition-preserving Project Cut',
+  ]);
+  const syntheticHead = gitRead([
+    'commit-tree',
+    `${cutSha}^{tree}`,
+    '-p',
+    alphaHead,
+    '-p',
+    cutSha,
+    '-m',
+    'synthetic protected merge',
+  ]);
+  assert.equal(
+    findGitTreeEquivalentAncestor(sourceSha, syntheticHead, gitRead),
+    protectedReplay,
+  );
+
+  fs.writeFileSync(path.join(repository, 'changed.txt'), 'changed cut tree\n');
+  gitRead(['add', 'changed.txt']);
+  const changedCut = gitRead([
+    'commit-tree',
+    gitRead(['write-tree']),
+    '-p',
+    alphaHead,
+    '-p',
+    developmentHead,
+    '-m',
+    'changed Project Cut',
+  ]);
+  const changedSyntheticHead = gitRead([
+    'commit-tree',
+    `${changedCut}^{tree}`,
+    '-p',
+    alphaHead,
+    '-p',
+    changedCut,
+    '-m',
+    'synthetic changed merge',
+  ]);
+  assert.equal(
+    findGitTreeEquivalentAncestor(sourceSha, changedSyntheticHead, gitRead),
+    '',
+  );
+});
 
 test('Project Cut composition uses the exact merge-group base without ancestry', () => {
   const baseSha = 'a'.repeat(40);

--- a/scripts/source-acceptance.mjs
+++ b/scripts/source-acceptance.mjs
@@ -495,6 +495,33 @@ export function findGitTreeEquivalentAncestor(
   );
   if (treeMatch) return treeMatch;
 
+  // A qualified Project Cut is itself a two-parent composition commit: its
+  // first parent is the protected release base and its second parent is the
+  // protected development head, while its tree is exactly the development
+  // tree. GitHub then wraps that cut in the synthetic PR merge inspected
+  // above. Admit a retained exact-tree replay from the development chain only
+  // when every edge and tree in that nested topology is unchanged. An
+  // ordinary merge, a differently based cut, or a composed/conflict-resolved
+  // cut cannot enter this path.
+  const [cutSha, cutBaseParent, cutDevelopmentParent, ...cutExtraParents] =
+    gitRead(['rev-list', '--parents', '-n', '1', candidateParent])
+      .trim()
+      .split(/\s+/u);
+  if (
+    cutSha === candidateParent &&
+    cutBaseParent === baseParent &&
+    cutDevelopmentParent &&
+    cutExtraParents.length === 0 &&
+    gitRead(['rev-parse', `${cutDevelopmentParent}^{tree}`]) === candidateTree
+  ) {
+    const projectCutTreeMatch = findFirstParentTreeEquivalent(
+      sourceTree,
+      cutDevelopmentParent,
+      gitRead,
+    );
+    if (projectCutTreeMatch) return projectCutTreeMatch;
+  }
+
   // A protected base may advance in unrelated paths while GitHub exactly
   // replays the candidate's Project Cut. The whole trees then differ even
   // though the cumulative binary patch is byte-for-byte identical. Admit only


### PR DESCRIPTION
## Summary

Recognize an exact protected KFD source replay when the GitHub synthetic pull-request merge wraps the existing two-parent Project Cut topology.

## Related issue

Follow-up to the Work Design Alpha.4 release qualification exposed by #3563.

## Changes

- Traverse the Project Cut second-parent development chain only when the synthetic merge, protected base, cut parents, and candidate tree satisfy the strict composition-preserving topology.
- Keep ordinary merges, different bases, and changed-tree Project Cuts ineligible.
- Add real temporary-Git positive and negative regression coverage.

## Verification

- `./shifu check:source`
- Source check includes the isolated Work Design App assembly, Python wheel, installed-product preflight, dependency-closure, missing-dependency, manual-capture, read-only, and cross-platform path tests.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This Buildchain source-acceptance fix recognizes an exact protected KFD replay through the existing composition-preserving Project Cut topology without changing an architecture contract or weakening ordinary merge admission."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

The change is confined to Buildchain source-acceptance topology and is verified by exact-tree positive and changed-tree negative Git graph tests plus the full source gate.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
- [x] Tests added or updated
- [x] `./shifu check:source` passes
