### PR TITLE
fix(agent): resolve desktop session transport

### DIFF
--- a/framework/agent-session/src/capsule-transport-runtime.mjs
+++ b/framework/agent-session/src/capsule-transport-runtime.mjs
@@ -13,6 +13,43 @@ export class CapsuleTransportUnavailableError extends Error {
   }
 }
 
+export function capsuleNodePtyCandidates({
+  modulePath,
+  registryPath,
+  bundleDirectory = path.dirname(fileURLToPath(import.meta.url)),
+} = {}) {
+  return [
+    modulePath ? path.resolve(modulePath) : null,
+    registryPath
+      ? path.join(
+          path.dirname(path.dirname(path.resolve(registryPath))),
+          'agent-session-support',
+          'node-pty',
+          'lib',
+          'index.js',
+        )
+      : null,
+    path.join(bundleDirectory, 'node_modules', 'node-pty', 'lib', 'index.js'),
+    path.join(
+      bundleDirectory,
+      '..',
+      'node_modules',
+      'node-pty',
+      'lib',
+      'index.js',
+    ),
+    path.join(
+      bundleDirectory,
+      '..',
+      'app',
+      'node_modules',
+      'node-pty',
+      'lib',
+      'index.js',
+    ),
+  ];
+}
+
 export function createCapsuleNodePtyLoader({
   modulePath = process.env.KUNGFU_AGENT_SESSION_NODE_PTY_MODULE,
   registryPath = process.env.KUNGFU_AGENT_SESSION_REGISTRY,
@@ -21,33 +58,7 @@ export function createCapsuleNodePtyLoader({
   let loaded = null;
   return () => {
     if (loaded) return loaded;
-    const candidates = [
-      modulePath ? path.resolve(modulePath) : null,
-      registryPath
-        ? path.join(
-            path.dirname(path.dirname(path.resolve(registryPath))),
-            'agent-session-support',
-            'node-pty',
-            'lib',
-            'index.js',
-          )
-        : null,
-      path.join(
-        path.dirname(fileURLToPath(import.meta.url)),
-        'node_modules',
-        'node-pty',
-        'lib',
-        'index.js',
-      ),
-      path.join(
-        path.dirname(fileURLToPath(import.meta.url)),
-        '..',
-        'node_modules',
-        'node-pty',
-        'lib',
-        'index.js',
-      ),
-    ];
+    const candidates = capsuleNodePtyCandidates({ modulePath, registryPath });
     try {
       candidates.push(moduleRequire.resolve('node-pty/lib/index.js'));
     } catch {}

--- a/framework/agent-session/tests/capsule-transport-runtime.test.mjs
+++ b/framework/agent-session/tests/capsule-transport-runtime.test.mjs
@@ -10,6 +10,7 @@ import { setTimeout as delay } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
 import {
   CapsuleTransportUnavailableError,
+  capsuleNodePtyCandidates,
   createCapsuleNodePtyLoader,
 } from '../src/capsule-transport-runtime.mjs';
 import { detachedAgentSessionPaths } from '../src/product-client.mjs';
@@ -119,6 +120,22 @@ test('Capsule node-pty resolution is lazy and reports an optional capability', (
     },
   );
   assert.equal(resolveCalls, 1);
+});
+
+test('Capsule node-pty resolution includes the signed desktop app layout', () => {
+  assert.deepEqual(
+    capsuleNodePtyCandidates({
+      bundleDirectory:
+        '/Applications/Kungfu Episodes.app/Contents/Resources/tui',
+    }),
+    [
+      null,
+      null,
+      '/Applications/Kungfu Episodes.app/Contents/Resources/tui/node_modules/node-pty/lib/index.js',
+      '/Applications/Kungfu Episodes.app/Contents/Resources/node_modules/node-pty/lib/index.js',
+      '/Applications/Kungfu Episodes.app/Contents/Resources/app/node_modules/node-pty/lib/index.js',
+    ],
+  );
 });
 
 test('the detached control core starts without node-pty for native sessions', async () => {


### PR DESCRIPTION
## Summary

Deliver fix(agent): resolve desktop session transport from fix/installed-agent-session-node-pty-r13 into dev/v4/v4.0 through the kungfu-systems dual-account PR flow.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This maintenance delivery does not alter an architecture decision."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)