### PR TITLE
fix(tui): restore installed work lab bootstrap

### DIFF
--- a/framework/tui/src/main.tsx
+++ b/framework/tui/src/main.tsx
@@ -376,7 +376,16 @@ const EXIT_HISTORY_STATUS_FALLBACK: ExitHistoryStatus = {
 async function openTuiAgentWorkLab(projectTour = false): Promise<AgentWorkLab> {
   const paths = runtimePaths();
   const cli = tuiCliInvocation(paths);
-  bindMockAgentEnvironment(cli, paths);
+  const { mockPath } = resolveTuiAgentSessionPaths({
+    env: process.env,
+    argvEntry: process.argv[1],
+    modulePath: fileURLToPath(import.meta.url),
+  });
+  cli.env = bindTuiMockAgentEnvironment({
+    env: cli.env,
+    packagedBin: paths.packagedBin,
+    mockPath,
+  });
   if (projectTour) {
     const endpoint = await ensureTuiAgentSession(paths.runtimeDir);
     cli.env.KUNGFU_AGENT_SESSION_ENDPOINT = endpoint;

--- a/framework/tui/src/project-tour-view.test.ts
+++ b/framework/tui/src/project-tour-view.test.ts
@@ -50,6 +50,7 @@ test('Project Work awaits the shared Agent Session before rendering', () => {
   );
   const lab = source.slice(
     source.indexOf('async function openTuiAgentWorkLab'),
+    source.indexOf('function openTuiProjects'),
   );
   assert.match(
     lab,


### PR DESCRIPTION
## Summary

Restore the installed TUI Project Work bootstrap binding removed by the helper refactor, and tighten the existing regression test so it inspects the actual openTuiAgentWorkLab implementation.

Alpha.4 v17 Full Build run 33516523865 proved the production failure from the immutable App assembly: installed TUI bootstrap exited with bindMockAgentEnvironment is not defined. The source already imports bindTuiMockAgentEnvironment; this patch resolves the installed session paths explicitly and applies that binding before creating the Project CLI.

Exact head: 77f44dabf087255a2f94106698effc5df8b8faa0
Protected base at cut: 6b1145f3297653eaf92d7a451fd0f9ee4bb5b674
Failed immutable Alpha candidate: PR #3637 / ad26601b39ddc36f71a2822d8fbd63584ddf9dd4

## Verification

- Focused TUI suite: 40/40 pass, including real PTY lifecycle smoke.
- TUI build: pass.
- TUI bundle: pass.
- Hostile bundle startup against the installed App runtime from an empty temporary HOME and source-independent working directory: qualified Agent Work Lab report; no undefined symbol.
- Staged repository gate: pass.
- Full source gate reached 1213 Node tests with 1202 pass, 11 skip, 0 fail plus Work Design isolated packaging tests 16/16; its redundant cold Python dependency tail was stopped locally and remains owned by protected CI.

This is a minimal production bootstrap correction. It does not change Work Design authority, manual-capture policy, Assignment, Project Cut, release gates, or any immutable Alpha.3/v17 artifact.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This production bugfix restores the existing installed TUI bootstrap binding and strengthens the regression test without changing architecture or authority."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] release evidence, provenance, package publishing, or deployment surfaces
- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed