### PR TITLE
fix(release): admit shallow equivalent publication source

### DIFF
--- a/scripts/assemble-kungfu-publication-gate.mjs
+++ b/scripts/assemble-kungfu-publication-gate.mjs
@@ -248,6 +248,50 @@ export function resolveGitTreeSha({ repositoryRoot, sourceSha }) {
   return treeSha;
 }
 
+export function resolvePublicationSourceTreeSha({
+  repositoryRoot,
+  evidenceSourceSha,
+  targetSourceSha = '',
+  expectedSourceTreeSha = '',
+}) {
+  if (!/^[0-9a-f]{40}$/.test(evidenceSourceSha))
+    throw new Error('promotion source SHA must be an exact commit SHA');
+  try {
+    return resolveGitTreeSha({
+      repositoryRoot,
+      sourceSha: evidenceSourceSha,
+    });
+  } catch (error) {
+    if (!targetSourceSha) throw error;
+  }
+
+  if (!/^[0-9a-f]{40}$/.test(targetSourceSha))
+    throw new Error(
+      'publication target source SHA must be an exact commit SHA',
+    );
+  if (!/^[0-9a-f]{40}$/.test(expectedSourceTreeSha))
+    throw new Error(
+      'publication evidence source tree must be an exact Git tree SHA',
+    );
+
+  let targetSourceTreeSha;
+  try {
+    targetSourceTreeSha = resolveGitTreeSha({
+      repositoryRoot,
+      sourceSha: targetSourceSha,
+    });
+  } catch {
+    throw new Error(
+      `publication target commit is unavailable in the publication subject: ${targetSourceSha}`,
+    );
+  }
+  if (targetSourceTreeSha !== expectedSourceTreeSha)
+    throw new Error(
+      'publication target source tree does not match the release candidate',
+    );
+  return targetSourceTreeSha;
+}
+
 export function validateKungfuReleaseCandidatePassport({
   candidate,
   passport,
@@ -268,6 +312,8 @@ export async function assembleKungfuPublicationGate({
   evidenceRoot,
   runtimeRoot,
   sourceSha,
+  targetSourceSha = '',
+  evidenceSourceTreeSha = '',
   targetRef,
   outputPath,
 }) {
@@ -344,9 +390,18 @@ export async function assembleKungfuPublicationGate({
     throw new Error(
       `release-candidate passport is invalid: ${passportValidation.errors.join('; ')}`,
     );
-  const promotionTree = resolveGitTreeSha({
+  if (
+    evidenceSourceTreeSha &&
+    evidenceSourceTreeSha !== passport.source.treeHash
+  )
+    throw new Error(
+      'publication evidence source tree does not match the release candidate passport',
+    );
+  const promotionTree = resolvePublicationSourceTreeSha({
     repositoryRoot: subjectRoot,
-    sourceSha,
+    evidenceSourceSha: sourceSha,
+    targetSourceSha,
+    expectedSourceTreeSha: evidenceSourceTreeSha,
   });
 
   const controllerValidation = controllers.validateControllerReceipt(
@@ -500,6 +555,9 @@ async function main() {
     evidenceRoot: process.env.BUILDCHAIN_PUBLICATION_EVIDENCE_ROOT,
     runtimeRoot: process.env.BUILDCHAIN_PUBLICATION_AUTHORITY_RUNTIME_ROOT,
     sourceSha: process.env.BUILDCHAIN_PUBLICATION_SOURCE_SHA,
+    targetSourceSha: process.env.BUILDCHAIN_PUBLICATION_TARGET_SOURCE_SHA || '',
+    evidenceSourceTreeSha:
+      process.env.BUILDCHAIN_PUBLICATION_EVIDENCE_SOURCE_TREE || '',
     targetRef: process.env.BUILDCHAIN_PUBLICATION_TARGET_REF,
     outputPath: process.env.BUILDCHAIN_PUBLICATION_GATE_RESULT_PATH,
   });

--- a/scripts/assemble-kungfu-publication-gate.test.mjs
+++ b/scripts/assemble-kungfu-publication-gate.test.mjs
@@ -6,11 +6,12 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import {
   bindKungfuPublicationGateAggregate,
   createKungfuPublicationGateAggregate,
   resolveGitTreeSha,
+  resolvePublicationSourceTreeSha,
   validateKungfuReleaseCandidatePassport,
 } from './assemble-kungfu-publication-gate.mjs';
 
@@ -92,6 +93,54 @@ function gitTreeFixture() {
     evidenceSourceTreeSha,
     equivalentTargetSourceSha,
     differentTargetSourceSha,
+  };
+}
+
+function shallowPublicationSubjectFixture({ differentTarget = false } = {}) {
+  const repositoryRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-publication-source-test-'),
+  );
+  git(repositoryRoot, 'init', '--quiet');
+  git(repositoryRoot, 'config', 'user.name', 'Kungfu Test');
+  git(repositoryRoot, 'config', 'user.email', 'test@kungfu.invalid');
+  fs.writeFileSync(path.join(repositoryRoot, 'candidate.txt'), 'candidate\n');
+  git(repositoryRoot, 'add', 'candidate.txt');
+  git(repositoryRoot, 'commit', '--quiet', '-m', 'candidate');
+  const evidenceSourceSha = git(repositoryRoot, 'rev-parse', 'HEAD');
+  const evidenceSourceTreeSha = git(repositoryRoot, 'rev-parse', 'HEAD^{tree}');
+
+  if (differentTarget) {
+    fs.writeFileSync(path.join(repositoryRoot, 'candidate.txt'), 'different\n');
+    git(repositoryRoot, 'add', 'candidate.txt');
+    git(repositoryRoot, 'commit', '--quiet', '-m', 'different target');
+  } else {
+    git(repositoryRoot, 'commit', '--quiet', '--allow-empty', '-m', 'target');
+  }
+  const targetSourceSha = git(repositoryRoot, 'rev-parse', 'HEAD');
+  const subjectParent = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-publication-subject-test-'),
+  );
+  const subjectRoot = path.join(subjectParent, 'subject');
+  execFileSync(
+    'git',
+    [
+      'clone',
+      '--quiet',
+      '--depth',
+      '1',
+      pathToFileURL(repositoryRoot).href,
+      subjectRoot,
+    ],
+    { stdio: ['ignore', 'pipe', 'pipe'] },
+  );
+
+  return {
+    repositoryRoot,
+    subjectParent,
+    subjectRoot,
+    evidenceSourceSha,
+    evidenceSourceTreeSha,
+    targetSourceSha,
   };
 }
 
@@ -212,6 +261,71 @@ test('publication Gate aggregate rejects candidate reuse for a different target 
     );
   } finally {
     fs.rmSync(fixture.repositoryRoot, { recursive: true, force: true });
+  }
+});
+
+test('publication source tree uses an exact equivalent target in a depth-1 subject', () => {
+  const fixture = shallowPublicationSubjectFixture();
+  try {
+    const evidenceLookup = spawnSync(
+      'git',
+      ['cat-file', '-e', `${fixture.evidenceSourceSha}^{commit}`],
+      { cwd: fixture.subjectRoot },
+    );
+    assert.notEqual(evidenceLookup.status, 0);
+    assert.equal(
+      resolvePublicationSourceTreeSha({
+        repositoryRoot: fixture.subjectRoot,
+        evidenceSourceSha: fixture.evidenceSourceSha,
+        targetSourceSha: fixture.targetSourceSha,
+        expectedSourceTreeSha: fixture.evidenceSourceTreeSha,
+      }),
+      fixture.evidenceSourceTreeSha,
+    );
+  } finally {
+    fs.rmSync(fixture.repositoryRoot, { recursive: true, force: true });
+    fs.rmSync(fixture.subjectParent, { recursive: true, force: true });
+  }
+});
+
+test('publication source tree rejects a different depth-1 target tree', () => {
+  const fixture = shallowPublicationSubjectFixture({ differentTarget: true });
+  try {
+    assert.throws(
+      () =>
+        resolvePublicationSourceTreeSha({
+          repositoryRoot: fixture.subjectRoot,
+          evidenceSourceSha: fixture.evidenceSourceSha,
+          targetSourceSha: fixture.targetSourceSha,
+          expectedSourceTreeSha: fixture.evidenceSourceTreeSha,
+        }),
+      /publication target source tree does not match the release candidate/,
+    );
+  } finally {
+    fs.rmSync(fixture.repositoryRoot, { recursive: true, force: true });
+    fs.rmSync(fixture.subjectParent, { recursive: true, force: true });
+  }
+});
+
+test('publication source tree rejects an unavailable exact target commit', () => {
+  const fixture = shallowPublicationSubjectFixture();
+  try {
+    const unavailableTargetSourceSha = 'f'.repeat(40);
+    assert.throws(
+      () =>
+        resolvePublicationSourceTreeSha({
+          repositoryRoot: fixture.subjectRoot,
+          evidenceSourceSha: fixture.evidenceSourceSha,
+          targetSourceSha: unavailableTargetSourceSha,
+          expectedSourceTreeSha: fixture.evidenceSourceTreeSha,
+        }),
+      new RegExp(
+        `publication target commit is unavailable in the publication subject: ${unavailableTargetSourceSha}`,
+      ),
+    );
+  } finally {
+    fs.rmSync(fixture.repositoryRoot, { recursive: true, force: true });
+    fs.rmSync(fixture.subjectParent, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Summary

Allow the Alpha publication recovery controller to prove an unavailable sealed PR merge-ref through the exact target commit already checked out in a depth-1 publication subject, but only when that target tree is identical to the sealed candidate Passport tree.

The first exact Alpha.4 v19 recovery run `33554975106` failed closed before publication because evidence source `da72e0899c9ff09501e2b31008e7fd09ef3872f6` is intentionally unreachable from the depth-1 target checkout at `3ec1f6b1072fd6aa516d35634fffe801172b7cd8`. Both commits bind tree `33cd9210897f965b4ab91b12f3bfdec05ee5870d`.

Exact head: `c2a28b934bccb74e8d49951b574b379d34758128`
Protected base at cut: `9fb10b89da1ed5d25c1fa32843a4a1e6ce795d06`
Sealed immutable candidate: Build run `33543172280` / source `da72e0899c9ff09501e2b31008e7fd09ef3872f6`

## Safety and behavior

- The evidence aggregate remains bound to its sealed evidence source for the outer Buildchain recovery rebind.
- Fallback requires an exact target commit SHA, an exact expected evidence tree SHA, a locally resolvable target commit, and byte-identical target/candidate trees.
- A different tree or unavailable target fails closed.
- Alpha.3 and the immutable v19 candidate are not modified or rebuilt.

## Verification

- `node --test scripts/assemble-kungfu-publication-gate.test.mjs`: 11 pass, 1 environment-dependent skip, 0 fail.
- Added real depth-1 Git fixture coverage for equivalent target, different target tree, and unavailable exact target.
- `./shifu check`: passed, including the existing isolated Work Design assembly closure suite and release promotion contracts.
- Commit-time staged gate: passed.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This recovery bugfix preserves the existing exact-tree publication authority while making it executable in an intentional depth-1 target checkout."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed
