### PR TITLE
fix(buildchain): preserve Warrant through protected landing

### DIFF
--- a/.github/workflows/dev-pr-auto-merge.yml
+++ b/.github/workflows/dev-pr-auto-merge.yml
@@ -703,7 +703,10 @@ jobs:
       native-heartbeat-seconds: 300
       delivery-class: ${{ needs.delivery-contract.outputs.delivery-class || 'native-proof-required' }}
       delivery-priority: ${{ needs.delivery-contract.outputs.priority || 'ordinary' }}
-      warrant-lease-seconds: 5400
+      # The qualified Warrant must remain live across the bounded 120-minute
+      # source retry plus the protected merge-group qualification.  A 90-minute
+      # lease expires deterministically between those two fail-closed stages.
+      warrant-lease-seconds: 14400
       required-status-checks: |-
         Candidate source acceptance / check
       queue-admission-context: Queue admission lease
@@ -1063,7 +1066,9 @@ jobs:
       native-heartbeat-seconds: 300
       delivery-class: ${{ needs.delivery-contract.outputs.delivery-class || 'native-proof-required' }}
       delivery-priority: ${{ needs.delivery-contract.outputs.priority || 'ordinary' }}
-      warrant-lease-seconds: 5400
+      # Preserve the same exact-candidate lease window when the deferred
+      # landing call consumes the already-qualified Warrant.
+      warrant-lease-seconds: 14400
       required-status-checks: |-
         Candidate source acceptance / check
       queue-admission-context: Queue admission lease

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -641,7 +641,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:c557513ed3609d1102777f5d9d88c74900e9de92443be15a1445d47f6fc6b4b9",
+          "definitionDigest": "sha256:33ede7c62cd843ae525cad2f0da4589e9aa5f6c1068b916c2fbe35ca7691057d",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@3553236e52ba9daa0b83422aec269d14a6bc65ad"],
           "steps": []
@@ -661,7 +661,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:c00b7b5458f7ed65d20d75aaa1a19aeddb4704c72d83464363d24788750b1064",
+          "definitionDigest": "sha256:cb382de4cdaf2fccd4f6c51d8c3e11e3b4437902d4a55af704f2e659ea2a73f5",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@3553236e52ba9daa0b83422aec269d14a6bc65ad"],
           "steps": []

--- a/scripts/dev-pr-auto-merge.test.mjs
+++ b/scripts/dev-pr-auto-merge.test.mjs
@@ -241,6 +241,12 @@ test('Dev auto-merge waits for PR checks and lands through the native queue', ()
     /native-command: >-[\s\S]*KUNGFU_FNM_DIST_MIRROR=\$\{\{ vars\.KUNGFU_FNM_DIST_MIRROR \}\}[\s\S]*KUNGFU_FNM_SHA256=\$\{\{ vars\.KUNGFU_FNM_SHA256 \}\}[\s\S]*dev-delivery:native-under-warrant/u,
   );
   assert.match(workflow, /native-heartbeat-seconds: 300/u);
+  assert.equal(
+    [...workflow.matchAll(/warrant-lease-seconds: 14400/gu)].length,
+    2,
+    'qualification and landing must both preserve a lease that covers the bounded source retry and merge-group qualification',
+  );
+  assert.doesNotMatch(workflow, /warrant-lease-seconds: 5400/u);
   assert.match(
     workflow,
     /native-proof-json: \$\{\{ needs\.delivery-contract\.outputs\.native-proof-json \}\}/u,

--- a/scripts/dev-pr-auto-merge.test.mjs
+++ b/scripts/dev-pr-auto-merge.test.mjs
@@ -241,9 +241,12 @@ test('Dev auto-merge waits for PR checks and lands through the native queue', ()
     /native-command: >-[\s\S]*KUNGFU_FNM_DIST_MIRROR=\$\{\{ vars\.KUNGFU_FNM_DIST_MIRROR \}\}[\s\S]*KUNGFU_FNM_SHA256=\$\{\{ vars\.KUNGFU_FNM_SHA256 \}\}[\s\S]*dev-delivery:native-under-warrant/u,
   );
   assert.match(workflow, /native-heartbeat-seconds: 300/u);
-  assert.equal(
-    [...workflow.matchAll(/warrant-lease-seconds: 14400/gu)].length,
-    2,
+  const warrantLeaseSeconds = [
+    ...workflow.matchAll(/warrant-lease-seconds: (\d+)/gu),
+  ].map((match) => Number(match[1]));
+  assert.deepEqual(
+    warrantLeaseSeconds,
+    [14400, 14400],
     'qualification and landing must both preserve a lease that covers the bounded source retry and merge-group qualification',
   );
   assert.doesNotMatch(workflow, /warrant-lease-seconds: 5400/u);


### PR DESCRIPTION
## Summary

- Extend the exact Delivery Warrant lease to cover the bounded source retry and protected merge-group qualification.
- Keep qualification and deferred landing on the same fail-closed lease window.
- Add a contract assertion and refresh workflow authority.

## Safety boundaries

- Does not bypass or weaken any protected gate.
- Keeps the lease finite and exact-candidate fenced.
- Does not change product code or publish a release.

## Validation

- `node --test scripts/dev-pr-auto-merge.test.mjs`
- repository pre-commit gates

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Corrects the bounded lease window for the existing protected delivery protocol without changing architecture or publishing a release"
}
-->
