### PR TITLE
fix(delivery): close Warrant bootstrap imports

### DIFF
--- a/scripts/affected-native-proof-bootstrap.test.mjs
+++ b/scripts/affected-native-proof-bootstrap.test.mjs
@@ -8,16 +8,15 @@ import { fileURLToPath } from 'node:url';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
-test('affected-native proof bootstrap has no installed package imports', () => {
-  const sourceOnlyModules = [
-    'scripts/affected-native-proof.mjs',
-    'scripts/project-cut-family-queue-lease.mjs',
-    'product/release/affected-native-artifact-lookup.mjs',
-    'product/release/affected-native-proof-cli.mjs',
-    'framework/spec/format/project-cut-canonical-json.mjs',
-  ];
-  for (const relativePath of sourceOnlyModules) {
-    const source = fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
+function assertSourceOnlyClosure(entryModules) {
+  const pending = [...entryModules];
+  const visited = new Set();
+  while (pending.length > 0) {
+    const relativePath = pending.pop();
+    if (visited.has(relativePath)) continue;
+    visited.add(relativePath);
+    const absolutePath = path.join(ROOT, relativePath);
+    const source = fs.readFileSync(absolutePath, 'utf8');
     const specifiers = [
       ...source.matchAll(/(?:from|import)\s+['"]([^'"]+)['"]/gu),
     ].map((match) => match[1]);
@@ -29,5 +28,28 @@ test('affected-native proof bootstrap has no installed package imports', () => {
       [],
       `${relativePath} must run before workspace dependencies are installed`,
     );
+    for (const specifier of specifiers.filter((entry) =>
+      entry.startsWith('.'),
+    )) {
+      pending.push(
+        path.relative(
+          ROOT,
+          path.resolve(path.dirname(absolutePath), specifier),
+        ),
+      );
+    }
   }
+  return visited;
+}
+
+test('affected-native proof bootstrap has no installed package imports', () => {
+  const closure = assertSourceOnlyClosure([
+    'scripts/affected-native-proof.mjs',
+    'scripts/dev-delivery-warrant-input.mjs',
+  ]);
+  assert.ok(closure.has('scripts/project-cut-family-queue-lease.mjs'));
+  assert.equal(
+    closure.has('scripts/project-cut-merge-queue-admission.mjs'),
+    false,
+  );
 });

--- a/scripts/affected-native-proof-bootstrap.test.mjs
+++ b/scripts/affected-native-proof-bootstrap.test.mjs
@@ -2,54 +2,57 @@
 
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SOURCE_ONLY_CLOSURE = [
+  'scripts/affected-native-proof.mjs',
+  'scripts/dev-delivery-warrant-input.mjs',
+  'scripts/project-cut-family-queue-lease.mjs',
+  'product/release/affected-native-artifact-lookup.mjs',
+  'product/release/affected-native-proof-cli.mjs',
+  'framework/spec/format/project-cut-canonical-json.mjs',
+];
 
-function assertSourceOnlyClosure(entryModules) {
-  const pending = [...entryModules];
-  const visited = new Set();
-  while (pending.length > 0) {
-    const relativePath = pending.pop();
-    if (visited.has(relativePath)) continue;
-    visited.add(relativePath);
-    const absolutePath = path.join(ROOT, relativePath);
-    const source = fs.readFileSync(absolutePath, 'utf8');
-    const specifiers = [
-      ...source.matchAll(/(?:from|import)\s+['"]([^'"]+)['"]/gu),
-    ].map((match) => match[1]);
-    assert.deepEqual(
-      specifiers.filter(
-        (specifier) =>
-          !specifier.startsWith('node:') && !specifier.startsWith('.'),
-      ),
-      [],
-      `${relativePath} must run before workspace dependencies are installed`,
-    );
-    for (const specifier of specifiers.filter((entry) =>
-      entry.startsWith('.'),
-    )) {
-      pending.push(
-        path.relative(
-          ROOT,
-          path.resolve(path.dirname(absolutePath), specifier),
-        ),
-      );
-    }
+function copySourceOnlyClosure(destination, omitted = '') {
+  for (const relativePath of SOURCE_ONLY_CLOSURE) {
+    if (relativePath === omitted) continue;
+    const output = path.join(destination, relativePath);
+    fs.mkdirSync(path.dirname(output), { recursive: true });
+    fs.copyFileSync(path.join(ROOT, relativePath), output);
   }
-  return visited;
 }
 
-test('affected-native proof bootstrap has no installed package imports', () => {
-  const closure = assertSourceOnlyClosure([
-    'scripts/affected-native-proof.mjs',
-    'scripts/dev-delivery-warrant-input.mjs',
-  ]);
-  assert.ok(closure.has('scripts/project-cut-family-queue-lease.mjs'));
-  assert.equal(
-    closure.has('scripts/project-cut-merge-queue-admission.mjs'),
-    false,
+test('affected-native Warrant bootstrap loads from its source-only closure', async (t) => {
+  const destination = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-warrant-bootstrap-'),
+  );
+  t.after(() => fs.rmSync(destination, { recursive: true, force: true }));
+  copySourceOnlyClosure(destination);
+  assert.equal(fs.existsSync(path.join(destination, 'node_modules')), false);
+  await import(
+    `${pathToFileURL(path.join(destination, 'scripts/dev-delivery-warrant-input.mjs')).href}?complete`
+  );
+});
+
+test('affected-native Warrant bootstrap fails when its source closure is incomplete', async (t) => {
+  const destination = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kungfu-warrant-bootstrap-missing-'),
+  );
+  t.after(() => fs.rmSync(destination, { recursive: true, force: true }));
+  copySourceOnlyClosure(
+    destination,
+    'scripts/project-cut-family-queue-lease.mjs',
+  );
+  await assert.rejects(
+    import(
+      `${pathToFileURL(path.join(destination, 'scripts/dev-delivery-warrant-input.mjs')).href}?missing`
+    ),
+    (error) =>
+      error?.code === 'ERR_MODULE_NOT_FOUND' &&
+      String(error.message).includes('project-cut-family-queue-lease.mjs'),
   );
 });

--- a/scripts/dev-delivery-warrant-input.mjs
+++ b/scripts/dev-delivery-warrant-input.mjs
@@ -6,7 +6,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { digest } from './affected-native-proof.mjs';
-import { parseFamilyQueueLeaseMarker } from './project-cut-merge-queue-admission.mjs';
+import { parseFamilyQueueLeaseMarker } from './project-cut-family-queue-lease.mjs';
 
 const ROOT = /^sha256:[0-9a-f]{64}$/u;
 const SHA = /^[0-9a-f]{40}$/u;


### PR DESCRIPTION
## Summary

Keep the protected dev Delivery Warrant input runnable before Kungfu workspace dependencies are installed.

## Related issue

Same-tree bootstrap successor to #3706; unblocks the exact protected delivery of #3705.

## Changes

- import the family queue lease parser from its dependency-free source leaf instead of the full merge-queue admission graph
- load the exact six-file source closure from temporary roots without `node_modules`, including an exact missing-leaf negative case

## Verification

- `./shifu check:source` (pass, exit 0)
- independent review of exact head `2868039c042d8bbfcc153d6166e1d2232b4b647f`: accepted, P0/P1/P2 none

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix restores the existing dependency-free protected Warrant bootstrap contract without changing architecture authority"
}
-->

## [Evolution Map](../docs/evolution/README.md) impact

Evolution impact: none

## Governance risk check

Does this PR touch any of these boundaries?

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

This same-repository bootstrap PR permits the existing exact-head merge adapter to repair its protected consumer without weakening #3705's required-Warrant delivery.

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required; existing contract restored)
