### PR TITLE
test(agent): make signed app layout expectation portable

### DIFF
--- a/framework/agent-session/tests/capsule-transport-runtime.test.mjs
+++ b/framework/agent-session/tests/capsule-transport-runtime.test.mjs
@@ -123,19 +123,36 @@ test('Capsule node-pty resolution is lazy and reports an optional capability', (
 });
 
 test('Capsule node-pty resolution includes the signed desktop app layout', () => {
-  assert.deepEqual(
-    capsuleNodePtyCandidates({
-      bundleDirectory:
-        '/Applications/Kungfu Episodes.app/Contents/Resources/tui',
-    }),
-    [
-      null,
-      null,
-      '/Applications/Kungfu Episodes.app/Contents/Resources/tui/node_modules/node-pty/lib/index.js',
-      '/Applications/Kungfu Episodes.app/Contents/Resources/node_modules/node-pty/lib/index.js',
-      '/Applications/Kungfu Episodes.app/Contents/Resources/app/node_modules/node-pty/lib/index.js',
-    ],
+  const bundleDirectory = path.join(
+    path.sep,
+    'Applications',
+    'Kungfu Episodes.app',
+    'Contents',
+    'Resources',
+    'tui',
   );
+  assert.deepEqual(capsuleNodePtyCandidates({ bundleDirectory }), [
+    null,
+    null,
+    path.join(bundleDirectory, 'node_modules', 'node-pty', 'lib', 'index.js'),
+    path.join(
+      bundleDirectory,
+      '..',
+      'node_modules',
+      'node-pty',
+      'lib',
+      'index.js',
+    ),
+    path.join(
+      bundleDirectory,
+      '..',
+      'app',
+      'node_modules',
+      'node-pty',
+      'lib',
+      'index.js',
+    ),
+  ]);
 });
 
 test('the detached control core starts without node-pty for native sessions', async () => {


### PR DESCRIPTION
## Summary

Make the signed desktop app layout assertion use Node path composition so it validates the same runtime candidates on Windows and POSIX hosts. This repairs the Windows verification failure in Alpha.4 v16 without changing Capsule resolution behavior.

## Validation

- Complete zero-write ./shifu check:source passed.
- Targeted Capsule node-pty signed desktop app layout test passed.
- Biome and git diff --check passed.
- A path.win32 projection matches the backslash paths observed in Full Build run 33445853523.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This focused cross-platform test correction preserves Agent Session runtime behavior and release architecture."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)

<!-- kungfu-family-queue-lease:v1 eyJzY2hlbWEiOiJwcm9qZWN0LmN1dC5mYW1pbHktcXVldWUtbGVhc2UvdjEiLCJzdGF0ZSI6ImFjdGl2ZSIsImluaXRpYXRpdmVJZCI6Imt1bmdmdS10ZWNobmljYWwtc3Rld2FyZHNoaXAiLCJhc3NpZ25tZW50SWQiOiIyMDI2LTA4LTI2LWt1bmdmdS13b3JrLWRlc2lnbi1pbnN0YWxsLWNsb3N1cmUiLCJkZWxpdmVyeUNsYXNzIjoicmVsZWFzZSIsImRldkhlYWQiOiI4YjVjNWJmZmI4NmVjOTAyYjc4NzhjZmNiZjI5OTEwNTNkY2E2ZTMyIiwicHVsbFJlcXVlc3RIZWFkIjoiOWJhMzYyMzFmZmY2NmRiNjNkNzE0Yzk4YjM3ZDU1N2I1ZWVlYTYwYSIsInJlcGxheWVkQ2FuZGlkYXRlIjoiOTk3ODdjZmI0ZTZjN2VmMTBmMDAxMDUxMzRjYTJiYmM5YmEwYTkzZSIsInJlcGxheWVkVHJlZSI6Ijc1Njc0ODcxM2JiMmY2OTlmMmY4YzczODc4ZjAyZTkxYjYxNGIxMjUiLCJxdWV1ZUF0dGVtcHQiOiI5YmEzNjIzMWZmZjY2ZGI2M2Q3MTRjOThiMzdkNTU3YjVlZWVhNjBhQDhiNWM1YmZmYjg2ZWM5MDJiNzg3OGNmY2JmMjk5MTA1M2RjYTZlMzIiLCJhZG1pc3Npb25Qcm9vZlJvb3QiOiJzaGEyNTY6YmIyODkyM2I3YTAzNjNhNTJlMjAxMGM1NWQxNjc2NWE4YWY2NTdiYzU3YmI4NTc1OWE5ODIzNTViMTE5OTJhMyIsImFkbWlzc2lvblByb29mUm9vdHMiOlsic2hhMjU2OjFmMzViNzRjNGFlMzM0NTk4Y2Y3YjYyNzczNTZkZTEyM2M3YzMyMjYwNTllNmM3YzdjZGE1MWZlMTA4YWZjYzUiLCJzaGEyNTY6YmIyODkyM2I3YTAzNjNhNTJlMjAxMGM1NWQxNjc2NWE4YWY2NTdiYzU3YmI4NTc1OWE5ODIzNTViMTE5OTJhMyJdLCJzdGF0dXNDb250ZXh0IjoiUXVldWUgZmFtaWx5IGxlYXNlL2Q5OWYzYTkxNjY3MzllMGQiLCJsZWFzZVJvb3QiOiJzaGEyNTY6NzQ3YWRlM2Q4NTM5NWMzMzk0M2NlOTE3MjFmMWFlYzIyZDgzOTg0NmMyZTFiZmY4YTliNmE3MjU0YTU3MzM5MyJ9 -->