### PR TITLE
fix(release): seal prebuilt layer artifacts for KFD verify

### DIFF
--- a/framework/release/kfd-candidate-evidence.mjs
+++ b/framework/release/kfd-candidate-evidence.mjs
@@ -23,6 +23,15 @@ export const KFD_ARTIFACT_WITNESS_JSONS = SUPPORTED_KFD_PLATFORMS.map(
   (platform) => `product/release/qualification/kfd/artifacts/${platform}.json`,
 );
 
+export const KFD_PREBUILT_LAYER_ARTIFACTS = {
+  format: 'product/release/spec',
+  sdk: 'framework/core/build/stage/sdk',
+  surfaces: 'product/release/npm',
+};
+
+const KFD_PREBUILT_LAYER_ARTIFACTS_CONTRACT =
+  'kungfu.kfd-prebuilt-layer-artifacts/v1';
+
 const GITHUB_RUNNER_PLATFORM_IDS = new Map([
   ['Linux:X64', 'linux-x64'],
   ['Linux:ARM64', 'linux-arm64'],
@@ -367,6 +376,94 @@ function listFiles(directory, relativeRoot) {
   return rows.sort((left, right) => left.path.localeCompare(right.path));
 }
 
+function prebuiltLayerArtifactRoot(root) {
+  return path.join(
+    root,
+    '.buildchain',
+    'runtime',
+    'kfd-candidate-evidence',
+    'prebuilt-layer-artifacts',
+  );
+}
+
+function prebuiltLayerArtifactManifest(root) {
+  return path.join(prebuiltLayerArtifactRoot(root), 'manifest.json');
+}
+
+function validatePrebuiltLayerEntry(root, layer, entry, sourceRoot) {
+  const expectedPath = KFD_PREBUILT_LAYER_ARTIFACTS[layer];
+  if (!expectedPath || entry?.path !== expectedPath) {
+    throw new Error(`invalid sealed KFD ${layer} layer artifact path`);
+  }
+  const artifactRoot = path.join(sourceRoot, expectedPath);
+  const files = listFiles(artifactRoot, artifactRoot);
+  if (files.length === 0) {
+    throw new Error(`missing sealed KFD ${layer} layer artifact files`);
+  }
+  if (entry.root !== rooted(files)) {
+    throw new Error(`sealed KFD ${layer} layer artifact digest mismatch`);
+  }
+  return { artifactRoot, files };
+}
+
+export function sealKfdPrebuiltLayerArtifacts({ root = process.cwd() } = {}) {
+  const output = prebuiltLayerArtifactRoot(root);
+  fs.rmSync(output, { recursive: true, force: true });
+  fs.mkdirSync(output, { recursive: true });
+  const layers = {};
+  for (const [layer, relativePath] of Object.entries(
+    KFD_PREBUILT_LAYER_ARTIFACTS,
+  )) {
+    const source = path.join(root, relativePath);
+    const files = listFiles(source, source);
+    if (files.length === 0) {
+      throw new Error(`missing prebuilt KFD ${layer} layer artifacts`);
+    }
+    const target = path.join(output, relativePath);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.cpSync(source, target, { recursive: true });
+    layers[layer] = { path: relativePath, root: rooted(files) };
+  }
+  const body = {
+    schema: KFD_PREBUILT_LAYER_ARTIFACTS_CONTRACT,
+    layers,
+  };
+  const manifest = { ...body, manifestRoot: rooted(body) };
+  writeJson(prebuiltLayerArtifactManifest(root), manifest);
+  return manifest;
+}
+
+export function restoreKfdPrebuiltLayerArtifact({
+  root = process.cwd(),
+  layer,
+} = {}) {
+  const manifestPath = prebuiltLayerArtifactManifest(root);
+  if (!fs.existsSync(manifestPath)) {
+    throw new Error('missing sealed KFD prebuilt layer artifact manifest');
+  }
+  const manifest = readJson(manifestPath);
+  const { manifestRoot, ...body } = manifest;
+  if (
+    manifest.schema !== KFD_PREBUILT_LAYER_ARTIFACTS_CONTRACT ||
+    manifestRoot !== rooted(body)
+  ) {
+    throw new Error('invalid sealed KFD prebuilt layer artifact manifest');
+  }
+  const entry = manifest.layers?.[layer];
+  const sealed = validatePrebuiltLayerEntry(
+    root,
+    layer,
+    entry,
+    prebuiltLayerArtifactRoot(root),
+  );
+  const target = path.join(root, entry.path);
+  fs.rmSync(target, { recursive: true, force: true });
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.cpSync(sealed.artifactRoot, target, { recursive: true });
+  validatePrebuiltLayerEntry(root, layer, entry, root);
+  return entry;
+}
+
 export function releaseArtifactRoot(root = process.cwd()) {
   const releaseDir = path.join(root, 'product', 'release');
   const rows = listFiles(releaseDir, releaseDir).filter(
@@ -631,7 +728,13 @@ export function runVerifiedQualification({
   sourceSha,
   sourceTree,
   buildArtifactWitness,
+  prepareReleaseArtifacts,
 }) {
+  const prepareStatus = prepareReleaseArtifacts?.();
+  if (prepareStatus !== undefined && prepareStatus !== 0) {
+    return prepareStatus || 1;
+  }
+  sealKfdPrebuiltLayerArtifacts({ root });
   prepareKfdArtifactWitness({
     root,
     platform,

--- a/scripts/kfd-candidate-evidence.mjs
+++ b/scripts/kfd-candidate-evidence.mjs
@@ -11,6 +11,7 @@ import {
   verifyKfdCandidatePayloadSet,
   verifyKfdManifestSet,
 } from '../framework/release/kfd-candidate-evidence.mjs';
+import { runShifuWithCache } from './run-shifu-lifecycle.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -50,6 +51,14 @@ function usage() {
 `;
 }
 
+function prepareReleaseArtifacts() {
+  for (const task of ['pack:spec', 'pack:sdk', 'pack:npm-release-inventory']) {
+    const status = runShifuWithCache([task], { root: ROOT });
+    if (status !== 0) return status;
+  }
+  return 0;
+}
+
 const { mode, options } = parse(process.argv.slice(2));
 let result;
 if (mode === 'source-check') {
@@ -85,6 +94,7 @@ if (mode === 'source-check') {
     platform: options.platform,
     sourceSha: options.sourceSha,
     sourceTree: options.sourceTree,
+    prepareReleaseArtifacts,
   });
   result = { ok: process.exitCode === 0 };
 } else if (mode === 'verify-manifest-set') {

--- a/scripts/kfd-candidate-evidence.test.mjs
+++ b/scripts/kfd-candidate-evidence.test.mjs
@@ -13,7 +13,9 @@ import {
   kfdEvidenceRoot,
   prepareKfdArtifactWitness,
   resolveKfdSourcePlatform,
+  restoreKfdPrebuiltLayerArtifact,
   runVerifiedQualification,
+  sealKfdPrebuiltLayerArtifacts,
   verifyKfdCandidatePayloadSet,
   verifyKfdManifestSet,
 } from '../framework/release/kfd-candidate-evidence.mjs';
@@ -185,6 +187,20 @@ function artifactFixture(platform = 'linux-x64') {
   return { root, platform, sourceSha, sourceTree };
 }
 
+function writePrebuiltLayerArtifacts(root) {
+  const artifacts = {
+    'product/release/spec/kungfu-spec.tgz': 'spec artifact\n',
+    'framework/core/build/stage/sdk/python/kungfu.whl': 'wheel artifact\n',
+    'product/release/npm/kungfu-core.tgz': 'npm artifact\n',
+  };
+  for (const [relativePath, content] of Object.entries(artifacts)) {
+    const target = path.join(root, relativePath);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, content);
+  }
+  return artifacts;
+}
+
 test('accepts a complete sealed four-platform KFD payload set', () => {
   const root = fixture();
   assert.deepEqual(
@@ -234,6 +250,7 @@ test('seals the artifact witness before qualification and the capsule after it',
 
 test('the Verify wrapper restores pre-qualification evidence after qualification cleanup', () => {
   const fixture = artifactFixture();
+  let prepared = 0;
   const qualification = path.join(
     fixture.root,
     'product',
@@ -249,6 +266,11 @@ test('the Verify wrapper restores pre-qualification evidence after qualification
     runVerifiedQualification({
       ...fixture,
       command,
+      prepareReleaseArtifacts() {
+        prepared += 1;
+        writePrebuiltLayerArtifacts(fixture.root);
+        return 0;
+      },
       buildArtifactWitness: () => ({
         id: 'kungfu-collaboration-interface',
         standard: 'kfd-3',
@@ -258,6 +280,7 @@ test('the Verify wrapper restores pre-qualification evidence after qualification
     }),
     0,
   );
+  assert.equal(prepared, 1);
   assert.equal(
     fs.existsSync(path.join(qualification, 'qualification-passed.json')),
     true,
@@ -265,6 +288,59 @@ test('the Verify wrapper restores pre-qualification evidence after qualification
   assert.equal(
     fs.existsSync(path.join(qualification, 'kfd', 'candidate-evidence.json')),
     true,
+  );
+});
+
+test('sealed prebuilt layer artifacts restore exact bytes and reject tampering', () => {
+  const fixture = artifactFixture();
+  const artifacts = writePrebuiltLayerArtifacts(fixture.root);
+  const manifest = sealKfdPrebuiltLayerArtifacts(fixture);
+  assert.equal(manifest.schema, 'kungfu.kfd-prebuilt-layer-artifacts/v1');
+  for (const layer of ['format', 'sdk', 'surfaces']) {
+    const relativePath = manifest.layers[layer].path;
+    fs.rmSync(path.join(fixture.root, relativePath), {
+      recursive: true,
+      force: true,
+    });
+    restoreKfdPrebuiltLayerArtifact({ ...fixture, layer });
+  }
+  for (const [relativePath, content] of Object.entries(artifacts)) {
+    assert.equal(
+      fs.readFileSync(path.join(fixture.root, relativePath), 'utf8'),
+      content,
+    );
+  }
+  const sealedWheel = path.join(
+    fixture.root,
+    '.buildchain/runtime/kfd-candidate-evidence/prebuilt-layer-artifacts',
+    'framework/core/build/stage/sdk/python/kungfu.whl',
+  );
+  fs.appendFileSync(sealedWheel, 'tampered\n');
+  assert.throws(
+    () => restoreKfdPrebuiltLayerArtifact({ ...fixture, layer: 'sdk' }),
+    /sealed KFD sdk layer artifact digest mismatch/u,
+  );
+});
+
+test('Verify stops before witnessing when release artifact materialization fails', () => {
+  const fixture = artifactFixture();
+  assert.equal(
+    runVerifiedQualification({
+      ...fixture,
+      command: [process.execPath, '-e', 'process.exit(0)'],
+      prepareReleaseArtifacts: () => 29,
+    }),
+    29,
+  );
+  assert.equal(
+    fs.existsSync(
+      path.join(
+        fixture.root,
+        'product/release/qualification/kfd/artifacts',
+        `${fixture.platform}.json`,
+      ),
+    ),
+    false,
   );
 });
 

--- a/scripts/run-layer-artifact-gate.mjs
+++ b/scripts/run-layer-artifact-gate.mjs
@@ -4,6 +4,7 @@
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
+import { restoreKfdPrebuiltLayerArtifact } from '../framework/release/kfd-candidate-evidence.mjs';
 import { runShifuWithCache } from './run-shifu-lifecycle.mjs';
 import { writeShifuGateEvidence } from './shifu-gate-evidence.mjs';
 
@@ -57,10 +58,15 @@ function reportFile(layer) {
 
 export function runLayerArtifactGate(
   layer,
-  { run = runShifuWithCache, env = process.env } = {},
+  {
+    run = runShifuWithCache,
+    env = process.env,
+    restore = restoreKfdPrebuiltLayerArtifact,
+  } = {},
 ) {
   const usePrebuiltArtifacts =
     env.KUNGFU_VERIFY_PREBUILT_RELEASE_ARTIFACTS === '1';
+  if (usePrebuiltArtifacts) restore({ root: ROOT, layer });
   for (const args of layerArtifactStages(layer, { usePrebuiltArtifacts })) {
     const status = run(args, { env });
     if (status !== 0) return status;

--- a/scripts/run-layer-artifact-gate.test.mjs
+++ b/scripts/run-layer-artifact-gate.test.mjs
@@ -38,14 +38,19 @@ test('artifact Gate fails closed and does not advance after a failed stage', () 
 
 test('KFD Verify qualifies sealed release artifacts without repacking them', () => {
   const calls = [];
+  const restored = [];
   const status = runLayerArtifactGate('sdk', {
     run(args) {
       calls.push(args);
       return 0;
     },
     env: { KUNGFU_VERIFY_PREBUILT_RELEASE_ARTIFACTS: '1' },
+    restore(options) {
+      restored.push(options.layer);
+    },
   });
   assert.equal(status, 0);
+  assert.deepEqual(restored, ['sdk']);
   assert.deepEqual(calls, [
     [
       'layers:qualify:sdk',
@@ -64,6 +69,7 @@ test('prebuilt-artifact qualification still fails closed without a pack fallback
       return 23;
     },
     env: { KUNGFU_VERIFY_PREBUILT_RELEASE_ARTIFACTS: '1' },
+    restore() {},
   });
   assert.equal(status, 23);
   assert.deepEqual(calls, [


### PR DESCRIPTION
## Summary

Deliver fix(release): seal prebuilt layer artifacts for KFD verify from fix/kfd-prebuilt-artifact-closure-alpha4 into dev/v4/v4.0 through the kungfu-systems dual-account PR flow.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This maintenance delivery does not alter an architecture decision."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)