### PR TITLE
fix(release): verify sealed product artifacts without rebuild

### DIFF
--- a/framework/core/tests/qualification/runtime-activation/run.mjs
+++ b/framework/core/tests/qualification/runtime-activation/run.mjs
@@ -116,6 +116,26 @@ export const SUITES = [
   },
 ];
 
+export function productDistributionCommand(env = process.env) {
+  if (env.KUNGFU_VERIFY_PREBUILT_RELEASE_ARTIFACTS !== '1')
+    return [LAUNCHER, 'dist'];
+  const expectedRoot = env.KUNGFU_VERIFY_PREBUILT_RELEASE_ARTIFACT_ROOT || '';
+  if (!/^sha256:[a-f0-9]{64}$/u.test(expectedRoot)) {
+    throw new Error(
+      'prebuilt product qualification requires an exact release artifact root',
+    );
+  }
+  return [
+    LAUNCHER,
+    'exec',
+    process.execPath,
+    'scripts/kfd-candidate-evidence.mjs',
+    'artifact-root-check',
+    '--expected-root',
+    expectedRoot,
+  ];
+}
+
 const COVERAGE = {
   'daemonless-storage': ['activation-core'],
   'direct-no-fork-coordinator': ['activation-core'],
@@ -198,12 +218,15 @@ export function sourceFacts() {
   };
 }
 
-export function qualificationPlan({ mode, withProduct }) {
+export function qualificationPlan({ mode, withProduct }, env = process.env) {
   return SUITES.map((suite) => {
     const required = !suite.product || withProduct;
     return {
       id: suite.id,
-      command: [...suite.command],
+      command:
+        suite.id === 'product-distribution'
+          ? productDistributionCommand(env)
+          : [...suite.command],
       required,
       status: mode === 'dry-run' ? 'planned' : required ? 'planned' : 'skipped',
       exit_code: null,

--- a/framework/core/tests/qualification/runtime-activation/run.test.mjs
+++ b/framework/core/tests/qualification/runtime-activation/run.test.mjs
@@ -18,6 +18,7 @@ import {
   defaultOutputDir,
   evaluateQualification,
   executeQualificationSuites,
+  productDistributionCommand,
   qualificationPlan,
   retainQualificationArtifacts,
   suiteEnvironment,
@@ -222,6 +223,31 @@ test('source qualification uv runs preserve the exact tracked lockfile', () => {
   for (const suite of uvSuites) {
     assert.ok(suite.command.includes('--frozen'), suite.id);
   }
+});
+
+test('sealed release qualification verifies the prebuilt product without rebuilding it', () => {
+  const root = `sha256:${'a'.repeat(64)}`;
+  const command = productDistributionCommand({
+    KUNGFU_VERIFY_PREBUILT_RELEASE_ARTIFACTS: '1',
+    KUNGFU_VERIFY_PREBUILT_RELEASE_ARTIFACT_ROOT: root,
+  });
+  assert.equal(command.includes('dist'), false);
+  assert.deepEqual(command.slice(-3), [
+    'artifact-root-check',
+    '--expected-root',
+    root,
+  ]);
+  assert.deepEqual(productDistributionCommand({}), [
+    process.platform === 'win32' ? 'shifu.cmd' : './shifu',
+    'dist',
+  ]);
+  assert.throws(
+    () =>
+      productDistributionCommand({
+        KUNGFU_VERIFY_PREBUILT_RELEASE_ARTIFACTS: '1',
+      }),
+    /requires an exact release artifact root/u,
+  );
 });
 
 test('only source-tree Python suites allow the hosted qualification interpreter', () => {

--- a/framework/release/kfd-candidate-evidence.mjs
+++ b/framework/release/kfd-candidate-evidence.mjs
@@ -475,6 +475,49 @@ export function releaseArtifactRoot(root = process.cwd()) {
   return { files: rows, root: rooted(rows) };
 }
 
+function releaseArtifactDelta(expectedFiles, actualFiles) {
+  const expected = new Map(
+    (expectedFiles || []).map((entry) => [entry.path, entry]),
+  );
+  const actual = new Map(
+    (actualFiles || []).map((entry) => [entry.path, entry]),
+  );
+  const added = [];
+  const removed = [];
+  const changed = [];
+  for (const artifactPath of [
+    ...new Set([...expected.keys(), ...actual.keys()]),
+  ].sort()) {
+    const before = expected.get(artifactPath);
+    const after = actual.get(artifactPath);
+    if (!before) added.push(artifactPath);
+    else if (!after) removed.push(artifactPath);
+    else if (before.bytes !== after.bytes || before.sha256 !== after.sha256)
+      changed.push(artifactPath);
+  }
+  return { added, removed, changed };
+}
+
+export function verifyReleaseArtifactRoot({
+  root = process.cwd(),
+  expectedRoot = '',
+  expectedFiles,
+} = {}) {
+  if (!/^sha256:[a-f0-9]{64}$/u.test(expectedRoot))
+    throw new Error('expected KFD release artifact root is missing or invalid');
+  const artifact = releaseArtifactRoot(root);
+  if (artifact.root === expectedRoot) return artifact;
+  const delta = expectedFiles
+    ? releaseArtifactDelta(expectedFiles, artifact.files)
+    : null;
+  const detail = delta
+    ? `; added=${delta.added.join(',') || '<none>'}; removed=${delta.removed.join(',') || '<none>'}; changed=${delta.changed.join(',') || '<none>'}`
+    : '';
+  throw new Error(
+    `KFD artifact digest mismatch: expected ${expectedRoot}, got ${artifact.root}${detail}`,
+  );
+}
+
 function assertPlatform(platform) {
   if (!SUPPORTED_KFD_PLATFORMS.includes(platform)) {
     throw new Error(
@@ -529,6 +572,7 @@ export function prepareKfdArtifactWitness({
     candidate: identity,
     sourceGateRoot: sourceGate.gateRoot,
     artifactRoot: artifact.root,
+    artifactFiles: artifact.files,
   };
   const witness = {
     ...baseWitness,
@@ -560,12 +604,11 @@ export function finalizeKfdCandidateEvidence({
   if (!fs.existsSync(witnessPath))
     throw new Error(`missing KFD artifact witness: ${platform}`);
   const witness = readJson(witnessPath);
-  const artifact = releaseArtifactRoot(root);
-  if (witness.candidateBinding?.artifactRoot !== artifact.root) {
-    throw new Error(
-      `KFD artifact digest mismatch: expected ${witness.candidateBinding?.artifactRoot || '<empty>'}, got ${artifact.root}`,
-    );
-  }
+  const artifact = verifyReleaseArtifactRoot({
+    root,
+    expectedRoot: witness.candidateBinding?.artifactRoot || '',
+    expectedFiles: witness.candidateBinding?.artifactFiles,
+  });
   if (
     witness.candidateBinding?.candidate?.sourceSha !== identity.sourceSha ||
     witness.candidateBinding?.candidate?.sourceTree !== identity.sourceTree ||
@@ -758,6 +801,8 @@ export function runVerifiedQualification({
     env: {
       ...process.env,
       KUNGFU_VERIFY_PREBUILT_RELEASE_ARTIFACTS: '1',
+      KUNGFU_VERIFY_PREBUILT_RELEASE_ARTIFACT_ROOT:
+        releaseArtifactRoot(root).root,
     },
     stdio: 'inherit',
   });

--- a/scripts/kfd-candidate-evidence.mjs
+++ b/scripts/kfd-candidate-evidence.mjs
@@ -10,6 +10,7 @@ import {
   sealKfdSourceEvidence,
   verifyKfdCandidatePayloadSet,
   verifyKfdManifestSet,
+  verifyReleaseArtifactRoot,
 } from '../framework/release/kfd-candidate-evidence.mjs';
 import { runShifuWithCache } from './run-shifu-lifecycle.mjs';
 
@@ -46,6 +47,7 @@ function usage() {
   node scripts/kfd-candidate-evidence.mjs source-check --source-sha SHA --source-tree TREE --out FILE [--github-output FILE]
   node scripts/kfd-candidate-evidence.mjs source --source-sha SHA --source-tree TREE --expected-input-root ROOT
   node scripts/kfd-candidate-evidence.mjs run-verify --platform PLATFORM --source-sha SHA --source-tree TREE -- COMMAND...
+  node scripts/kfd-candidate-evidence.mjs artifact-root-check --expected-root ROOT
   node scripts/kfd-candidate-evidence.mjs verify-manifest-set --manifest-root DIR --source-sha SHA
   node scripts/kfd-candidate-evidence.mjs verify-set --payload-root DIR --source-sha SHA [--source-tree TREE]
 `;
@@ -97,6 +99,16 @@ if (mode === 'source-check') {
     prepareReleaseArtifacts,
   });
   result = { ok: process.exitCode === 0 };
+} else if (mode === 'artifact-root-check') {
+  const artifact = verifyReleaseArtifactRoot({
+    root: ROOT,
+    expectedRoot: options.expectedRoot,
+  });
+  result = {
+    ok: true,
+    artifactRoot: artifact.root,
+    fileCount: artifact.files.length,
+  };
 } else if (mode === 'verify-manifest-set') {
   result = verifyKfdManifestSet({
     manifestRoot: path.resolve(ROOT, options.manifestRoot),

--- a/scripts/kfd-candidate-evidence.test.mjs
+++ b/scripts/kfd-candidate-evidence.test.mjs
@@ -12,12 +12,14 @@ import {
   finalizeKfdCandidateEvidence,
   kfdEvidenceRoot,
   prepareKfdArtifactWitness,
+  releaseArtifactRoot,
   resolveKfdSourcePlatform,
   restoreKfdPrebuiltLayerArtifact,
   runVerifiedQualification,
   sealKfdPrebuiltLayerArtifacts,
   verifyKfdCandidatePayloadSet,
   verifyKfdManifestSet,
+  verifyReleaseArtifactRoot,
 } from '../framework/release/kfd-candidate-evidence.mjs';
 
 const SOURCE_SHA = 'a'.repeat(40);
@@ -260,7 +262,7 @@ test('the Verify wrapper restores pre-qualification evidence after qualification
   const command = [
     process.execPath,
     '-e',
-    `const fs=require('node:fs');if(process.env.KUNGFU_VERIFY_PREBUILT_RELEASE_ARTIFACTS!=='1')process.exit(23);fs.rmSync(${JSON.stringify(qualification)},{recursive:true,force:true});fs.mkdirSync(${JSON.stringify(qualification)},{recursive:true});fs.writeFileSync(${JSON.stringify(path.join(qualification, 'qualification-passed.json'))},'{}\\n')`,
+    `const fs=require('node:fs');if(process.env.KUNGFU_VERIFY_PREBUILT_RELEASE_ARTIFACTS!=='1'||!/^sha256:[a-f0-9]{64}$/.test(process.env.KUNGFU_VERIFY_PREBUILT_RELEASE_ARTIFACT_ROOT||''))process.exit(23);fs.rmSync(${JSON.stringify(qualification)},{recursive:true,force:true});fs.mkdirSync(${JSON.stringify(qualification)},{recursive:true});fs.writeFileSync(${JSON.stringify(path.join(qualification, 'qualification-passed.json'))},'{}\\n')`,
   ];
   assert.equal(
     runVerifiedQualification({
@@ -361,7 +363,35 @@ test('fails before Verify completion when artifact bytes change after witnessing
   );
   assert.throws(
     () => finalizeKfdCandidateEvidence(fixture),
-    /KFD artifact digest mismatch/u,
+    /KFD artifact digest mismatch:.*changed=artifact\.bin/u,
+  );
+});
+
+test('reports added, removed, and changed release artifacts without restoring them', () => {
+  const fixture = artifactFixture();
+  const before = verifyReleaseArtifactRoot({
+    root: fixture.root,
+    expectedRoot: releaseArtifactRoot(fixture.root).root,
+  });
+  fs.appendFileSync(
+    path.join(fixture.root, 'product/release/artifact.bin'),
+    'changed\n',
+  );
+  fs.writeFileSync(
+    path.join(fixture.root, 'product/release/added.bin'),
+    'added\n',
+  );
+  assert.throws(
+    () =>
+      verifyReleaseArtifactRoot({
+        root: fixture.root,
+        expectedRoot: before.root,
+        expectedFiles: [
+          ...before.files,
+          { path: 'removed.bin', bytes: 1, sha256: `sha256:${'0'.repeat(64)}` },
+        ],
+      }),
+    /added=added\.bin; removed=removed\.bin; changed=artifact\.bin/u,
   );
 });
 


### PR DESCRIPTION
## Summary

Verify sealed CLI and desktop release artifacts read-only during KFD product qualification, while preserving ordinary product-distribution rebuild coverage and fail-closed exact artifact inventory checks.

## Validation

- Full ./shifu check:source passed: Node 1207 (1196 pass, 11 declared skips), Python 40/40, runtime upgrade 143/143, desktop 73/73, TypeScript and Biome.
- Focused KFD/runtime-activation tests passed 38/38.
- Actual artifact-root-check passed against the locally assembled release root.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This maintenance fix preserves release architecture and strengthens immutable artifact verification."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)