### PR TITLE
fix(delivery): consume qualified Warrant artifact

### DIFF
--- a/.github/workflows/dev-pr-auto-merge.yml
+++ b/.github/workflows/dev-pr-auto-merge.yml
@@ -752,8 +752,9 @@ jobs:
       - name: Download exact qualified Warrant evidence
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          name: buildchain-dev-delivery-control-${{ github.run_id }}-${{ github.run_attempt }}-${{ needs.resolve-target.outputs.expected-pr-number }}
+          pattern: buildchain-dev-delivery-warrant-*-${{ needs.resolve-target.outputs.expected-pr-number }}
           path: .buildchain/native-check-bridge/warrant
+          merge-multiple: true
 
       - name: Re-run failed source jobs under the qualified Warrant
         id: publish

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -671,10 +671,10 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:252fcb7fc9c2707dca015efa8d10471c08789d0b08cc2922c40c5f4646108b06",
+          "definitionDigest": "sha256:ce1a9dc0ead77fb8d7abb5b14cc3d4c05990676234ea2537f3fa03f9327d9ffd",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":[],"inheritedSecrets":false,"environment":null},
           "externalActions": ["actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093","actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"],
-          "steps": [{"index":1,"label":"name:Download exact qualified Warrant evidence","authority":"evidence-publication","definitionDigest":"sha256:6f64d2b75f97c3db57fd605a6e4615dbba96ae8dc715c676cb42534e18f2e719"},{"index":2,"label":"id:publish","authority":"evidence-publication","definitionDigest":"sha256:2134b4b8c40cb21295524c5d27e0de267513178872a697b329760d24c8529c78"},{"index":3,"label":"name:Upload exact native CheckRun bridge receipt","authority":"evidence-publication","definitionDigest":"sha256:0738c87b720b7aca17c51a18e36864e6329e7fb64d75cd89549be39e5fa4c0e4"}]
+          "steps": [{"index":1,"label":"name:Download exact qualified Warrant evidence","authority":"evidence-publication","definitionDigest":"sha256:7cf85852095de6c5c926b19a599f250dfa7f8effc83d436701c80b66b24ac0b1"},{"index":2,"label":"id:publish","authority":"evidence-publication","definitionDigest":"sha256:2134b4b8c40cb21295524c5d27e0de267513178872a697b329760d24c8529c78"},{"index":3,"label":"name:Upload exact native CheckRun bridge receipt","authority":"evidence-publication","definitionDigest":"sha256:0738c87b720b7aca17c51a18e36864e6329e7fb64d75cd89549be39e5fa4c0e4"}]
         },
         {
           "id": "resolve-target",

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -198,7 +198,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:8db5f303719ccf3df51acf4f196a340d5b6e459c4ad5cac7b77a36404bf91d0c"
+          "sourceRoot": "sha256:e9bccaff4edbea90ad1cd1681386ae7f01e4d1c86614c477c1cf14263b108457"
         },
         {
           "path": ".github/workflows/dev-gate-latency-patrol.yml",
@@ -877,5 +877,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:ebe9a1138607e2a51d76cbbbddf9c73109110a050551deb5555b21fcfa2a6a22"
+  "registryRoot": "sha256:d2be4baae8eb35843c691e7fbf8198b09f9706cb5b791daefb6cf1df8135f6ce"
 }

--- a/scripts/dev-pr-auto-merge.test.mjs
+++ b/scripts/dev-pr-auto-merge.test.mjs
@@ -295,7 +295,7 @@ test('Qualified native proof re-runs the exact failed source jobs before landing
   assert.doesNotMatch(bridge, /checks: write/u);
   assert.match(
     bridge,
-    /name: buildchain-dev-delivery-control-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}-\$\{\{ needs\.resolve-target\.outputs\.expected-pr-number \}\}/u,
+    /pattern: buildchain-dev-delivery-warrant-\*-\$\{\{ needs\.resolve-target\.outputs\.expected-pr-number \}\}[\s\S]*merge-multiple: true/u,
   );
   assert.match(
     bridge,


### PR DESCRIPTION
## Summary

Repair the protected Dev PR controller so the native CheckRun bridge downloads the final qualified Warrant artifact instead of the earlier provisional admission-control artifact.

Live failure evidence: repository-dispatch run 33461163549 completed native execution and independent evidence sealing successfully, then failed because buildchain-dev-delivery-control-33461163549-1-3623 still contained phase=provisional while the bridge correctly required phase=qualified. The same run produced buildchain-dev-delivery-warrant-dev-v4-v4.0-3623 with the qualified evidence.

## Changes

- Select the PR-scoped buildchain-dev-delivery-warrant-* artifact emitted by the credentialed finalizer.
- Merge the single matching artifact into the existing fail-closed candidate resolver.
- Keep exact PR/head/source-run, phase, root, expiry, and single-resolution checks unchanged.
- Refresh checked workflow authority and release publication roots.

## Verification

- 55/55 focused workflow, Gate catalog, and publication-control tests passed.
- Full staged Kungfu pre-commit/source gate passed.
- Workflow authority and release publication control-plane checks passed.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This focused delivery-controller correction restores the already-declared qualified-Warrant evidence path without changing product or release architecture."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation/checked authority roots updated