### PR TITLE
fix(ci): bind Warrant repository to protected base

### DIFF
--- a/.github/workflows/dev-pr-auto-merge.yml
+++ b/.github/workflows/dev-pr-auto-merge.yml
@@ -602,7 +602,7 @@ jobs:
           qualification_output=.buildchain/dev-delivery-input/project-cut-qualification.log
           proof=.buildchain/dev-delivery-input/project-cut-proof.json
 
-          test "$GITHUB_REPOSITORY" = "$(jq -r '.head.repo.full_name' "$pull_request")"
+          test "$GITHUB_REPOSITORY" = "$(jq -r '.base.repo.full_name' "$pull_request")"
           test "$TARGET_BRANCH" = "$(jq -r '.base.ref' "$pull_request")"
           test "$EXPECTED_HEAD" = "$(jq -r '.head.sha' "$pull_request")"
           current_base="$(git rev-parse 'HEAD^{commit}')"
@@ -834,7 +834,7 @@ jobs:
             --arg repository "$GITHUB_REPOSITORY" \
             --arg branch "$TARGET_BRANCH" \
             --arg head "$EXPECTED_HEAD" \
-            '.head.repo.full_name == $repository
+            '.base.repo.full_name == $repository
              and .head.sha == $head
              and .base.ref == $branch
              and .state == "open"' \

--- a/scripts/affected-native-proof-bootstrap.test.mjs
+++ b/scripts/affected-native-proof-bootstrap.test.mjs
@@ -67,3 +67,19 @@ test('protected Project Cut replay materializes its declared Work dependency clo
     /name: Check out protected consumer adapter[\s\S]*name: Install protected Work consumer dependencies[\s\S]*corepack pnpm install --filter '@kungfu-tech\/work\.\.\.' --prod --frozen-lockfile --ignore-scripts[\s\S]*name: Produce exact Project Cut replay proof/u,
   );
 });
+
+test('protected Warrant binds repository authority to the PR base for fork heads', () => {
+  const workflow = fs.readFileSync(
+    path.join(ROOT, '.github/workflows/dev-pr-auto-merge.yml'),
+    'utf8',
+  );
+  assert.match(
+    workflow,
+    /test "\$GITHUB_REPOSITORY" = "\$\(jq -r '\.base\.repo\.full_name' "\$pull_request"\)"/u,
+  );
+  assert.match(
+    workflow,
+    /'\.base\.repo\.full_name == \$repository[\s\S]*and \.head\.sha == \$head/u,
+  );
+  assert.doesNotMatch(workflow, /\.head\.repo\.full_name == \$repository/u);
+});


### PR DESCRIPTION
## Summary

- bind protected Warrant replay repository identity to the PR base repository
- preserve fork head identity solely as candidate source coordinates
- apply the same base-authority check to replay and landing
- add an exact workflow regression test covering fork heads

## Verification

- `./shifu check:source`
- `node --test scripts/affected-native-proof-bootstrap.test.mjs`
- live PR #3705 API fixture proves base `kungfu-systems/kungfu`, head `dongkeren/kungfu`, exact head/base/state

## Scope

Bootstrap precursor for #3705. Warrant, Project Cut, Queue admission, source identity, and release gates remain fail-closed.

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix corrects fork-aware repository identity validation in the existing protected Warrant workflow without changing architecture authority"
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] none of the above

## Checklist

- [x] Commits are signed off (DCO)
- [x] Documentation updated if behavior changed (not required; existing contract corrected)