### PR TITLE
fix(ci): materialize Work closure for Warrant replay

### DIFF
--- a/.github/workflows/dev-pr-auto-merge.yml
+++ b/.github/workflows/dev-pr-auto-merge.yml
@@ -374,6 +374,17 @@ jobs:
         # shifu-entry-contract: allow bootstrapping the separately checked-out exact Buildchain runtime
         run: corepack pnpm install --frozen-lockfile --ignore-scripts
 
+      - name: Install protected Work consumer dependencies
+        if: >-
+          needs.resolve-target.outputs.source-workflow-run-id != '' &&
+          needs.resolve-target.outputs.expected-pr-number != ''
+        shell: bash
+        # Project Cut executes from the protected checkout and resolves only
+        # the workspace dependencies declared by @kungfu-tech/work.  Keep the
+        # Warrant consumer independent of candidate or developer node_modules.
+        # shifu-entry-contract: allow protected Work dependency bootstrap before the candidate launcher is trusted
+        run: corepack pnpm install --filter '@kungfu-tech/work...' --frozen-lockfile --ignore-scripts
+
       - name: Verify exact source qualification run
         if: >-
           needs.resolve-target.outputs.source-workflow-run-id != '' &&

--- a/.github/workflows/dev-pr-auto-merge.yml
+++ b/.github/workflows/dev-pr-auto-merge.yml
@@ -383,7 +383,7 @@ jobs:
         # the workspace dependencies declared by @kungfu-tech/work.  Keep the
         # Warrant consumer independent of candidate or developer node_modules.
         # shifu-entry-contract: allow protected Work dependency bootstrap before the candidate launcher is trusted
-        run: corepack pnpm install --filter '@kungfu-tech/work...' --frozen-lockfile --ignore-scripts
+        run: corepack pnpm install --filter '@kungfu-tech/work...' --prod --frozen-lockfile --ignore-scripts
 
       - name: Verify exact source qualification run
         if: >-

--- a/.github/workflows/dev-pr-auto-merge.yml
+++ b/.github/workflows/dev-pr-auto-merge.yml
@@ -380,7 +380,7 @@ jobs:
           needs.resolve-target.outputs.expected-pr-number != ''
         shell: bash
         # Project Cut executes from the protected checkout and resolves only
-        # the workspace dependencies declared by @kungfu-tech/work.  Keep the
+        # the production workspace dependencies declared by @kungfu-tech/work. Keep the
         # Warrant consumer independent of candidate or developer node_modules.
         # shifu-entry-contract: allow protected Work dependency bootstrap before the candidate launcher is trusted
         run: corepack pnpm install --filter '@kungfu-tech/work...' --prod --frozen-lockfile --ignore-scripts

--- a/scripts/affected-native-proof-bootstrap.test.mjs
+++ b/scripts/affected-native-proof-bootstrap.test.mjs
@@ -64,6 +64,6 @@ test('protected Project Cut replay materializes its declared Work dependency clo
   );
   assert.match(
     workflow,
-    /name: Check out protected consumer adapter[\s\S]*name: Install protected Work consumer dependencies[\s\S]*corepack pnpm install --filter '@kungfu-tech\/work\.\.\.' --frozen-lockfile --ignore-scripts[\s\S]*name: Produce exact Project Cut replay proof/u,
+    /name: Check out protected consumer adapter[\s\S]*name: Install protected Work consumer dependencies[\s\S]*corepack pnpm install --filter '@kungfu-tech\/work\.\.\.' --prod --frozen-lockfile --ignore-scripts[\s\S]*name: Produce exact Project Cut replay proof/u,
   );
 });

--- a/scripts/affected-native-proof-bootstrap.test.mjs
+++ b/scripts/affected-native-proof-bootstrap.test.mjs
@@ -56,3 +56,14 @@ test('affected-native Warrant bootstrap fails when its source closure is incompl
       String(error.message).includes('project-cut-family-queue-lease.mjs'),
   );
 });
+
+test('protected Project Cut replay materializes its declared Work dependency closure', () => {
+  const workflow = fs.readFileSync(
+    path.join(ROOT, '.github/workflows/dev-pr-auto-merge.yml'),
+    'utf8',
+  );
+  assert.match(
+    workflow,
+    /name: Check out protected consumer adapter[\s\S]*name: Install protected Work consumer dependencies[\s\S]*corepack pnpm install --filter '@kungfu-tech\/work\.\.\.' --frozen-lockfile --ignore-scripts[\s\S]*name: Produce exact Project Cut replay proof/u,
+  );
+});


### PR DESCRIPTION
## Summary

- materialize the protected `@kungfu-tech/work` production dependency closure before exact Project Cut replay
- keep Warrant independent of candidate and developer `node_modules`
- freeze checkout/install/replay ordering with a source-only workflow contract test

## Verification

- `./shifu check:source`
- `node --test scripts/affected-native-proof-bootstrap.test.mjs`
- clean detached protected checkout: production-only filtered Work install, then actual Project Cut replay for PR #3705 passed
- independent review P1 corrected by adding `--prod`; exact-head re-review requested

## Scope

Bootstrap precursor for #3705. This does not weaken Warrant, Project Cut, Queue admission, or release gates.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix restores the existing protected Project Cut replay bootstrap by materializing only its declared production dependency closure without changing architecture authority"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required; existing contract restored)