### PR TITLE
fix(release): bind KFD source gates to runner platform

### DIFF
--- a/framework/release/kfd-candidate-evidence.mjs
+++ b/framework/release/kfd-candidate-evidence.mjs
@@ -23,6 +23,13 @@ export const KFD_ARTIFACT_WITNESS_JSONS = SUPPORTED_KFD_PLATFORMS.map(
   (platform) => `product/release/qualification/kfd/artifacts/${platform}.json`,
 );
 
+const GITHUB_RUNNER_PLATFORM_IDS = new Map([
+  ['Linux:X64', 'linux-x64'],
+  ['Linux:ARM64', 'linux-arm64'],
+  ['macOS:ARM64', 'macos-arm64'],
+  ['Windows:X64', 'windows-x64'],
+]);
+
 const SOURCE_GATE_INPUTS = [
   '.buildchain/kfd/kfd-1/contract-world.witness.json',
   '.buildchain/kfd/kfd-1/documentation-pack.witness.json',
@@ -109,6 +116,36 @@ function sha256File(filePath) {
 
 function rooted(value) {
   return `sha256:${sha256(canonicalJson(value))}`;
+}
+
+export function resolveKfdSourcePlatform(
+  explicitPlatform = '',
+  env = process.env,
+) {
+  const platform =
+    explicitPlatform ||
+    env.BUILDCHAIN_PLATFORM_ID ||
+    env['INPUT_PLATFORM-ID'] ||
+    '';
+  if (platform) {
+    assertPlatform(platform);
+    return platform;
+  }
+  const runnerOs = env.RUNNER_OS || '';
+  const runnerArch = env.RUNNER_ARCH || '';
+  if (!runnerOs && !runnerArch) return '';
+  if (!runnerOs || !runnerArch) {
+    throw new Error(
+      `incomplete GitHub runner platform identity: RUNNER_OS=${runnerOs || '<empty>'}, RUNNER_ARCH=${runnerArch || '<empty>'}`,
+    );
+  }
+  const inferred = GITHUB_RUNNER_PLATFORM_IDS.get(`${runnerOs}:${runnerArch}`);
+  if (!inferred) {
+    throw new Error(
+      `unsupported GitHub runner platform identity: RUNNER_OS=${runnerOs}, RUNNER_ARCH=${runnerArch}`,
+    );
+  }
+  return inferred;
 }
 
 export function kfdEvidenceRoot(value) {
@@ -239,11 +276,9 @@ export function sealKfdSourceEvidence({
   expectedInputRoot = '',
   sourceSha = '',
   sourceTree = '',
-  platform = process.env.BUILDCHAIN_PLATFORM_ID ||
-    process.env['INPUT_PLATFORM-ID'] ||
-    '',
+  platform = '',
 } = {}) {
-  if (platform) assertPlatform(platform);
+  platform = resolveKfdSourcePlatform(platform);
   const prebuild = createKfdPrebuildGate({ root, sourceSha, sourceTree });
   if (expectedInputRoot && prebuild.inputRoot !== expectedInputRoot) {
     throw new Error(

--- a/scripts/kfd-candidate-evidence.test.mjs
+++ b/scripts/kfd-candidate-evidence.test.mjs
@@ -12,6 +12,7 @@ import {
   finalizeKfdCandidateEvidence,
   kfdEvidenceRoot,
   prepareKfdArtifactWitness,
+  resolveKfdSourcePlatform,
   runVerifiedQualification,
   verifyKfdCandidatePayloadSet,
   verifyKfdManifestSet,
@@ -19,6 +20,70 @@ import {
 
 const SOURCE_SHA = 'a'.repeat(40);
 const SOURCE_TREE = 'b'.repeat(40);
+
+test('resolves KFD source platforms from explicit Buildchain identities', () => {
+  assert.equal(
+    resolveKfdSourcePlatform('macos-arm64', {
+      BUILDCHAIN_PLATFORM_ID: 'linux-x64',
+      RUNNER_OS: 'Linux',
+      RUNNER_ARCH: 'X64',
+    }),
+    'macos-arm64',
+  );
+  assert.equal(
+    resolveKfdSourcePlatform('', {
+      BUILDCHAIN_PLATFORM_ID: 'linux-arm64',
+      RUNNER_OS: 'Linux',
+      RUNNER_ARCH: 'X64',
+    }),
+    'linux-arm64',
+  );
+  assert.equal(
+    resolveKfdSourcePlatform('', {
+      'INPUT_PLATFORM-ID': 'windows-x64',
+      RUNNER_OS: 'Linux',
+      RUNNER_ARCH: 'X64',
+    }),
+    'windows-x64',
+  );
+});
+
+test('infers every supported KFD source platform from GitHub runner identity', () => {
+  const cases = [
+    ['Linux', 'X64', 'linux-x64'],
+    ['Linux', 'ARM64', 'linux-arm64'],
+    ['macOS', 'ARM64', 'macos-arm64'],
+    ['Windows', 'X64', 'windows-x64'],
+  ];
+  for (const [runnerOs, runnerArch, expected] of cases) {
+    assert.equal(
+      resolveKfdSourcePlatform('', {
+        RUNNER_OS: runnerOs,
+        RUNNER_ARCH: runnerArch,
+      }),
+      expected,
+    );
+  }
+});
+
+test('keeps non-runner source sealing platform-neutral', () => {
+  assert.equal(resolveKfdSourcePlatform('', {}), '');
+});
+
+test('rejects incomplete or unsupported GitHub runner platform identity', () => {
+  assert.throws(
+    () => resolveKfdSourcePlatform('', { RUNNER_OS: 'Linux' }),
+    /incomplete GitHub runner platform identity/u,
+  );
+  assert.throws(
+    () =>
+      resolveKfdSourcePlatform('', {
+        RUNNER_OS: 'macOS',
+        RUNNER_ARCH: 'X64',
+      }),
+    /unsupported GitHub runner platform identity/u,
+  );
+});
 
 function writeJson(filePath, value) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });


### PR DESCRIPTION
## Summary

- infer the KFD source-evidence platform from standard GitHub runner identity when Buildchain has not exported a platform id yet
- fail closed for incomplete or unsupported runner identity while preserving platform-neutral local sealing
- cover all four supported runner mappings and precedence rules

## Root cause

The reusable Buildchain install lifecycle invokes the KFD source gate before BUILDCHAIN_PLATFORM_ID is available. Alpha.4 release-cut PR #3575 therefore sealed platform-neutral evidence on Linux x64, and the build later rejected it because the required linux-x64 witness was absent.

## Verification

- targeted KFD candidate suite: 13/13
- release promotion rehearsal: 25/25
- production-shape Linux/X64 seal resolves linux-x64 and passes the KFD evidence check
- full ./shifu check:source: passed (Node 1205 tests, Python 40 + 143 + 73, TypeScript and Biome)
- cold read-only source check: byte-identical before/after

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded bug fix corrects platform identity propagation for an existing KFD release-evidence gate; it does not alter an architecture contract or weaken any release authority."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] none of the above

This PR changes only how the existing KFD evidence sealer derives its already-required platform witness.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation remains accurate; behavior and tests are self-contained

No Work Design, Assignment, Project Cut, or release gate is weakened.