### PR TITLE
fix(runtime): bound hidden-state retention

### DIFF
--- a/docs/guides/native-agent-adapters.md
+++ b/docs/guides/native-agent-adapters.md
@@ -19,6 +19,14 @@ expansion is limited to `{skill_file}`, `{skill_dir}`, `{skills_root}`,
 JSON-quoted inside one argument. Generated files stay under Kungfu runtime
 state. Kungfu does not edit the provider's home or capture terminal bytes.
 
+Provider-owned diagnostic files under each native attempt are bounded before a
+new attempt starts. Kungfu preserves every unfinalized attempt, then removes
+files from finalized attempts when they are older than seven days or when the
+finalized-log pool exceeds 256 MiB, oldest first. The materialized adapter
+reports a `providerLogRetention` receipt with before/after bytes, removed file
+count, and the number of unfinalized files protected. The built-in Codex adapter
+also defaults `RUST_LOG` to `warn`; a caller may still override it explicitly.
+
 ## Register an adapter
 
 The example below uses a fictional `termagent` CLI:

--- a/docs/guides/upgrading.md
+++ b/docs/guides/upgrading.md
@@ -384,7 +384,12 @@ kungfu runtime upgrade gc-plan --json
 
 Unknown ownership fails closed. Cleanup owns only runtime-image inventory roots; it
 never owns workspace, Episode, journal, or session data. Applying a GC plan is an
-advanced operation and requires the unchanged plan id plus `--execute`.
+advanced operation and requires the unchanged plan id plus `--execute`. When
+`--references` is omitted, Core derives live references from runtime status and the
+active image pin; if an installed inventory has no active pin, the plan is blocked
+instead of treating the missing authority as an empty reference set. Operators may
+provide a verified reference array explicitly when another owner supplies the
+complete process, generation, lease, rollback, and recovery view.
 
 ## Offline and manual updates
 

--- a/framework/core/src/python/kungfu/agent/provider_bootstrap.py
+++ b/framework/core/src/python/kungfu/agent/provider_bootstrap.py
@@ -12,6 +12,7 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 from typing import Any, Callable, Mapping, Sequence
 import uuid
 
@@ -52,6 +53,11 @@ _PROMPT_INSTRUCTION_PREFIX = (
     "including surrogate pairs, then follow the decoded prompt exactly: "
 )
 _PROMPT_SAFE_CHARACTERS = frozenset(" .,:;/_-")
+_FINALIZED_AGENT_AUDIT = re.compile(
+    r"agent-console-native:(?P<attempt>[0-9a-f-]{36})-final\.json\Z"
+)
+_PROVIDER_LOG_RETENTION_SECONDS = 7 * 24 * 60 * 60
+_PROVIDER_LOG_MAX_BYTES = 256 * 1024 * 1024
 
 
 def resolve_command_wrapper(
@@ -447,6 +453,133 @@ def write_runtime_file(path: Path, content: str) -> None:
             temporary.unlink()
 
 
+def _finalized_native_attempts(runtime_dir: Path) -> set[str]:
+    attempts = set()
+    for audit in (runtime_dir / "skill-manager").glob(
+        "agent-console-native:*-final.json"
+    ):
+        match = _FINALIZED_AGENT_AUDIT.fullmatch(audit.name)
+        if match is None or audit.is_symlink() or not audit.is_file():
+            continue
+        try:
+            payload = json.loads(audit.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if str(payload.get("schema") or "").startswith("kungfu.skill-runtime-audit/"):
+            attempts.add(match.group("attempt"))
+    return attempts
+
+
+def _provider_log_files(provider_root: Path) -> list[Path]:
+    files: list[Path] = []
+    for parent, dirnames, filenames in os.walk(provider_root, followlinks=False):
+        dirnames[:] = [
+            name for name in dirnames if not (Path(parent) / name).is_symlink()
+        ]
+        files.extend(
+            path
+            for name in filenames
+            if not (path := Path(parent) / name).is_symlink() and path.is_file()
+        )
+    return files
+
+
+def _provider_log_inventory(
+    runtime_dir: Path, finalized: set[str]
+) -> tuple[list[tuple[int, str, int, Path]], int]:
+    eligible = []
+    active_files = 0
+    attempts_root = runtime_dir / "agent-sessions" / "native-attempts"
+    for attempt_root in attempts_root.iterdir() if attempts_root.is_dir() else []:
+        if not attempt_root.is_dir() or attempt_root.is_symlink():
+            continue
+        files = _provider_log_files(attempt_root / "provider-logs")
+        if attempt_root.name not in finalized:
+            active_files += len(files)
+            continue
+        for path in files:
+            stat = path.stat()
+            eligible.append((stat.st_mtime_ns, str(path), stat.st_size, path))
+    return eligible, active_files
+
+
+def _provider_log_removals(
+    eligible: list[tuple[int, str, int, Path]], cutoff_ns: int, max_bytes: int
+) -> set[Path]:
+    removals = {row[3] for row in eligible if row[0] < cutoff_ns}
+    retained_bytes = sum(row[2] for row in eligible if row[3] not in removals)
+    for _, _, size, path in sorted(eligible):
+        if retained_bytes <= max_bytes:
+            break
+        if path not in removals:
+            removals.add(path)
+            retained_bytes -= size
+    return removals
+
+
+def _remove_provider_logs(paths: set[Path]) -> tuple[int, int]:
+    removed_bytes = 0
+    removed_files = 0
+    for path in sorted(paths, key=lambda value: str(value).encode("utf-8")):
+        try:
+            size = path.stat().st_size
+            path.unlink()
+        except FileNotFoundError:
+            continue
+        removed_bytes += size
+        removed_files += 1
+    return removed_bytes, removed_files
+
+
+def _remove_empty_provider_log_dirs(runtime_dir: Path, finalized: set[str]) -> None:
+    attempts_root = runtime_dir / "agent-sessions" / "native-attempts"
+    for attempt in finalized:
+        provider_root = attempts_root / attempt / "provider-logs"
+        if not provider_root.is_dir() or provider_root.is_symlink():
+            continue
+        for parent, dirnames, _ in os.walk(provider_root, topdown=False):
+            for name in dirnames:
+                try:
+                    (Path(parent) / name).rmdir()
+                except OSError:
+                    pass
+
+
+def prune_finalized_provider_logs(
+    runtime_dir: str | Path,
+    *,
+    now_ns: int | None = None,
+    retention_seconds: int = _PROVIDER_LOG_RETENTION_SECONDS,
+    max_bytes: int = _PROVIDER_LOG_MAX_BYTES,
+) -> dict[str, Any]:
+    """Bound provider logs without touching unfinalized Agent attempts."""
+
+    root = Path(runtime_dir)
+    finalized = _finalized_native_attempts(root)
+    current_ns = time.time_ns() if now_ns is None else now_ns
+    cutoff_ns = current_ns - retention_seconds * 1_000_000_000
+    eligible, active_files = _provider_log_inventory(root, finalized)
+    before_bytes = sum(row[2] for row in eligible)
+    removals = _provider_log_removals(eligible, cutoff_ns, max_bytes)
+    removed_bytes, removed_files = _remove_provider_logs(removals)
+    _remove_empty_provider_log_dirs(root, finalized)
+
+    return {
+        "schema": "kungfu.provider-log-retention-receipt/v1",
+        "policy": {
+            "finalizedMaxAgeSeconds": retention_seconds,
+            "finalizedMaxBytes": max_bytes,
+            "unfinalizedAttempts": "preserved",
+        },
+        "eligibleBytesBefore": before_bytes,
+        "eligibleBytesAfter": max(0, before_bytes - removed_bytes),
+        "removedBytes": removed_bytes,
+        "removedFiles": removed_files,
+        "unfinalizedFilesPreserved": active_files,
+        "status": "within-budget",
+    }
+
+
 class ProviderBootstrapAdapter:
     """Materialize one provider Skill adapter under runtime state only."""
 
@@ -481,6 +614,7 @@ class ProviderBootstrapAdapter:
             / "native-provider-adapters"
             / adapter_id
         )
+        log_retention = None
         if session_id is None:
             session_root = adapter_root
         else:
@@ -491,6 +625,7 @@ class ProviderBootstrapAdapter:
                 raise ValueError(
                     "native Provider adapter session id must be a UUID"
                 ) from error
+            log_retention = prune_finalized_provider_logs(runtime_dir)
             session_root = (
                 Path(runtime_dir) / "agent-sessions" / "native-attempts" / session_token
             )
@@ -546,6 +681,7 @@ class ProviderBootstrapAdapter:
             "provider": adapter_id,
             "skillFile": str(skill_file),
             "providerLogDir": str(provider_log_dir),
+            "providerLogRetention": log_retention,
             "argv": [
                 render_text(str(value), paths) for value in skill.get("argv") or []
             ],

--- a/framework/core/src/python/kungfu/agent/runtime_profiles.py
+++ b/framework/core/src/python/kungfu/agent/runtime_profiles.py
@@ -79,7 +79,9 @@ def builtin_adapters() -> dict[str, dict[str, Any]]:
                     "-c",
                     "skills.config=[{path={skill_dir:json},enabled=true}]",
                 ],
-                "environment": {},
+                "environment": {
+                    "RUST_LOG": "warn",
+                },
                 "environmentJson": {},
                 "files": [],
             },

--- a/framework/core/src/python/kungfu/cli/commands/_runtime/upgrade.py
+++ b/framework/core/src/python/kungfu/cli/commands/_runtime/upgrade.py
@@ -220,6 +220,47 @@ def upgrade_reconcile(ctx, receipt, readiness_passed, as_json):
     click.echo(f"{payload['state']}: {payload['reasonCode']}")
 
 
+def _discover_gc_references(ctx, *, inventory_nonempty):
+    workspace = runtime_broker.workspace_id(ctx.runtime_dir)
+    current = runtime_upgrade.active_image(ctx.config_home, workspace)
+    status = runtime_service.route_status(ctx.home, ctx.runtime_dir, ctx.config_home)
+    references = runtime_upgrade.references_from_runtime_status(status, current)
+    return references, bool(inventory_nonempty and current is None)
+
+
+def _gc_reference_inputs(ctx, references, *, inventory_nonempty):
+    if references is not None:
+        return _load_array(references), False
+    return _discover_gc_references(ctx, inventory_nonempty=inventory_nonempty)
+
+
+def _plan_gc(ctx, references, unknown_references):
+    images = runtime_upgrade.list_images(ctx.config_home)
+    reference_values, discovery_incomplete = _gc_reference_inputs(
+        ctx, references, inventory_nonempty=images
+    )
+    return runtime_upgrade.plan_gc(
+        images,
+        reference_values,
+        unknown_references=unknown_references or discovery_incomplete,
+    )
+
+
+def _apply_gc(ctx, plan_value, references, unknown_references, expected_plan_id):
+    reference_values, discovery_incomplete = _gc_reference_inputs(
+        ctx,
+        references,
+        inventory_nonempty=plan_value.get("candidates") or plan_value.get("blocked"),
+    )
+    return runtime_upgrade.apply_gc(
+        plan_value,
+        expected_plan_id=expected_plan_id,
+        config_home=ctx.config_home,
+        references=reference_values,
+        unknown_references=unknown_references or discovery_incomplete,
+    )
+
+
 @runtime_upgrade_group.command(
     name="gc-plan", help="list only images with no live or retained reference"
 )
@@ -234,11 +275,7 @@ def upgrade_reconcile(ctx, receipt, readiness_passed, as_json):
 @click.option("--json", "as_json", is_flag=True, help="machine-readable output")
 @runtime_command_context
 def upgrade_gc_plan(ctx, references, unknown_references, as_json):
-    payload = runtime_upgrade.plan_gc(
-        runtime_upgrade.list_images(ctx.config_home),
-        _load_array(references),
-        unknown_references=unknown_references,
-    )
+    payload = _plan_gc(ctx, references, unknown_references)
     if as_json:
         _json(payload)
         return
@@ -275,12 +312,12 @@ def upgrade_gc(
         payload = {
             "schema": "kungfu.runtime-image-gc-receipt/v1",
             "planId": expected_plan_id,
-            "removedBuildIds": runtime_upgrade.apply_gc(
+            "removedBuildIds": _apply_gc(
+                ctx,
                 plan_value,
-                expected_plan_id=expected_plan_id,
-                config_home=ctx.config_home,
-                references=_load_array(references),
-                unknown_references=unknown_references,
+                references,
+                unknown_references,
+                expected_plan_id,
             ),
         }
     if as_json:

--- a/framework/core/tests/python/test_agent_console_ambient_adoption.py
+++ b/framework/core/tests/python/test_agent_console_ambient_adoption.py
@@ -5,7 +5,13 @@ from types import SimpleNamespace
 
 from click.testing import CliRunner
 
-from kungfu.agent import run_agent, session_contract, session_surface
+from kungfu.agent import (
+    provider_bootstrap,
+    run_agent,
+    runtime_profiles,
+    session_contract,
+    session_surface,
+)
 from kungfu.cli.commands import __registry__  # noqa: F401
 from kungfu.cli.commands import kfc
 from kungfu.workspace import resolve_workspace_target
@@ -14,6 +20,33 @@ from agent_bootstrap_fixtures import verified_bootstrap_receipt
 
 ROOT_HASH = "sha256:" + "a" * 64
 THREAD_ID = "019ff927-f9a4-7502-999a-6bc5a69bb702"
+
+
+def test_codex_defaults_to_bounded_diagnostic_logging():
+    assert runtime_profiles.builtin_adapters()["codex"]["skill"]["environment"] == {
+        "RUST_LOG": "warn"
+    }
+
+
+def test_provider_log_retention_prunes_only_finalized_attempts(tmp_path):
+    root = tmp_path / "runtime"
+    finalized = "00000000-0000-4000-8000-000000000001"
+    active = "00000000-0000-4000-8000-000000000002"
+    logs = [
+        root / "agent-sessions" / "native-attempts" / item / "provider-logs" / "log"
+        for item in (finalized, active)
+    ]
+    provider_bootstrap.write_runtime_file(logs[0], "old")
+    provider_bootstrap.write_runtime_file(logs[1], "live")
+    provider_bootstrap.write_runtime_file(
+        root / "skill-manager" / f"agent-console-native:{finalized}-final.json",
+        '{"schema":"kungfu.skill-runtime-audit/v2"}',
+    )
+    receipt = provider_bootstrap.prune_finalized_provider_logs(
+        root, now_ns=10_000_000_000, retention_seconds=100, max_bytes=0
+    )
+    assert not logs[0].exists() and logs[1].read_text(encoding="utf-8") == "live"
+    assert receipt["removedFiles"] == receipt["unfinalizedFilesPreserved"] == 1
 
 
 def process_identity():

--- a/framework/core/tests/python/test_runtime_upgrade.py
+++ b/framework/core/tests/python/test_runtime_upgrade.py
@@ -363,6 +363,24 @@ def test_cli_exposes_one_welded_upgrade_contract_and_inventory(tmp_path):
     }
 
 
+def test_cli_gc_plan_fails_closed_without_reference_authority(tmp_path):
+    runner = CliRunner()
+    home = tmp_path / "home"
+    source = _source(tmp_path, "runtime-a")
+    installed = _install(home / "config", source, _manifest(source, "runtime-a"), 1)
+
+    result = runner.invoke(
+        upgrade_test_cli,
+        ["--home", str(home), "runtime", "upgrade", "gc-plan", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["state"] == "action-required"
+    assert payload["candidates"] == []
+    assert [item["buildId"] for item in payload["blocked"]] == [installed["buildId"]]
+
+
 def test_corrupt_artifact_is_rejected_and_quarantine_is_recorded(tmp_path):
     source = _source(tmp_path, "runtime-a")
     manifest = _manifest(source, "runtime-a")

--- a/framework/maintainability/python-runtime-responsibility-map.json
+++ b/framework/maintainability/python-runtime-responsibility-map.json
@@ -107,7 +107,7 @@
     },
     {
       "path": "framework/core/src/python/kungfu/cli/commands/_runtime/upgrade.py",
-      "sha256": "31087321eebe2c102e66ad7fc765cba785ebdc57753e38d84ce7922b910548c6"
+      "sha256": "3f560eeb9fcf3aab55dd0912a35ffcdbf971d64890c68efd1ed3928152857131"
     },
     {
       "path": "framework/core/src/python/kungfu/cli/commands/_runtime/service.py",
@@ -136,14 +136,14 @@
     }
   },
   "current": {
-    "physicalLines": 3739,
-    "responsibilities": 191,
+    "physicalLines": 3776,
+    "responsibilities": 195,
     "maximumPhysicalLines": 850,
     "maximumResponsibilities": 51,
     "functionRisk": {
-      "functions": 161,
-      "baseRisk": 2226,
-      "changeRisk": 2558,
+      "functions": 165,
+      "baseRisk": 2266,
+      "changeRisk": 2616,
       "maximumBaseRisk": 265,
       "maximumChangeRisk": 267
     }
@@ -153,12 +153,12 @@
       "functions": 155,
       "previousBaseRisk": 2184,
       "currentBaseRisk": 2179,
-      "currentChangeRisk": 2493
+      "currentChangeRisk": 2499
     },
     "new": {
-      "functions": 6,
-      "currentBaseRisk": 47,
-      "currentChangeRisk": 65
+      "functions": 10,
+      "currentBaseRisk": 87,
+      "currentChangeRisk": 117
     },
     "retired": {
       "functions": 2,
@@ -190,12 +190,28 @@
     {
       "path": "framework/core/src/python/kungfu/_runtime_service/state.py",
       "symbol": "route_status"
+    },
+    {
+      "path": "framework/core/src/python/kungfu/cli/commands/_runtime/upgrade.py",
+      "symbol": "_apply_gc"
+    },
+    {
+      "path": "framework/core/src/python/kungfu/cli/commands/_runtime/upgrade.py",
+      "symbol": "_discover_gc_references"
+    },
+    {
+      "path": "framework/core/src/python/kungfu/cli/commands/_runtime/upgrade.py",
+      "symbol": "_gc_reference_inputs"
+    },
+    {
+      "path": "framework/core/src/python/kungfu/cli/commands/_runtime/upgrade.py",
+      "symbol": "_plan_gc"
     }
   ],
   "adapterRiskBudget": {
-    "functions": 6,
-    "baseRisk": 47,
-    "changeRisk": 65
+    "functions": 10,
+    "baseRisk": 87,
+    "changeRisk": 117
   },
   "processIdentityContinuity": [
     "_terminate_process_if_matches",
@@ -333,9 +349,9 @@
   "nonWrapperEvidence": [
     "The stable runtime_service facade preserves all 118 exact-baseline public symbols, while persistence paths, schema constants, native class signatures, side-effect ordering bodies, CoordinatorProcess, and the service-local child lifecycle remain AST-identical after removing only the declared call-time seam decorator.",
     "The CLI facade composes four responsibility owners and preserves all 42 exact-baseline Click function signatures and decorators; _plain_status moves to the rendering owner with the same bodyRoot and baseRisk 55.",
-    "Every one of the 155 exact-baseline business functions retains a previousId, previousBaseRisk 2184, and aggregate current baseRisk 2179; the only 6 new functions are the closed call-time facade adapter set, budgeted separately at baseRisk 47 and changeRisk 65, with no additional retired business function.",
+    "Every one of the 155 exact-baseline business functions retains a previousId, previousBaseRisk 2184, and aggregate current baseRisk 2179; the 10 new functions are the closed call-time facade and runtime-image GC discovery adapter set, budgeted separately at baseRisk 87 and changeRisk 117, with no additional retired business function.",
     "The migration raises measured transition changeRisk because same-owner functions acquire renamed-file movement cost; it does not raise business baseRisk or maximum baseRisk. The checker therefore records migration risk without misrepresenting it as steady-state responsibility risk.",
-    "Maximum file size falls from 1961 to 850 physical lines and maximum per-module responsibility count falls from 88 to 51. Aggregate lines and import-count responsibilities are reported honestly at 3673 and 191 because stable facades preserve every baseline module attribute and explicit owner dependencies are retained rather than hidden.",
+    "Maximum file size falls from 1961 to 850 physical lines and maximum per-module responsibility count falls from 88 to 51. Aggregate lines and import-count responsibilities are reported honestly at 3776 and 195 because stable facades preserve every baseline module attribute and explicit owner dependencies are retained rather than hidden.",
     "runtime_processes continues to own PID-reuse-fenced signalling and bounded process-tree termination from Wave 1; Wave 2 adds no cross-language, dependency, persistence-format, public API, or Click-surface change."
   ]
 }


### PR DESCRIPTION
## Summary

- fail closed runtime-image GC when implicit ownership cannot prove an active generation
- bound finalized provider logs by age and bytes while preserving unfinalized attempts
- lower default Codex log verbosity and document the maintenance contract

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This maintenance delivery does not alter an architecture decision."
}
-->

## Evolution Map impact

Evolution impact: none

## Validation

- `./shifu check:source`
- `node ./framework/core/.gyp/run-tests.mjs test:agent-console-contract`

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] No secrets, private logs, generated build output, or local state included
- [x] Active, selected, rollback, and unknown-ownership state fails closed