### PR TITLE
fix(release): verify sealed artifacts without repacking

### DIFF
--- a/framework/release/kfd-candidate-evidence.mjs
+++ b/framework/release/kfd-candidate-evidence.mjs
@@ -652,7 +652,10 @@ export function runVerifiedQualification({
   fs.renameSync(output, sealed);
   const result = spawnSync(command[0], command.slice(1), {
     cwd: root,
-    env: process.env,
+    env: {
+      ...process.env,
+      KUNGFU_VERIFY_PREBUILT_RELEASE_ARTIFACTS: '1',
+    },
     stdio: 'inherit',
   });
   fs.rmSync(output, { recursive: true, force: true });

--- a/scripts/kfd-candidate-evidence.test.mjs
+++ b/scripts/kfd-candidate-evidence.test.mjs
@@ -243,7 +243,7 @@ test('the Verify wrapper restores pre-qualification evidence after qualification
   const command = [
     process.execPath,
     '-e',
-    `const fs=require('node:fs');fs.rmSync(${JSON.stringify(qualification)},{recursive:true,force:true});fs.mkdirSync(${JSON.stringify(qualification)},{recursive:true});fs.writeFileSync(${JSON.stringify(path.join(qualification, 'qualification-passed.json'))},'{}\\n')`,
+    `const fs=require('node:fs');if(process.env.KUNGFU_VERIFY_PREBUILT_RELEASE_ARTIFACTS!=='1')process.exit(23);fs.rmSync(${JSON.stringify(qualification)},{recursive:true,force:true});fs.mkdirSync(${JSON.stringify(qualification)},{recursive:true});fs.writeFileSync(${JSON.stringify(path.join(qualification, 'qualification-passed.json'))},'{}\\n')`,
   ];
   assert.equal(
     runVerifiedQualification({

--- a/scripts/run-layer-artifact-gate.mjs
+++ b/scripts/run-layer-artifact-gate.mjs
@@ -10,7 +10,10 @@ import { writeShifuGateEvidence } from './shifu-gate-evidence.mjs';
 const ROOT = path.resolve(import.meta.dirname, '..');
 const REPORT_ROOT = path.join(ROOT, 'product', 'release', 'qualification');
 
-export function layerArtifactStages(layer) {
+export function layerArtifactStages(
+  layer,
+  { usePrebuiltArtifacts = false } = {},
+) {
   const definitions = {
     format: [
       ['pack:spec'],
@@ -42,7 +45,9 @@ export function layerArtifactStages(layer) {
   };
   if (!definitions[layer])
     throw new Error(`unknown layer artifact Gate '${layer}'`);
-  return definitions[layer];
+  return usePrebuiltArtifacts
+    ? definitions[layer].slice(1)
+    : definitions[layer];
 }
 
 function reportFile(layer) {
@@ -54,7 +59,9 @@ export function runLayerArtifactGate(
   layer,
   { run = runShifuWithCache, env = process.env } = {},
 ) {
-  for (const args of layerArtifactStages(layer)) {
+  const usePrebuiltArtifacts =
+    env.KUNGFU_VERIFY_PREBUILT_RELEASE_ARTIFACTS === '1';
+  for (const args of layerArtifactStages(layer, { usePrebuiltArtifacts })) {
     const status = run(args, { env });
     if (status !== 0) return status;
   }

--- a/scripts/run-layer-artifact-gate.test.mjs
+++ b/scripts/run-layer-artifact-gate.test.mjs
@@ -35,3 +35,43 @@ test('artifact Gate fails closed and does not advance after a failed stage', () 
   assert.equal(status, 17);
   assert.deepEqual(calls, [['pack:sdk']]);
 });
+
+test('KFD Verify qualifies sealed release artifacts without repacking them', () => {
+  const calls = [];
+  const status = runLayerArtifactGate('sdk', {
+    run(args) {
+      calls.push(args);
+      return 0;
+    },
+    env: { KUNGFU_VERIFY_PREBUILT_RELEASE_ARTIFACTS: '1' },
+  });
+  assert.equal(status, 0);
+  assert.deepEqual(calls, [
+    [
+      'layers:qualify:sdk',
+      '--',
+      '--report',
+      'product/release/qualification/layer-sdk-report.json',
+    ],
+  ]);
+});
+
+test('prebuilt-artifact qualification still fails closed without a pack fallback', () => {
+  const calls = [];
+  const status = runLayerArtifactGate('surfaces', {
+    run(args) {
+      calls.push(args);
+      return 23;
+    },
+    env: { KUNGFU_VERIFY_PREBUILT_RELEASE_ARTIFACTS: '1' },
+  });
+  assert.equal(status, 23);
+  assert.deepEqual(calls, [
+    [
+      'layers:qualify:surfaces',
+      '--',
+      '--report',
+      'product/release/qualification/layer-surface-report.json',
+    ],
+  ]);
+});


### PR DESCRIPTION
## Summary

- make KFD-wrapped Verify qualify the exact sealed release artifacts without rerunning pack stages
- preserve the default direct layer artifact Gate as pack + qualify
- keep missing or invalid prebuilt artifacts fail-closed with no repack fallback

## Validation

- focused release tests: 48/48
- ./shifu check:source
- Node: 1206 tests, 1195 pass, 11 declared skips, 0 fail
- Python: 40/40; runtime upgrade: 143/143; desktop: 73/73
- TypeScript and Biome checks pass

<!-- kungfu-adr-release:v1
{"schema":"kungfu.adr-release-pr/v1","kind":"adr-neutral","reason":"This release-path bugfix preserves existing artifact identities and KFD fail-closed authority; it does not change product architecture or public contracts."}
-->

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA4LTI2LWt1bmdmdS13b3JrLWRlc2lnbi1pbnN0YWxsLWNsb3N1cmUiLCJkZWxpdmVyeUNsYXNzIjoid29yay1kZXNpZ24taW5zdGFsbC1jbG9zdXJlIiwiZGV2SGVhZCI6ImQ2MDUyY2YyYTE3MjRkMTk1NWE4NGIzM2U1MWIzODVjMzhmNmVlMjciLCJwdWxsUmVxdWVzdEhlYWQiOiJlZmFjMDhmNWEzMGM5ODFhOGQzNDRlNmYyZjI3ZGUzZjkwODMzYTE5IiwicmVwbGF5ZWRDYW5kaWRhdGUiOiJlNDhjYzgzMDc1ZDJiOGU2YjVlNjRhYTAwZTQxYzM3OTE5ZjM5ZWYwIiwicmVwbGF5ZWRUcmVlIjoiMmNhNWU0ODhhMDVjY2YyMzE5MjE2NjEyOTdhYWUxYTllOWJiZjBiOSIsInF1ZXVlQXR0ZW1wdCI6ImVmYWMwOGY1YTMwYzk4MWE4ZDM0NGU2ZjJmMjdkZTNmOTA4MzNhMTlAZDYwNTJjZjJhMTcyNGQxOTU1YTg0YjMzZTUxYjM4NWMzOGY2ZWUyNyIsImFkbWlzc2lvblByb29mUm9vdCI6InNoYTI1NjpjMjI4ZWI5OWFlMDliMzMyNzhjZWExMDkwMGVlZTRmNzNhZjA1NjBlMTMwMTI5NGFhNTYyMjkxOWEyZGM4MWUxIiwiYWRtaXNzaW9uUHJvb2ZSb290cyI6WyJzaGEyNTY6MWYzNWI3NGM0YWUzMzQ1OThjZjdiNjI3NzM1NmRlMTIzYzdjMzIyNjA1OWU2YzdjN2NkYTUxZmUxMDhhZmNjNSIsInNoYTI1NjpjMjI4ZWI5OWFlMDliMzMyNzhjZWExMDkwMGVlZTRmNzNhZjA1NjBlMTMwMTI5NGFhNTYyMjkxOWEyZGM4MWUxIl0sInN0YXR1c0NvbnRleHQiOiJRdWV1ZSBmYW1pbHkgbGVhc2UvZDk5ZjNhOTE2NjczOWUwZCIsImxlYXNlUm9vdCI6InNoYTI1Njo3MjIwMGI4ZDM0MjZkOTE2YmE1MzkyMjI4NWMxNGJjNTY0NDY0NjYyMWE5MGU4NTkzMzU3NzcyOWE0MTBkNTk4In0 -->