### PR TITLE
fix(buildchain): preserve Warrant through protected landing

### DIFF
--- a/.github/workflows/dev-pr-auto-merge.yml
+++ b/.github/workflows/dev-pr-auto-merge.yml
@@ -703,7 +703,10 @@ jobs:
       native-heartbeat-seconds: 300
       delivery-class: ${{ needs.delivery-contract.outputs.delivery-class || 'native-proof-required' }}
       delivery-priority: ${{ needs.delivery-contract.outputs.priority || 'ordinary' }}
-      warrant-lease-seconds: 5400
+      # The qualified Warrant must remain live across the bounded 120-minute
+      # source retry plus the protected merge-group qualification.  A 90-minute
+      # lease expires deterministically between those two fail-closed stages.
+      warrant-lease-seconds: 14400
       required-status-checks: |-
         Candidate source acceptance / check
       queue-admission-context: Queue admission lease
@@ -1063,7 +1066,9 @@ jobs:
       native-heartbeat-seconds: 300
       delivery-class: ${{ needs.delivery-contract.outputs.delivery-class || 'native-proof-required' }}
       delivery-priority: ${{ needs.delivery-contract.outputs.priority || 'ordinary' }}
-      warrant-lease-seconds: 5400
+      # Preserve the same exact-candidate lease window when the deferred
+      # landing call consumes the already-qualified Warrant.
+      warrant-lease-seconds: 14400
       required-status-checks: |-
         Candidate source acceptance / check
       queue-admission-context: Queue admission lease

--- a/docs/qualification/gates/workflow-authority.json
+++ b/docs/qualification/gates/workflow-authority.json
@@ -641,7 +641,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:c557513ed3609d1102777f5d9d88c74900e9de92443be15a1445d47f6fc6b4b9",
+          "definitionDigest": "sha256:33ede7c62cd843ae525cad2f0da4589e9aa5f6c1068b916c2fbe35ca7691057d",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@3553236e52ba9daa0b83422aec269d14a6bc65ad"],
           "steps": []
@@ -661,7 +661,7 @@
           "authority": "qualification",
           "publication": "none",
           "receipt": "diagnostic",
-          "definitionDigest": "sha256:c00b7b5458f7ed65d20d75aaa1a19aeddb4704c72d83464363d24788750b1064",
+          "definitionDigest": "sha256:cb382de4cdaf2fccd4f6c51d8c3e11e3b4437902d4a55af704f2e659ea2a73f5",
           "credentials": {"githubToken":"write","oidc":false,"repositorySecrets":["KUNGFU_GITHUB_TOKEN"],"inheritedSecrets":false,"environment":null},
           "externalActions": ["kungfu-systems/buildchain/.github/workflows/dev-pr-auto-merge.yml@3553236e52ba9daa0b83422aec269d14a6bc65ad"],
           "steps": []

--- a/framework/release/publication-surfaces.json
+++ b/framework/release/publication-surfaces.json
@@ -198,7 +198,7 @@
           "classification": "non-publication",
           "owner": "kungfu-ci",
           "surfaceIds": [],
-          "sourceRoot": "sha256:a4c3835a0f4bdfa2e9dc98b051374a7c7a0ff2c1c09de95d01db75896e924e03"
+          "sourceRoot": "sha256:b72bd1d663f0033f7fdc99da8aa154bd36545302db7332d6e4b8f8f57234df38"
         },
         {
           "path": ".github/workflows/dev-gate-latency-patrol.yml",
@@ -877,5 +877,5 @@
       }
     }
   ],
-  "registryRoot": "sha256:284d7b639648708a12b0210c4e3255e06468d84466ec7b4edf0757385edcb642"
+  "registryRoot": "sha256:5f6ec7a92a50c192d801092241616ff8cdd23c1808bb82c9eacb7ff0859f49f5"
 }

--- a/scripts/dev-pr-auto-merge.test.mjs
+++ b/scripts/dev-pr-auto-merge.test.mjs
@@ -241,6 +241,12 @@ test('Dev auto-merge waits for PR checks and lands through the native queue', ()
     /native-command: >-[\s\S]*KUNGFU_FNM_DIST_MIRROR=\$\{\{ vars\.KUNGFU_FNM_DIST_MIRROR \}\}[\s\S]*KUNGFU_FNM_SHA256=\$\{\{ vars\.KUNGFU_FNM_SHA256 \}\}[\s\S]*dev-delivery:native-under-warrant/u,
   );
   assert.match(workflow, /native-heartbeat-seconds: 300/u);
+  assert.equal(
+    [...workflow.matchAll(/warrant-lease-seconds: 14400/gu)].length,
+    2,
+    'qualification and landing must both preserve a lease that covers the bounded source retry and merge-group qualification',
+  );
+  assert.doesNotMatch(workflow, /warrant-lease-seconds: 5400/u);
   assert.match(
     workflow,
     /native-proof-json: \$\{\{ needs\.delivery-contract\.outputs\.native-proof-json \}\}/u,

--- a/scripts/dev-pr-auto-merge.test.mjs
+++ b/scripts/dev-pr-auto-merge.test.mjs
@@ -241,9 +241,12 @@ test('Dev auto-merge waits for PR checks and lands through the native queue', ()
     /native-command: >-[\s\S]*KUNGFU_FNM_DIST_MIRROR=\$\{\{ vars\.KUNGFU_FNM_DIST_MIRROR \}\}[\s\S]*KUNGFU_FNM_SHA256=\$\{\{ vars\.KUNGFU_FNM_SHA256 \}\}[\s\S]*dev-delivery:native-under-warrant/u,
   );
   assert.match(workflow, /native-heartbeat-seconds: 300/u);
-  assert.equal(
-    [...workflow.matchAll(/warrant-lease-seconds: 14400/gu)].length,
-    2,
+  const warrantLeaseSeconds = [
+    ...workflow.matchAll(/warrant-lease-seconds: (\d+)/gu),
+  ].map((match) => Number(match[1]));
+  assert.deepEqual(
+    warrantLeaseSeconds,
+    [14400, 14400],
     'qualification and landing must both preserve a lease that covers the bounded source retry and merge-group qualification',
   );
   assert.doesNotMatch(workflow, /warrant-lease-seconds: 5400/u);


### PR DESCRIPTION
## Summary

- Keep the exact Delivery Warrant live across bounded source retry and merge-group qualification.
- Refresh workflow authority and release publication source roots.
- Add exact lease-window contract coverage.

## Safety boundaries

- Finite, exact-candidate fenced lease; no gate bypass.
- No product code or release publication.

## Validation

- `node --test scripts/dev-pr-auto-merge.test.mjs`
- `./shifu check:release-publication-control-plane`
- repository commit gates

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "Corrects the bounded protected-delivery lease and closes its generated authority roots without architecture or release changes"
}
-->
