### PR TITLE
fix(runtime): track split CLI surface owner

### DIFF
--- a/scripts/check-runtime-surface-integration.mjs
+++ b/scripts/check-runtime-surface-integration.mjs
@@ -52,7 +52,7 @@ for (const relative of Object.values(fixture.surfaces)) {
 
 for (const relative of [
   fixture.surfaces.python,
-  fixture.surfaces.cli,
+  fixture.surfaces.cliOwner,
   fixture.surfaces.node,
   fixture.surfaces.libkungfuTypes,
   fixture.surfaces.gui,
@@ -64,6 +64,18 @@ for (const relative of [
     `surface does not expose the shared product status: ${relative}`,
   );
 }
+
+const cliFacade = read(fixture.surfaces.cliFacade);
+assert.match(
+  cliFacade,
+  /from kungfu\.cli\.commands\._runtime\.base import \(/,
+  'stable CLI facade does not re-export the runtime command owner',
+);
+assert.match(
+  cliFacade,
+  /_plain_status as _plain_status/,
+  'stable CLI facade does not preserve the shared product-status renderer',
+);
 
 const guiMain = read('framework/gui/src/main/index.ts');
 for (const command of fixture.ordinaryLifecycleCommands) {

--- a/tests/fixtures/runtime-surface-integration/cases.json
+++ b/tests/fixtures/runtime-surface-integration/cases.json
@@ -3,7 +3,8 @@
   "productStatusSchema": "kungfu.runtime.product-status/v1",
   "surfaces": {
     "python": "framework/core/src/python/kungfu/runtime_broker.py",
-    "cli": "framework/core/src/python/kungfu/cli/commands/runtime.py",
+    "cliOwner": "framework/core/src/python/kungfu/cli/commands/_runtime/base.py",
+    "cliFacade": "framework/core/src/python/kungfu/cli/commands/runtime.py",
     "node": "framework/api/src/capability/runtime.ts",
     "libkungfuTypes": "framework/core/lib/kungfu.d.ts",
     "gui": "framework/gui/src/runtime-status.ts",


### PR DESCRIPTION
## Summary

- bind runtime-surface parity to the split CLI implementation owner
- retain the stable public CLI facade as an independently checked compatibility surface
- preserve the shared product-status renderer across the facade boundary

## Root cause

The runtime lifecycle decomposition moved the product-status implementation from `kungfu.cli.commands.runtime` to `kungfu.cli.commands._runtime.base`, while the release parity fixture still treated the stable facade as the implementation owner. Full Alpha.4 Build therefore failed after product assembly and product runtime smoke had already passed.

## Verification

- `./shifu test:runtime-surface`: passed, 7/7 tests
- `./shifu check:source`: passed, including 1206 Node tests, 40 Python source tests, 143 runtime-upgrade tests, and 73 desktop-update tests
- the parity gate now checks both the real owner and the facade re-export relationship

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bounded bug fix updates stale verification ownership after an already-landed runtime decomposition; it does not change runtime semantics or weaken a release gate."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] none of the above

This PR strengthens the existing release parity proof by distinguishing implementation ownership from compatibility exposure.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation remains accurate; behavior and tests are self-contained

No Work Design, Assignment, Project Cut, or release gate is weakened.