### PR TITLE
fix(agent): preserve external WorkRef profile projection

### DIFF
--- a/framework/core/src/python/kungfu/agent/session_surface.py
+++ b/framework/core/src/python/kungfu/agent/session_surface.py
@@ -240,20 +240,18 @@ def _active_work_profiles(work_ref):
     return [{"id": work_ref["profileId"], "root": work_ref["profileRoot"]}]
 
 
-def _qualified_active_work_profiles(runtime_dir, work_ref):
+def _project_active_work_profiles(runtime_dir, work_ref):
+    """Project the bound Work authority or this Console's unbound discovery."""
+
+    if work_ref is not None:
+        validated = session_contract.validate_work_ref(work_ref)
+        return _active_work_profiles(validated)
+
     from kungfu.assignment_runtime import profile_lifecycle
 
     profile = profile_lifecycle.resolve_qualified_work_profile(
         runtime_dir, required=False
     )
-    if work_ref is not None and (
-        profile is None
-        or work_ref.get("profileId") != profile["id"]
-        or work_ref.get("profileRoot") != profile["root"]
-    ):
-        raise ValueError(
-            "native Agent WorkRef does not match the exact qualified Work Control Profile root"
-        )
     return (
         [{"id": profile["id"], "root": profile["root"]}] if profile is not None else []
     )
@@ -275,7 +273,7 @@ def _console_envelope_work_projection(envelope, *, enabled):
 def _console_work_projection(runtime_dir, work_ref, *, enabled):
     if not enabled:
         return [], None
-    return _qualified_active_work_profiles(runtime_dir, work_ref), work_ref
+    return _project_active_work_profiles(runtime_dir, work_ref), work_ref
 
 
 class ReturnCodeResult(Protocol):

--- a/framework/core/tests/python/test_agent_console_ambient_adoption.py
+++ b/framework/core/tests/python/test_agent_console_ambient_adoption.py
@@ -240,6 +240,73 @@ def test_current_native_console_can_project_identity_without_stale_work_binding(
     session_contract.validate_agent_console_envelope(current["envelope"])
 
 
+def test_current_native_console_preserves_bound_external_work_profile(
+    monkeypatch, tmp_path
+):
+    project = tmp_path / "console-project"
+    runtime = project / ".kungfu" / "runtime"
+    runtime.mkdir(parents=True)
+    target = SimpleNamespace(
+        identity=SimpleNamespace(
+            workspace_kind="project",
+            identity_state="qualified",
+            workspace_root=str(project),
+            workspace_id="project:console",
+        ),
+        runtime_dir=str(runtime),
+    )
+    monkeypatch.setattr(
+        session_surface, "resolve_workspace_target", lambda *_a, **_k: target
+    )
+    work_ref = {
+        "schema": "kungfu.work-ref/v1",
+        "workspaceId": "project:work",
+        "profileId": "kungfu.work-control",
+        "profileRoot": ROOT_HASH,
+        "entityType": "assignment",
+        "entityId": "assignment:external",
+        "entityRoot": "sha256:" + "c" * 64,
+        "purpose": "continue-project-assignment",
+        "systemTimeCut": "sha256:" + "d" * 64,
+        "initiativeId": "initiative:external",
+    }
+    monkeypatch.setattr(
+        "kungfu.assignment_runtime.profile_lifecycle.resolve_qualified_work_profile",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("bound Work projection must not rediscover Console Profile")
+        ),
+    )
+    identity = process_identity()
+    identity_root = session_contract.semantic_root(identity)
+
+    def invoke(request):
+        assert request["operation"] == "show"
+        return {
+            "lifecycleState": "running",
+            "binding": {"kind": "work", "workRef": work_ref},
+            "attempt": {
+                "provider": "codex",
+                "observer": {"processIdentityRoot": identity_root},
+            },
+        }
+
+    current = session_surface.current_native_console(
+        str(runtime),
+        adopt=False,
+        cwd=str(project),
+        environ={"KUNGFU_CLI_BIN": "/exact/kungfu"},
+        process_identity=identity,
+        session_invoker=invoke,
+    )
+
+    assert current["envelope"]["workspaceId"] == "project:console"
+    assert current["envelope"]["workRef"] == work_ref
+    assert current["envelope"]["activeProfiles"] == [
+        {"id": "kungfu.work-control", "root": ROOT_HASH}
+    ]
+    session_contract.validate_agent_console_envelope(current["envelope"])
+
+
 def test_public_bind_work_cli_adopts_current_codex_process(monkeypatch, tmp_path):
     envelope = console_envelope()
     calls = []


### PR DESCRIPTION
## Summary

Deliver fix(agent): preserve external WorkRef profile projection from fix/work-ref-console-profile-projection into dev/v4/v4.0 through the kungfu-systems dual-account PR flow.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This maintenance delivery does not alter an architecture decision."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)