### PR TITLE
fix(dev): bind Warrant requalification to live PR head repository

### DIFF
--- a/.github/workflows/dev-pr-auto-merge.yml
+++ b/.github/workflows/dev-pr-auto-merge.yml
@@ -835,11 +835,13 @@ jobs:
             --arg branch "$TARGET_BRANCH" \
             --arg head "$EXPECTED_HEAD" \
             '.base.repo.full_name == $repository
+             and (.head.repo.full_name | type == "string" and length > 0)
              and .head.sha == $head
              and .base.ref == $branch
              and .state == "open"' \
             "$live_pr" >/dev/null
 
+          source_head_repository="$(jq -er '.head.repo.full_name' "$live_pr")"
           native_root="$(jq -er '.warrant.nativeProofRoot' "$warrant")"
           qualification_root="$(jq -er '.receiptRoot' "$warrant")"
           state_root="$(jq -er '.after.stateRoot' "$warrant")"
@@ -848,14 +850,14 @@ jobs:
           source_run_prior="$evidence/source-workflow-run-prior.json"
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID" > "$source_run_prior"
           jq -e \
-            --arg repository "$GITHUB_REPOSITORY" \
+            --arg sourceHeadRepository "$source_head_repository" \
             --arg head "$EXPECTED_HEAD" \
             --argjson sourceRun "$SOURCE_RUN_ID" \
             '.id == $sourceRun
              and .name == "Core affected native"
              and .path == ".github/workflows/affected-native-pr.yml"
              and .event == "pull_request"
-             and .head_repository.full_name == $repository
+             and .head_repository.full_name == $sourceHeadRepository
              and .head_sha == $head
              and .status == "completed"
              and (.conclusion == "failure" or .conclusion == "success")
@@ -926,7 +928,7 @@ jobs:
           fi
 
           jq -e \
-            --arg repository "$GITHUB_REPOSITORY" \
+            --arg sourceHeadRepository "$source_head_repository" \
             --arg head "$EXPECTED_HEAD" \
             --argjson sourceRun "$SOURCE_RUN_ID" \
             --argjson expectedAttempt "$expected_attempt" \
@@ -934,7 +936,7 @@ jobs:
              and .name == "Core affected native"
              and .path == ".github/workflows/affected-native-pr.yml"
              and .event == "pull_request"
-             and .head_repository.full_name == $repository
+             and .head_repository.full_name == $sourceHeadRepository
              and .head_sha == $head
              and .run_attempt == $expectedAttempt
              and .status == "completed"

--- a/scripts/collect-layer-publication.test.mjs
+++ b/scripts/collect-layer-publication.test.mjs
@@ -47,6 +47,7 @@ function completeFixture(root) {
     'site',
     'skill',
     'tui',
+    'work',
   ])
     write(root, 'linux', `kungfu-tech-${packageName}-4.0.0-alpha.1.tgz`);
   for (const platform of ['darwin-arm64', 'linux-x64', 'win32-x64']) {
@@ -64,7 +65,7 @@ function completeFixture(root) {
   write(root, 'win32', 'Kungfu Setup 4.0.0-alpha.1.exe');
 }
 
-test('collects the exact 43-file cross-platform publication set', () => {
+test('collects the exact 44-file cross-platform publication set', () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kungfu-publish-test-'));
   try {
     const input = path.join(root, 'input');
@@ -79,7 +80,12 @@ test('collects the exact 43-file cross-platform publication set', () => {
     const manifest = JSON.parse(
       fs.readFileSync(path.join(output, 'manifest.json'), 'utf8'),
     );
-    assert.equal(manifest.artifacts.length, 43);
+    assert.equal(manifest.artifacts.length, 44);
+    assert.ok(
+      manifest.artifacts.some(
+        ({ name }) => name === 'kungfu-tech-work-4.0.0-alpha.1.tgz',
+      ),
+    );
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/scripts/dev-pr-auto-merge.test.mjs
+++ b/scripts/dev-pr-auto-merge.test.mjs
@@ -317,8 +317,21 @@ test('Qualified native proof re-runs the exact failed source jobs before landing
   );
   assert.match(
     bridge,
-    /\.head\.repo\.full_name == \$repository[\s\S]*\.head\.sha == \$head[\s\S]*\.base\.ref == \$branch[\s\S]*\.state == "open"/u,
+    /\.base\.repo\.full_name == \$repository[\s\S]*\.head\.repo\.full_name \| type == "string" and length > 0[\s\S]*\.head\.sha == \$head[\s\S]*\.base\.ref == \$branch[\s\S]*\.state == "open"/u,
   );
+  assert.match(
+    bridge,
+    /source_head_repository="\$\(jq -er '\.head\.repo\.full_name' "\$live_pr"\)"/u,
+  );
+  assert.equal(
+    (
+      bridge.match(
+        /\.head_repository\.full_name == \$sourceHeadRepository/gu,
+      ) || []
+    ).length,
+    2,
+  );
+  assert.doesNotMatch(bridge, /\.head_repository\.full_name == \$repository/u);
   assert.match(
     bridge,
     /check_name=affected-native%20%2F%20linux&filter=latest&per_page=100/u,
@@ -382,6 +395,20 @@ test('Qualified native proof re-runs the exact failed source jobs before landing
   );
   assert.match(landing, /queue-admission-context: Queue admission lease/u);
   assert.match(landing, /landing-mode: queue[\s\S]*dry-run: false/u);
+});
+
+test('source workflow repository follows the exact live PR head repository', () => {
+  const qualifies = (liveHeadRepository, sourceRunRepository) =>
+    typeof liveHeadRepository === 'string' &&
+    liveHeadRepository.length > 0 &&
+    sourceRunRepository === liveHeadRepository;
+
+  assert.equal(
+    qualifies('kungfu-systems/kungfu', 'kungfu-systems/kungfu'),
+    true,
+  );
+  assert.equal(qualifies('dongkeren/kungfu', 'dongkeren/kungfu'), true);
+  assert.equal(qualifies('dongkeren/kungfu', 'kungfu-systems/kungfu'), false);
 });
 
 test('Dev delivery fails closed to fenced native execution without a v3 receipt', () => {


### PR DESCRIPTION
## Summary

- bind source workflow provenance to the exact live pull request head repository
- preserve protected base, exact head, run, attempt, CheckRun, and Warrant validation
- repair the publication fixture to include the registered `@kungfu-tech/work` package

## Verification

- `./shifu check`
- `node --test scripts/dev-pr-auto-merge.test.mjs scripts/collect-layer-publication.test.mjs`
- `node scripts/run-documentation-material-tests.mjs`

## ADR delivery / release declaration

<!-- kungfu-adr-release:v1
{
  "schema": "kungfu.adr-release-pr/v1",
  "kind": "adr-neutral",
  "reason": "This bugfix corrects exact live fork provenance validation and synchronizes a release fixture with the existing npm registry without changing an architecture contract."
}
-->

## Evolution Map impact

Evolution impact: none

## Governance risk check

- [x] release evidence, provenance, package publishing, or deployment surfaces
- [ ] credentials, tokens, secrets, or private logs
- [ ] provider APIs, CLIs, OpenTelemetry, billing, quota, or usage attribution
- [ ] official hosted or managed services
- [ ] official branding, package names, release identity, or domains
- [ ] none of the above

The change preserves every existing exact-head, Warrant, and protected-base authority check; it replaces only the incorrect base-repository comparison with the exact live PR head repository.
