### PR TITLE
fix(release): pass qualification evidence arguments directly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,7 +251,7 @@ jobs:
       # Functional native qualification stays credential-free. The declarative
       # signing inventory lets Buildchain seal the exact unsigned macOS app and
       # finalize signing and notarization inside its protected authority.
-      verify-command: node scripts/run-shifu-lifecycle.mjs cache-apply ${{ startsWith(github.base_ref, 'release/') && 'release:qualify:candidate' || 'alpha:qualify' }} -- --kfd-source-input-root ${{ needs.preflight.outputs.kfd-source-input-root }} --source-only-receipt-root ${{ needs.preflight.outputs.receipt-root }} --source-only-source-tree ${{ needs.preflight.outputs.source-tree }} --source-only-policy-root ${{ needs.preflight.outputs.policy-root }}
+      verify-command: node scripts/run-shifu-lifecycle.mjs cache-apply ${{ startsWith(github.base_ref, 'release/') && 'release:qualify:candidate' || 'alpha:qualify' }} --kfd-source-input-root ${{ needs.preflight.outputs.kfd-source-input-root }} --source-only-receipt-root ${{ needs.preflight.outputs.receipt-root }} --source-only-source-tree ${{ needs.preflight.outputs.source-tree }} --source-only-policy-root ${{ needs.preflight.outputs.policy-root }}
       release-candidate: true
       publish-channel: ${{ (fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'self-hosted' || fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'github-hosted') && 'none' || (github.event_name == 'pull_request' && (startsWith(github.base_ref, 'release/') && 'release' || 'alpha') || 'none') }}
       # Keep the external-runner relay request explicit. Buildchain resolves

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -338,7 +338,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "qualifying",
-          "definitionDigest": "sha256:883d0b2d9211d27ff8ccbef2097424a4d5df2b41dd21040ff3a0b2d682b2d774",
+          "definitionDigest": "sha256:092a9c8f6f61e64319e4e34fca21e78109e05133ebf968301d8ce34f2fcd74c8",
           "credentials": {"githubToken":"write","oidc":true,"repositorySecrets":["BUILDCHAIN_ARTIFACT_RELAY_S3_DOWNLOAD_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_ROLE_ARN","BUILDCHAIN_ARTIFACT_RELAY_S3_UPLOAD_ROLE_ARN","KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/.build.yml@675b4f2a51af7e5f2aac58011c7ede0313b2b105"],
           "steps": []

--- a/docs/qualification/gates/workflow-bindings.json
+++ b/docs/qualification/gates/workflow-bindings.json
@@ -535,7 +535,7 @@
           "require-install": true,
           "require-build": true,
           "require-verify": true,
-          "verify-command": "node scripts/run-shifu-lifecycle.mjs cache-apply ${{ startsWith(github.base_ref, 'release/') && 'release:qualify:candidate' || 'alpha:qualify' }} -- --kfd-source-input-root ${{ needs.preflight.outputs.kfd-source-input-root }} --source-only-receipt-root ${{ needs.preflight.outputs.receipt-root }} --source-only-source-tree ${{ needs.preflight.outputs.source-tree }} --source-only-policy-root ${{ needs.preflight.outputs.policy-root }}",
+          "verify-command": "node scripts/run-shifu-lifecycle.mjs cache-apply ${{ startsWith(github.base_ref, 'release/') && 'release:qualify:candidate' || 'alpha:qualify' }} --kfd-source-input-root ${{ needs.preflight.outputs.kfd-source-input-root }} --source-only-receipt-root ${{ needs.preflight.outputs.receipt-root }} --source-only-source-tree ${{ needs.preflight.outputs.source-tree }} --source-only-policy-root ${{ needs.preflight.outputs.policy-root }}",
           "release-candidate": true,
           "publish-channel": "${{ (fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'self-hosted' || fromJSON(inputs.macos-overflow-request-json || '{}').mode == 'github-hosted') && 'none' || (github.event_name == 'pull_request' && (startsWith(github.base_ref, 'release/') && 'release' || 'alpha') || 'none') }}",
           "artifact-transfer-mode": "s3-to-github-artifacts",

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -136,7 +136,7 @@
             "product-stable",
             "product-binaries"
           ],
-          "sourceRoot": "sha256:f99058012e5426e8a6999ccad84fd08c0ef3d42566b48af4ee768ae4b915303f"
+          "sourceRoot": "sha256:60fac6ea28e32abde8b1ded9847b5659be9bf421417c90919d7db0784009861c"
         },
         {
           "path": ".github/workflows/buildchain-validate.yml",
@@ -877,5 +877,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:e3461b29a3164767c71ce0b2e014c47114bff1f56fcd7ae997303b0bb9072203"
+  "registryRoot": "sha256:284d7b639648708a12b0210c4e3255e06468d84466ec7b4edf0757385edcb642"
 }

--- a/scripts/alpha-promotion-preflight.test.mjs
+++ b/scripts/alpha-promotion-preflight.test.mjs
@@ -177,6 +177,10 @@ test('Alpha build lanes reuse one exact-tree source receipt in the product-owned
     workflow,
     /cache-apply[^\n]+alpha:qualify[^\n]+--source-only-receipt-root \$\{\{ needs\.preflight\.outputs\.receipt-root \}\}[^\n]+--source-only-source-tree \$\{\{ needs\.preflight\.outputs\.source-tree \}\}/u,
   );
+  assert.doesNotMatch(
+    workflow,
+    /(?:alpha:qualify' \}\}|release:qualify:candidate) -- --kfd-source-input-root/u,
+  );
   assert.doesNotMatch(workflow, /verify-substage-evidence-path/u);
 });
 


### PR DESCRIPTION
## Summary

Deliver fix(release): pass qualification evidence arguments directly from fix/alpha5-qualify-argv into dev/v4/v4.0 through the kungfu-systems dual-account PR flow.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This maintenance delivery does not alter an architecture decision."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] none of the above

## Checklist

- [x] Commits are signed off (DCO)