### PR TITLE
fix(profile): relocate exact bundled lifecycle source

### DIFF
--- a/framework/core/src/python/kungfu/_profile_composition/support.py
+++ b/framework/core/src/python/kungfu/_profile_composition/support.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from pathlib import Path
 from typing import Any, Mapping, NoReturn
 
@@ -113,6 +114,25 @@ def _source_directory(state: Mapping[str, Any]) -> Path | None:
         if current.parent == current:
             break
         current = current.parent
+    return _relocated_source_directory(state)
+
+
+def _relocated_source_directory(state: Mapping[str, Any]) -> Path | None:
+    """Resolve an identical bundled source after product-image replacement."""
+
+    bundled_root = os.environ.get("KF_BUNDLED_EXTENSION_ROOT", "")
+    profile_id = state.get("profile_id")
+    profile_root = state.get("profile_suite_root")
+    if bundled_root and isinstance(profile_id, str) and isinstance(profile_root, str):
+        try:
+            discovered = profile_sdk.discover_source(
+                profile_id,
+                search_roots=[bundled_root],
+            )
+            if discovered.get("profileSuiteRoot") == profile_root:
+                return Path(discovered["source"]).expanduser().resolve()
+        except (KeyError, profile_sdk.ProfileSdkError):
+            pass
     return None
 
 

--- a/framework/core/src/python/kungfu/assignment_runtime/profile_lifecycle.py
+++ b/framework/core/src/python/kungfu/assignment_runtime/profile_lifecycle.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Literal, NoReturn, overload
@@ -65,13 +66,38 @@ def _retained_profile_source(runtime_dir: str | Path, state: dict[str, Any]) -> 
     closure = dict((state.get("latest_event") or {}).get("closure") or {})
     profile_path = Path(str(closure.get("profile_path") or "")).expanduser()
     if not profile_path.is_file():
-        _missing_profile(
+        return _relocated_profile_source(
             runtime_dir,
-            "Qualified Work Control Profile retained source is unavailable",
-            code="work-control-profile-source-unavailable",
-            profilePath=str(profile_path),
+            profile_path,
         )
     return profile_path.resolve().parent
+
+
+def _relocated_profile_source(
+    runtime_dir: str | Path,
+    profile_path: Path,
+) -> Path:
+    """Find only the current bundled copy of one missing retained source."""
+
+    bundled_root = os.environ.get("KF_BUNDLED_EXTENSION_ROOT", "")
+    if bundled_root:
+        try:
+            discovered = profile_sdk.discover_source(
+                WORK_CONTROL_PROFILE_ID,
+                runtime_dir,
+                search_roots=[bundled_root],
+            )
+            return Path(discovered["source"]).expanduser().resolve()
+        except (KeyError, profile_sdk.ProfileSdkError):
+            pass
+
+    _missing_profile(
+        runtime_dir,
+        "Qualified Work Control Profile retained source is unavailable",
+        code="work-control-profile-source-unavailable",
+        profilePath=str(profile_path),
+        bundledExtensionRoot=bundled_root or None,
+    )
 
 
 @overload
@@ -110,33 +136,39 @@ def resolve_qualified_work_profile(
     if state is None:
         return None
     retained_source = _retained_profile_source(runtime_dir, state)
-    if source is not None and Path(source).expanduser().resolve() != retained_source:
-        raise profile_sdk.ProfileSdkError(
-            "work-control-profile-source-drift",
-            "Explicit Work Control Profile source does not match the qualified retained source",
-            profileId=WORK_CONTROL_PROFILE_ID,
-            retainedSource=str(retained_source),
-            observedSource=str(Path(source).expanduser().resolve()),
-        )
-    validated = profile_sdk.validate_source(retained_source, runtime_dir)
+    retained_root = str(state.get("profile_suite_root", ""))
+    resolved_source = (
+        Path(source).expanduser().resolve() if source is not None else retained_source
+    )
+    validated = profile_sdk.validate_source(resolved_source, runtime_dir)
     inspection = validated["inspection"]
-    profile_id = str((inspection.get("profile") or {}).get("id") or "")
-    profile_root = str(inspection.get("profile_suite_root") or "")
-    retained_root = str(state.get("profile_suite_root") or "")
-    if profile_id != WORK_CONTROL_PROFILE_ID or profile_root != retained_root:
-        raise profile_sdk.ProfileSdkError(
+    profile_id = str(inspection.get("profile", {}).get("id", ""))
+    profile_root = str(inspection.get("profile_suite_root", ""))
+    diagnosis = {
+        False: (
             "work-control-profile-source-root-drift",
             "Qualified Work Control Profile retained source no longer matches its exact root",
+        ),
+        True: (
+            "work-control-profile-source-drift",
+            "Explicit Work Control Profile source does not match the qualified retained root",
+        ),
+    }[resolved_source != retained_source]
+    if profile_id != WORK_CONTROL_PROFILE_ID or profile_root != retained_root:
+        raise profile_sdk.ProfileSdkError(
+            diagnosis[0],
+            diagnosis[1],
             profileId=WORK_CONTROL_PROFILE_ID,
+            retainedSource=str(retained_source),
             retainedRoot=retained_root,
+            observedSource=str(resolved_source),
             observedProfileId=profile_id,
             observedRoot=profile_root,
-            source=str(retained_source),
         )
     return {
         "id": WORK_CONTROL_PROFILE_ID,
         "root": retained_root,
-        "source": str(retained_source),
+        "source": str(resolved_source),
     }
 
 

--- a/framework/core/tests/python/test_profile_composition.py
+++ b/framework/core/tests/python/test_profile_composition.py
@@ -399,6 +399,24 @@ def test_manager_projects_lifecycle_and_current_source_health(tmp_path):
     assert [view["id"] for view in managed["catalog"]["views"]] == ["week-table"]
 
 
+def test_manager_relocates_removed_source_from_exact_bundled_root(
+    tmp_path, monkeypatch
+):
+    source = _source(tmp_path)
+    runtime = tmp_path / "runtime"
+    _activate(source, runtime)
+    bundled_root = tmp_path / "current-image" / "extensions"
+    bundled_root.mkdir(parents=True)
+    relocated = source.rename(bundled_root / "week-day")
+    monkeypatch.setenv("KF_BUNDLED_EXTENSION_ROOT", str(bundled_root))
+
+    managed = profile_composition.manager(runtime)["profiles"][0]
+
+    assert managed["health"] == "active"
+    assert managed["source"] == str(relocated.resolve())
+    assert managed["catalog"]["activeExactRoot"] is True
+
+
 def test_manager_reports_source_drift_without_hiding_lifecycle_state(tmp_path):
     source = _source(tmp_path)
     runtime = tmp_path / "runtime"

--- a/framework/core/tests/python/test_work_authority_surface.py
+++ b/framework/core/tests/python/test_work_authority_surface.py
@@ -64,6 +64,208 @@ def test_qualified_work_profile_resolves_retained_exact_source(monkeypatch, tmp_
     }
 
 
+def test_qualified_work_profile_accepts_equivalent_explicit_bundled_source(
+    monkeypatch, tmp_path
+):
+    retained = tmp_path / "rollback-image" / "work-control"
+    bundled = tmp_path / "current-image" / "work-control"
+    retained.mkdir(parents=True)
+    bundled.mkdir(parents=True)
+    (retained / "profile.json").write_text("{}\n", encoding="utf-8")
+    profile_root = f"sha256:{'a' * 64}"
+    monkeypatch.setattr(
+        profile_lifecycle.storage_service,
+        "profile_lifecycle",
+        lambda *_args, **_kwargs: {
+            "profile_suite_root": profile_root,
+            "qualified": True,
+            "activated": True,
+            "removed": False,
+            "latest_event": {
+                "closure": {"profile_path": str(retained / "profile.json")}
+            },
+        },
+    )
+    monkeypatch.setattr(
+        profile_lifecycle.profile_sdk,
+        "validate_source",
+        lambda observed_source, observed_runtime: (
+            {
+                "inspection": {
+                    "profile": {"id": "kungfu.work-control"},
+                    "profile_suite_root": profile_root,
+                }
+            }
+            if observed_source in {retained.resolve(), bundled.resolve()}
+            and observed_runtime == tmp_path
+            else (_ for _ in ()).throw(AssertionError("source/runtime drift"))
+        ),
+    )
+
+    assert profile_lifecycle.resolve_qualified_work_profile(
+        tmp_path,
+        source=bundled,
+    ) == {
+        "id": "kungfu.work-control",
+        "root": profile_root,
+        "source": str(bundled.resolve()),
+    }
+
+
+def test_qualified_work_profile_rejects_explicit_source_with_different_root(
+    monkeypatch, tmp_path
+):
+    retained = tmp_path / "rollback-image" / "work-control"
+    bundled = tmp_path / "current-image" / "work-control"
+    retained.mkdir(parents=True)
+    bundled.mkdir(parents=True)
+    (retained / "profile.json").write_text("{}\n", encoding="utf-8")
+    retained_root = f"sha256:{'a' * 64}"
+    observed_root = f"sha256:{'b' * 64}"
+    monkeypatch.setattr(
+        profile_lifecycle.storage_service,
+        "profile_lifecycle",
+        lambda *_args, **_kwargs: {
+            "profile_suite_root": retained_root,
+            "qualified": True,
+            "activated": True,
+            "removed": False,
+            "latest_event": {
+                "closure": {"profile_path": str(retained / "profile.json")}
+            },
+        },
+    )
+    monkeypatch.setattr(
+        profile_lifecycle.profile_sdk,
+        "validate_source",
+        lambda observed_source, _runtime: {
+            "inspection": {
+                "profile": {"id": "kungfu.work-control"},
+                "profile_suite_root": (
+                    retained_root
+                    if observed_source == retained.resolve()
+                    else observed_root
+                ),
+            }
+        },
+    )
+
+    with __import__("pytest").raises(
+        profile_lifecycle.profile_sdk.ProfileSdkError,
+        match="does not match the qualified retained root",
+    ) as error:
+        profile_lifecycle.resolve_qualified_work_profile(
+            tmp_path,
+            source=bundled,
+        )
+
+    assert error.value.diagnosis["code"] == "work-control-profile-source-drift"
+    assert error.value.diagnosis["retainedRoot"] == retained_root
+    assert error.value.diagnosis["observedRoot"] == observed_root
+
+
+def test_qualified_work_profile_relocates_missing_source_by_exact_root(
+    monkeypatch, tmp_path
+):
+    missing = tmp_path / "removed-image" / "work-control" / "profile.json"
+    bundled_root = tmp_path / "current-image" / "extensions"
+    source = bundled_root / "work-control"
+    source.mkdir(parents=True)
+    profile_root = f"sha256:{'a' * 64}"
+    monkeypatch.setenv("KF_BUNDLED_EXTENSION_ROOT", str(bundled_root))
+    monkeypatch.setattr(
+        profile_lifecycle.storage_service,
+        "profile_lifecycle",
+        lambda *_args, **_kwargs: {
+            "profile_suite_root": profile_root,
+            "qualified": True,
+            "activated": True,
+            "removed": False,
+            "latest_event": {"closure": {"profile_path": str(missing)}},
+        },
+    )
+    monkeypatch.setattr(
+        profile_lifecycle.profile_sdk,
+        "discover_source",
+        lambda profile_id, runtime_dir, *, search_roots: (
+            {
+                "source": str(source),
+                "profileSuiteRoot": profile_root,
+            }
+            if profile_id == "kungfu.work-control"
+            and runtime_dir == tmp_path
+            and search_roots == [str(bundled_root)]
+            else (_ for _ in ()).throw(AssertionError("discovery boundary drift"))
+        ),
+    )
+    monkeypatch.setattr(
+        profile_lifecycle.profile_sdk,
+        "validate_source",
+        lambda observed_source, observed_runtime: (
+            {
+                "inspection": {
+                    "profile": {"id": "kungfu.work-control"},
+                    "profile_suite_root": profile_root,
+                }
+            }
+            if observed_source == source.resolve() and observed_runtime == tmp_path
+            else (_ for _ in ()).throw(AssertionError("source/runtime drift"))
+        ),
+    )
+
+    assert profile_lifecycle.resolve_qualified_work_profile(tmp_path) == {
+        "id": "kungfu.work-control",
+        "root": profile_root,
+        "source": str(source.resolve()),
+    }
+
+
+def test_qualified_work_profile_relocation_rejects_root_drift(monkeypatch, tmp_path):
+    missing = tmp_path / "removed-image" / "work-control" / "profile.json"
+    bundled_root = tmp_path / "current-image" / "extensions"
+    source = bundled_root / "work-control"
+    source.mkdir(parents=True)
+    retained_root = f"sha256:{'a' * 64}"
+    observed_root = f"sha256:{'b' * 64}"
+    monkeypatch.setenv("KF_BUNDLED_EXTENSION_ROOT", str(bundled_root))
+    monkeypatch.setattr(
+        profile_lifecycle.storage_service,
+        "profile_lifecycle",
+        lambda *_args, **_kwargs: {
+            "profile_suite_root": retained_root,
+            "qualified": True,
+            "activated": True,
+            "removed": False,
+            "latest_event": {"closure": {"profile_path": str(missing)}},
+        },
+    )
+    monkeypatch.setattr(
+        profile_lifecycle.profile_sdk,
+        "discover_source",
+        lambda *_args, **_kwargs: {"source": str(source)},
+    )
+    monkeypatch.setattr(
+        profile_lifecycle.profile_sdk,
+        "validate_source",
+        lambda *_args, **_kwargs: {
+            "inspection": {
+                "profile": {"id": "kungfu.work-control"},
+                "profile_suite_root": observed_root,
+            }
+        },
+    )
+
+    with __import__("pytest").raises(
+        profile_lifecycle.profile_sdk.ProfileSdkError,
+        match="retained source no longer matches its exact root",
+    ) as error:
+        profile_lifecycle.resolve_qualified_work_profile(tmp_path)
+
+    assert error.value.diagnosis["code"] == "work-control-profile-source-root-drift"
+    assert error.value.diagnosis["retainedRoot"] == retained_root
+    assert error.value.diagnosis["observedRoot"] == observed_root
+
+
 def test_missing_work_profile_has_specific_fail_closed_diagnosis(monkeypatch, tmp_path):
     def missing(*_args, **_kwargs):
         raise ValueError("Profile not found: kungfu.work-control")


### PR DESCRIPTION
## Summary

Keep Work Control Profile authority stable when an installed product image moves or is replaced.

## Related issue

None.

## Changes

- resolve an explicitly supplied bundled Profile source when it has the same Profile ID and exact content root as the lifecycle authority;
- recover a missing recorded Profile path only from the current bundled extension root, with the same exact ID and root checks;
- keep arbitrary extension-root search, root drift, and Profile substitution fail-closed;
- cover both rollback-retained and replaced-image layouts in the lifecycle and composition tests.

## Verification

- `./shifu check:source`
- 45 Work Authority tests
- 64 Profile SDK and composition tests
- 23 Work Control Profile tests
- preview distribution build `20260831T171228Z-d9ad86858`
- local preview promotion and installed-runtime exact-root verification

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bug fix preserves the existing exact Profile root authority while allowing an identical bundled source to move with a product image."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation is not required because the external behavior and authority contract are unchanged
