### PR TITLE
test(agent): make signed app layout expectation portable

### DIFF
--- a/framework/agent-session/tests/capsule-transport-runtime.test.mjs
+++ b/framework/agent-session/tests/capsule-transport-runtime.test.mjs
@@ -123,19 +123,36 @@ test('Capsule node-pty resolution is lazy and reports an optional capability', (
 });
 
 test('Capsule node-pty resolution includes the signed desktop app layout', () => {
-  assert.deepEqual(
-    capsuleNodePtyCandidates({
-      bundleDirectory:
-        '/Applications/Kungfu Episodes.app/Contents/Resources/tui',
-    }),
-    [
-      null,
-      null,
-      '/Applications/Kungfu Episodes.app/Contents/Resources/tui/node_modules/node-pty/lib/index.js',
-      '/Applications/Kungfu Episodes.app/Contents/Resources/node_modules/node-pty/lib/index.js',
-      '/Applications/Kungfu Episodes.app/Contents/Resources/app/node_modules/node-pty/lib/index.js',
-    ],
+  const bundleDirectory = path.join(
+    path.sep,
+    'Applications',
+    'Kungfu Episodes.app',
+    'Contents',
+    'Resources',
+    'tui',
   );
+  assert.deepEqual(capsuleNodePtyCandidates({ bundleDirectory }), [
+    null,
+    null,
+    path.join(bundleDirectory, 'node_modules', 'node-pty', 'lib', 'index.js'),
+    path.join(
+      bundleDirectory,
+      '..',
+      'node_modules',
+      'node-pty',
+      'lib',
+      'index.js',
+    ),
+    path.join(
+      bundleDirectory,
+      '..',
+      'app',
+      'node_modules',
+      'node-pty',
+      'lib',
+      'index.js',
+    ),
+  ]);
 });
 
 test('the detached control core starts without node-pty for native sessions', async () => {


### PR DESCRIPTION
## Summary

Make the signed desktop App node-pty layout assertion use the host-native `node:path` implementation instead of hard-coding a POSIX `/Applications/...` expectation.

This is the fresh protected-dev successor to closed PR #3621. It preserves the exact production candidates and changes only the cross-platform test construction exposed by Alpha.4 v16 Full Build run `33445853523` on Windows.

Exact head: `78c7473cfd47ba4ee370a3f393b0117505d1c995`
Protected base at cut: `731ae3c60aa09cceafbbb1447578355832082b2d`
Current protected controller merge: `09ec64ba86b1a4c9668285cb126a4e05f6df8b98`

## Verification

- `node --test framework/agent-session/tests/capsule-transport-runtime.test.mjs`: 5/5 pass.
- `node --test scripts/check-work-design-preflight.test.mjs scripts/documentation-product-pack.test.mjs`: 36/36 pass.
- Project Cut: qualified, one replayed commit, `compositionChanged=false` on the original protected base; the patch is independent of the subsequently merged delivery-controller change.
- DCO signed and worktree clean.

The Work Design closure remains read-only, explicit-only for manual capture, and complete for App assembly, wheel, installed product, missing dependency, undeclared static ESM dependency, and POSIX/Windows path handling.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This test-only portability correction preserves the existing signed App layout contract while expressing its expected path with the host-native path implementation."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
